### PR TITLE
Added @param definitions to instanceOf method comment.

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -1214,6 +1214,8 @@ Y.log('Fetching loader: ' + config.base + config.loaderPath, 'info', 'yui');
      * memory leak in IE when the item tested is
      * window/document
      * @method instanceOf
+     * @param o {Object} The object to check.
+     * @param type {Object} The class to check against.
      * @since 3.3.0
      */
 };


### PR DESCRIPTION
Little change to make the built docs more complete - required arguments were not included in the method definition comment block.
