### PR TITLE
Fixing #2531941

### DIFF
--- a/src/io/js/transports.js
+++ b/src/io/js/transports.js
@@ -45,7 +45,7 @@ Y.mix(Y.IO, {
         xdr: function () {
             return XDR ? new XDomainRequest() : null;
         },
-        iframe: {},
+        iframe:function () { return {}; },
         flash: null,
         nodejs: null
     },


### PR DESCRIPTION
The Bug http://yuilibrary.com/projects/yui3/ticket/2531941 
 returns error that "a.IO.transports[k] is not a function" because iframe is set to {} instead of 
function(){ return {}; }
