### PR TITLE
Updated second API typo on inRegion

### DIFF
--- a/src/dom/js/dom-region.js
+++ b/src/dom/js/dom-region.js
@@ -83,7 +83,8 @@ Y.mix(DOM, {
      * Check if any part of this node is in the passed region
      * @method inRegion
      * @for DOM
-     * @param {Object} node2 The node to get the region from or an Object literal of the region
+     * @param {Object} node The node to get the region from
+     * @param {Object} node2 The second node to get the region from or an Object literal of the region
      * $param {Boolean} all Should all of the node be inside the region
      * @param {Object} altRegion An object literal containing the region for this node if we already have the data (for performance i.e. DragDrop)
      * @return {Boolean} True if in region, false if not.


### PR DESCRIPTION
Added definition for parameter that was missing cause YUIDoc to show only 2 parameters as being needed for the function rather than 4 (other param is missing from YUIDoc due to use of $ instead of @ but that was already included in a separate pull request).
