### PR TITLE
Added hasNext property to req.

### DIFF
--- a/src/app/js/router.js
+++ b/src/app/js/router.js
@@ -560,7 +560,7 @@ Y.Router = Y.extend(Router, Y.Base, {
                     req.params = matches.concat();
                 }
                 
-                req.hasNext = routes.length;
+                req.pendingRoutes = routes.length;
                 
                 callback.call(self, req, res, req.next);
             }


### PR DESCRIPTION
This provides a way for route callback functions to determine if there are any matching routes after this one.

An issue came up in an app with many routes.  About half of the routes require a user to be logged in.  Instead of putting the log in check within each route, it would be far more convenient to put the log in check in one route before all the others then call next() once it has been confirmed that the user is actually logged in.

Currently the best solution for this scenario is to create a route with a regex path that matches every possible path that requires user log in.  As the app grows, that regex could become quite unwieldy.  The next best option is to use wild card routes, but there is a drawback to using wild card routes for this purpose.  If the '*' route forces a user to log in, but there happens to be a typo in the path, the call to next() won't do anything.  So they logged in for nothing.  If the app is set up to display a 404 message, a user would have to log in to see the 404.

While user log in and 404 may be a rare occurrence, it just seems silly.  There could also be other use cases where a wild card route is used to set up something and the next route is expected to make use of the something and clean up after it.  If a next route doesn't actually exist, the clean up step won't be performed.

To make wild card routes more useful when chaining routes, a hasNext property has been added to the request object that gets passed to all route callback functions.  The hasNext property is an integer count of routes left to be dispatched after this one.  It will be 0 if there are no more routes, so req.hasRoute could be used as a simple condition to pre detect 404 errors.
