### PR TITLE
Fix #2530967 - Y.Lang.trim() should support non-string values for ES5 compatibility

### DIFF
--- a/src/yui/js/yui-lang.js
+++ b/src/yui/js/yui-lang.js
@@ -250,19 +250,44 @@ L.sub = function(s, o) {
 
 /**
  * Returns a string without any leading or trailing whitespace.  If
- * the input is not a string, the input will be returned untouched.
+ * the input is not a string, the input will be returned the result of
+ * calling ToString.
  * @method trim
  * @static
  * @param s {string} the string to trim.
  * @return {string} the trimmed string.
  */
 L.trim = STRING_PROTO.trim ? function(s) {
-    return s && s.trim ? s.trim() : s;
+    var t = L.type(s);
+
+    switch (t) {
+        case 'string':
+            return s.trim();
+        case 'undefined':
+        case 'null':
+        case 'boolean':
+        case 'number':
+            return String(s);
+        case 'object':
+            return TOSTRING.call(s);
+        default:
+            return s;
+    }
 } : function (s) {
-    try {
-        return s.replace(TRIMREGEX, '');
-    } catch (e) {
-        return s;
+    var t = L.type(s);
+
+    switch (t) {
+        case 'string':
+            return s.replace(TRIMREGEX, '');
+        case 'undefined':
+        case 'null':
+        case 'boolean':
+        case 'number':
+            return String(s);
+        case 'object':
+            return TOSTRING.call(s);
+        default:
+            return s;
     }
 };
 

--- a/src/yui/tests/lang-test.js
+++ b/src/yui/tests/lang-test.js
@@ -122,12 +122,15 @@ suite.add(new Y.Test.Case({
     },
 
     test_trim: function() {
-        Assert.areEqual(Lang.trim("  My String"), "My String");
-        Assert.areEqual(Lang.trim("My String  "), "My String");
-        Assert.areEqual(Lang.trim("  My String  "), "My String");
-        Assert.areEqual(Lang.trim(null), null);
-        Assert.areEqual(Lang.trim(undefined), undefined);
-        Assert.areEqual(Lang.trim({}), "[object Object]");
+        Assert.areSame(Lang.trim("  My String"), "My String");
+        Assert.areSame(Lang.trim("My String  "), "My String");
+        Assert.areSame(Lang.trim("  My String  "), "My String");
+        Assert.areSame(Lang.trim(null), "null");
+        Assert.areSame(Lang.trim(undefined), "undefined");
+        Assert.areSame(Lang.trim(true), "true");
+        Assert.areSame(Lang.trim(false), "false");
+        Assert.areSame(Lang.trim(1), "1");
+        Assert.areSame(Lang.trim({}), "[object Object]");
     },
 
     test_trim_left: function() {


### PR DESCRIPTION
Please review. Test results on browsers that I have are as follows.

```
$ yeti src/yui/tests/lang.html
Connected to http://localhost:9000
Waiting for agents to connect at http://localhost:9000.
When ready, press Enter to begin testing.
✔ Testing started!
✔ Y.Lang on Safari (5.1) / iOS 5.1
✔ Agent completed: Safari (5.1) / iOS 5.1
✔ Y.Lang on Chrome (18.0.1025.109) / Mac OS
✔ Agent completed: Chrome (18.0.1025.109) / Mac OS
✔ Y.Lang on Firefox (11.0) / Mac OS
✔ Agent completed: Firefox (11.0) / Mac OS
✔ Y.Lang on Safari (5.1.4) / Mac OS
✔ Agent completed: Safari (5.1.4) / Mac OS
✔ Y.Lang on Chrome (17.0.963.79) / Windows Vista
✔ Agent completed: Chrome (17.0.963.79) / Windows Vista
✔ Y.Lang on Firefox (10.0.2) / Windows Vista
✔ Agent completed: Firefox (10.0.2) / Windows Vista
✔ Y.Lang on Opera (11.52) / Mac OS
✔ Agent completed: Opera (11.52) / Mac OS
✔ Y.Lang on Internet Explorer (8.0) / Windows Vista
✔ Agent completed: Internet Explorer (8.0) / Windows Vista
✔ Y.Lang on Opera (11.61) / Windows Vista
✔ Agent completed: Opera (11.61) / Windows Vista
153 tests passed! (10126ms)
```
