### PR TITLE
Update style rule on .yui3-skin-sam .yui3-tab-label to be correct

### DIFF
--- a/src/tabview/assets/skins/sam/tabview-skin.css
+++ b/src/tabview/assets/skins/sam/tabview-skin.css
@@ -20,7 +20,7 @@
     border:solid #a3a3a3;
     border-width: 1px 1px 0 1px;
     color:#000;
-    cursor:hand;
+    cursor:pointer;
     font-size:85%;
     padding:0.3em .75em;
     text-decoration:none;


### PR DESCRIPTION
Update style rule for .yui3-skin-sam .yui3-tab-label to use "cursor:pointer" instead of invalid "cursor:hand" declaration
