### PR TITLE
fixed Y.WidgetModality constructor to avoid requiring config object

### DIFF
--- a/src/widget-modality/js/Widget-Modality.js
+++ b/src/widget-modality/js/Widget-Modality.js
@@ -52,7 +52,7 @@ var WIDGET         = 'widget',
      * @param {Object} config User configuration object
      */
     function WidgetModal(config) {
-        if (config.modal) {
+        if (config && config.modal) {
             Y.after(this._renderUIModal, this, RENDER_UI);
             Y.after(this._syncUIModal, this, SYNC_UI);
             Y.after(this._bindUIModal, this, BIND_UI);


### PR DESCRIPTION
```
var A = Y.Base.create("a", Y.Widget, [Y.WidgetModality]);
new A().render(); // exception
new A({}).render(); // works
```
