### PR TITLE
Spelling fix and i.e. --> e.g.

### DIFF
--- a/src/dom/js/dom-region.js
+++ b/src/dom/js/dom-region.js
@@ -45,12 +45,12 @@ Y.mix(DOM, {
     },
 
     /**
-     * Find the intersect information for the passes nodes.
+     * Find the intersect information for the passed nodes.
      * @method intersect
      * @for DOM
      * @param {HTMLElement} element The first element 
      * @param {HTMLElement | Object} element2 The element or region to check the interect with
-     * @param {Object} altRegion An object literal containing the region for the first element if we already have the data (for performance i.e. DragDrop)
+     * @param {Object} altRegion An object literal containing the region for the first element if we already have the data (for performance e.g. DragDrop)
      * @return {Object} Object literal containing the following intersection data: (top, right, bottom, left, area, yoff, xoff, inRegion)
      */
     intersect: function(node, node2, altRegion) {
@@ -85,7 +85,7 @@ Y.mix(DOM, {
      * @for DOM
      * @param {Object} node2 The node to get the region from or an Object literal of the region
      * $param {Boolean} all Should all of the node be inside the region
-     * @param {Object} altRegion An object literal containing the region for this node if we already have the data (for performance i.e. DragDrop)
+     * @param {Object} altRegion An object literal containing the region for this node if we already have the data (for performance e.g. DragDrop)
      * @return {Boolean} True if in region, false if not.
      */
     inRegion: function(node, node2, all, altRegion) {
@@ -125,7 +125,7 @@ Y.mix(DOM, {
      * @for DOM
      * @param {HTMLElement} element The DOM element. 
      * @param {Boolean} all Should all of the node be inside the region
-     * @param {Object} altRegion An object literal containing the region for this node if we already have the data (for performance i.e. DragDrop)
+     * @param {Object} altRegion An object literal containing the region for this node if we already have the data (for performance e.g. DragDrop)
      * @return {Boolean} True if in region, false if not.
      */
     inViewportRegion: function(node, all, altRegion) {


### PR DESCRIPTION
Fixed spelling of word "passed" in docs for the "intersect" function.

Replaced instances of "i.e." (literally 'id est' in Latin, 'that is' in English) with "e.g." (literally 'exempli gratia' in Latin, 'for example' in English) because they were referencing example cases not singular implementations.
