### PR TITLE
Y.Get does not properly fail with Webkit

### DIFF
--- a/src/yui/js/get.js
+++ b/src/yui/js/get.js
@@ -431,6 +431,11 @@ var ua = Y.UA,
                 n.addEventListener('load', function() {
                     _loaded(id, url);
                 }, false);
+                
+                // Adding onerror handler Safari, to handle 5+
+                n.addEventListener('error', function(e) {
+                    _fail(id, e + ': ' + url);
+                });
             }
 
         } else {


### PR DESCRIPTION
Adding the "error" event listener for Webkit, as noted in the following issue:
http://yuilibrary.com/projects/yui3/ticket/2530116

Safari 5+ is not calling the handler for "onFailure" when using Y.Get. "onLoad" is correctly
called, but there is never a notification of failure.
