### PR TITLE
Fix array list

### DIFF
--- a/src/collection/js/arraylist.js
+++ b/src/collection/js/arraylist.js
@@ -130,7 +130,9 @@ ArrayListProto = {
      * @return { Array } an array representation of the ArrayList
      */
     toJSON: function () {
-        return this._items;
+        return YArray.map(this._items, function(i) {
+          return (i && i.toJSON) ? i.toJSON() : i;
+        });
     }
 };
 // Default implementation does not distinguish between public and private


### PR DESCRIPTION
This is a fix to the toJSON method on ArrayList.  Currently, it does not call toJSON on the objects it contains.  This changes the implementation to call the toJSON method on each element in the array if it has the method.  
