### PR TITLE
Fixed YUIDoc typo that had a '$' instead of '@' in front of 'param'

### DIFF
--- a/src/dom/js/dom-region.js
+++ b/src/dom/js/dom-region.js
@@ -80,11 +80,12 @@ Y.mix(DOM, {
         
     },
     /**
-     * Check if any part of this node is in the passed region
+     * Check if any part of the passed nodes are in the same region.
      * @method inRegion
      * @for DOM
-     * @param {Object} node2 The node to get the region from or an Object literal of the region
-     * $param {Boolean} all Should all of the node be inside the region
+     * @param {Object} node The first node to get the region from.
+     * @param {Object} node2 The second node to get the region from or an Object literal of the region
+     * @param {Boolean} all Should all of the node be inside the region
      * @param {Object} altRegion An object literal containing the region for this node if we already have the data (for performance i.e. DragDrop)
      * @return {Boolean} True if in region, false if not.
      */


### PR DESCRIPTION
And updated general description to note that nodes must be passed as parameters.
