### PR TITLE
Doc typo fix in sortable

### DIFF
--- a/src/sortable/js/sortable.js
+++ b/src/sortable/js/sortable.js
@@ -1,4 +1,3 @@
-
     /**
      * The class allows you to create a Drag & Drop reordered list.
      * @module sortable
@@ -214,7 +213,7 @@
             return this;
         },
         /**
-        * @method plug
+        * @method sync
         * @description Passthrough to the DD.Delegate syncTargets method.
         * @chainable
         */


### PR DESCRIPTION
Just a tiny copy/paste typo fix for the sync method
