### PR TITLE
Add doctype to avoid script error with yeti

### DIFF
--- a/src/yui/tests/assets/xframe.html
+++ b/src/yui/tests/assets/xframe.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 <title>xframe tester</title>


### PR DESCRIPTION
Currently, I just have the following script error with yeti 0.2.0:

```
$ yeti src/yui/tests/lang.html
Creating a Hub at http://localhost:9000
Waiting for agents to connect at http://localhost:9000.
When ready, press Enter to begin testing.
  Agent connected: Chrome (18.0.1025.58) / Mac OS
✔ Testing started!
✖ Script error: Uncaught Error: Yeti requires HTML files with doctypes.
  URL: http://localhost:9000/public/inject.js
  Line: 50
  User-Agent: Chrome (18.0.1025.58) / Mac OS
✔ Agent completed: Chrome (18.0.1025.58) / Mac OS
0 tests passed! (393ms)
```
