### PR TITLE
Added detects iOS device with the retina display.

### DIFF
--- a/src/yui/js/yui-ua.js
+++ b/src/yui/js/yui-ua.js
@@ -173,6 +173,14 @@ YUI.Env.parseUA = function(subUA) {
          */
         ios: null,
         /**
+         * Detects iOS device with the retina display
+         * @property ios
+         * @type boolean
+         * @default false
+         * @static
+         */
+        retina: false,
+        /**
          * Detects Googles Android OS version
          * @property android
          * @type float
@@ -266,6 +274,7 @@ YUI.Env.parseUA = function(subUA) {
                 m = ua.match(/iPad|iPod|iPhone/);
                 if (m && m[0]) {
                     o[m[0].toLowerCase()] = o.ios;
+                    o.retina = (win.devicePixelRatio || 1) >= 2;
                 }
             } else {
                 m = ua.match(/NokiaN[^\/]*|webOS\/\d\.\d/);


### PR DESCRIPTION
The iPhone screen resolution is different from the generations. [1]
- iPhone 3GS: 480 x 320 px (163 ppi)
- iPhone 4: 960 x 640 px (326 ppi)

You may need to display images of different sizes when developing Web applications in this effect. This is an added feature to help these cases.

Please review this one. If you don't need, please close this request.

[1] http://en.wikipedia.org/wiki/IPhone#Model_comparison
