### PR TITLE
[#2531616] Documented value/valueFn behavior.

### DIFF
--- a/src/app/docs/view/index.mustache
+++ b/src/app/docs/view/index.mustache
@@ -319,6 +319,21 @@ View classes and subclasses provide the following attributes.
         <p>
         If you specify a container element that isn't already on the page, then you'll need to append it to the page yourself. You can do this in the `render()` method the first time the view is rendered.
         </p>
+
+        <p>
+        Note that if you are extending a view and want to set a default value for the `container` attribute in `ATTRS`, you must use `valueFn`:
+        </p>
+
+```
+ATTRS: {
+    container: {
+        valueFn: function () { /* return a Y.Node */ }
+    }
+}
+```
+        <p>
+        The view's constructor will ignore any assignments using the `value` property. The reason for this is that `container` already supplies its own `valueFn`, which <a href="/yui/docs/attribute/#configuration">takes priority over `value`</a>.
+        </p>
       </td>
     </tr>
   </tbody>

--- a/src/app/js/view.js
+++ b/src/app/js/view.js
@@ -374,12 +374,16 @@ Y.View = Y.extend(View, Y.Base, {
 
         The default container is a `<div>` Node, but you can override this in
         a subclass, or by passing in a custom `container` config value at
-        instantiation time.
+        instantiation time. If you override the default container in a subclass
+        using `ATTRS`, you must use the `valueFn` property. The view's constructor 
+        will ignore any assignments using `value`.
 
         When `container` is overridden by a subclass or passed as a config
-        option at instantiation time, it may be provided as a selector string, a
-        DOM element, or a `Y.Node` instance. The value will be converted into a
-        `Y.Node` instance if it isn't one already.
+        option at instantiation time, you can provide it as a selector string, a
+        DOM element, a `Y.Node` instance, or (if you are subclassing and modifying
+        the attribute), a `valueFn` function that returns a `Y.Node` instance. 
+        The value will be converted into a `Y.Node` instance if it isn't one 
+        already.
 
         The container is not added to the page automatically. This allows you to
         have full control over how and when your view is actually rendered to


### PR DESCRIPTION
Explained that when overriding the default value for container, you need to use valueFn, not value.
