### PR TITLE
Avoid wrapping the mod.fn and Y.use callback method with try/catch to get reasonable stacktrace.

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -688,7 +688,9 @@ with any configuration info required for the module.
                         }
                     }
 
-                    if (mod.fn) {
+                    if (mod.fn && Y.config.throwFail) {
+                        mod.fn(Y, name);
+                    } else if (mod.fn) {
                         try {
                             mod.fn(Y, name);
                         } catch (e) {
@@ -823,6 +825,11 @@ with any configuration info required for the module.
         if (!response.success && this.config.loadErrorFn) {
             this.config.loadErrorFn.call(this, this, callback, response, args);
         } else if (callback) {
+            if (this.config.throwFail) {
+                callback(this, response);
+                return;
+            }
+
             try {
                 callback(this, response);
             } catch (e) {


### PR DESCRIPTION
This is a pull request for ticket #2531679 change.

This is a repro case http://jsfiddle.net/aURCe/. The 'push on undefined' errors should be reported with a stacktrace that allows for easy problematic file/line location.
