### PR TITLE
Fixed typo in getAttribute method description.

### DIFF
--- a/src/dom/js/dom-attrs.js
+++ b/src/dom/js/dom-attrs.js
@@ -73,7 +73,7 @@ Y.mix(Y_DOM, {
 
     /**
      * Provides a normalized attribute interface. 
-     * @method getAttibute
+     * @method getAttribute
      * @param {HTMLElement} el The target element for the attribute.
      * @param {String} attr The attribute to get.
      * @return {String} The current value of the attribute. 


### PR DESCRIPTION
Fixed typo in getAttribute method description: "@method getAttibute" changed to "@method getAttribute".
