### PR TITLE
Add detects Windows Phone devices.

### DIFF
--- a/src/yui/js/yui-ua.js
+++ b/src/yui/js/yui-ua.js
@@ -358,6 +358,10 @@ YUI.Env.parseUA = function(subUA) {
                 m = ua.match(/MSIE\s([^;]*)/);
                 if (m && m[1]) {
                     o.ie = numberify(m[1]);
+                    m = ua.match(/IEMobile[^;]*/);
+                    if (m) {
+                        o.mobile = m[0];
+                    }
                 } else { // not opera, webkit, or ie
                     m = ua.match(/Gecko\/([^\s]*)/);
                     if (m) {


### PR DESCRIPTION
Recently, It's feels Windows Phone 7 is one of modern mobile OS. These devices can be detected by finding the `IEMobile` token.

The following example user agent:

```
Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; FujitsuToshibaMobileCommun; IS12T; KDDI)
```

How it works:

``` javascript
if (Y.UA.ie) {
    if (Y.UA.mobile) {
        // I am IE Mobile (Windows Phone).
    } else {
        // I am IE (PC).
    }
}
```

See also about detection:
http://windowsteamblog.com/windows_phone/b/wpdev/archive/2011/08/29/introducing-the-ie9-on-windows-phone-mango-user-agent-string.aspx

Please review.
