### PR TITLE
Editor sometimes gives a '0' is null or undefined

### DIFF
--- a/sandbox/editor/js/frame.js
+++ b/sandbox/editor/js/frame.js
@@ -147,6 +147,12 @@ YUI.add('frame', function(Y) {
                 if (e.type.substring(0, 3) !== 'key') {
                     node = this._instance.one('win');
                     xy = this._iframe.getXY();
+                    // Sometimes in IE8, this._iframe._node becomes null
+                    // after hiding some elements, thus causing a javascript
+                    // error
+                    if (xy === null) {
+                        return;
+                    }
                     e.frameX = xy[0] + e.pageX - node.get('scrollLeft');
                     e.frameY = xy[1] + e.pageY - node.get('scrollTop');
                 }

--- a/src/editor/js/frame.js
+++ b/src/editor/js/frame.js
@@ -146,6 +146,12 @@
                 if (e.type.substring(0, 3) !== 'key') {
                     node = this._instance.one('win');
                     xy = this._iframe.getXY();
+                    // Sometimes in IE8, this._iframe._node becomes null
+                    // after hiding some elements, thus causing a javascript
+                    // error
+                    if (xy === null) {
+                       return;
+                    }
                     e.frameX = xy[0] + e.pageX - node.get('scrollLeft');
                     e.frameY = xy[1] + e.pageY - node.get('scrollTop');
                 }


### PR DESCRIPTION
Sometimes in IE8, in Frame 
the _iframe._node becomes null after hiding a parent div (doesn't always happen) causing a javascript error '0' is null or undefined, that is because this._iframe.getXY() would return null

This fixes this issue by skipping the dom event in such a case.
