### PR TITLE
Fixing #2530178 - 'fireOnce' issue on Y and Y.Global

### DIFF
--- a/src/event-custom/js/event-target.js
+++ b/src/event-custom/js/event-target.js
@@ -555,8 +555,7 @@ Y.log('EventTarget unsubscribeAll() is deprecated, use detachAll()', 'warn', 'de
     publish: function(type, opts) {
         var events, ce, ret, defaults,
             edata    = this._yuievt,
-            pre      = edata.config.prefix,
-            broadcast = opts && opts.broadcast || false;
+            pre      = edata.config.prefix;
 
         if (L.isObject(type)) {
             ret = {};
@@ -591,11 +590,10 @@ Y.log('EventTarget unsubscribeAll() is deprecated, use detachAll()', 'warn', 'de
             events[type] = ce;
         }
         
-        if(broadcast && this !== Y && this !== Y.Global){
-            YArray.each((broadcast == 2) ? [Y,Y.Global] : [Y], function(et){
+        if(ce && ce.broadcast && this !== Y && this !== Y.Global){
+            YArray.each((ce.broadcast == 2) ? [Y,Y.Global] : [Y], function(et){
                 defaults = Y.merge(et._yuievt.defaults);
-                et.publish(type,
-                          (opts) ? Y.mix(defaults, opts, true, ['fireOnce']) : defaults);
+                et.publish(type, Y.mix(defaults, ce, true, ['fireOnce']));
             });
         }
 

--- a/src/event-custom/tests/customevent.html
+++ b/src/event-custom/tests/customevent.html
@@ -787,10 +787,11 @@ o.after('e', f1).on('foo:e', f2).on('foo:e2', f3).on('detach, e', f4).detach('de
                 
                 var fired1 = 0,
                     fired2 = 0,
-                    fired3 = 0;
-                
-                et.fire(eventType);
-                
+                    fired3 = 0,
+                    fired4 = 0,
+                    fired5 = 0,
+                    fired6 = 0;
+                    
                 et.on(eventType, function (e) {
                     fired1++;
                 });
@@ -804,10 +805,26 @@ o.after('e', f1).on('foo:e', f2).on('foo:e2', f3).on('detach, e', f4).detach('de
                 });
                 
                 et.fire(eventType);
+                et.fire(eventType);
+                
+                et.on(eventType, function (e) {
+                    fired4++;
+                });
+                
+                Y.on(eventType, function (e) {
+                    fired5++;
+                });
+                
+                Y.Global.on(eventType, function (e) {
+                    fired6++;
+                });
                 
                 Y.Assert.areEqual(1, fired1);
                 Y.Assert.areEqual(1, fired2);
                 Y.Assert.areEqual(0, fired3);
+                Y.Assert.areEqual(1, fired4);
+                Y.Assert.areEqual(1, fired5);
+                Y.Assert.areEqual(0, fired6);
             },
             
             "test fireOnce with broadcast 2": function () {
@@ -870,8 +887,7 @@ o.after('e', f1).on('foo:e', f2).on('foo:e2', f3).on('detach, e', f4).detach('de
                 });
                 
                 et.publish(eventType, {
-                    fireOnce: true,
-                    broadcast:  2
+                    fireOnce: true
                 });
                 
                 var fired1 = 0,
@@ -967,11 +983,111 @@ o.after('e', f1).on('foo:e', f2).on('foo:e2', f3).on('detach, e', f4).detach('de
                 Y.Assert.areEqual(1, fired6);
         
             },
-    
+            
+            "test fireOnce with default config": function () {
+                var et = new Y.EventTarget({fireOnce: true}),
+                    eventType = 'myEvent5';
+                et.publish(eventType, {
+                    broadcast:  2
+                });
+                
+                var fired1 = 0,
+                    fired2 = 0,
+                    fired3 = 0,
+                    fired4 = 0,
+                    fired5 = 0,
+                    fired6 = 0
+                
+                et.on(eventType, function (e) {
+                    fired1++;
+                });
+                
+                Y.on(eventType, function (e) {
+                    fired2++;
+                });
+                
+                Y.Global.on(eventType, function (e) {
+                    fired3++;
+                });
+                
+                et.fire(eventType);
+                et.fire(eventType);
+                
+                et.on(eventType, function (e) {
+                    fired4++;
+                });
+                
+                Y.on(eventType, function (e) {
+                    fired5++;
+                });
+                
+                Y.Global.on(eventType, function (e) {
+                    fired6++;
+                });
+                
+                Y.Assert.areEqual(1, fired1);
+                Y.Assert.areEqual(1, fired2);
+                Y.Assert.areEqual(1, fired3);
+                Y.Assert.areEqual(1, fired4);
+                Y.Assert.areEqual(1, fired5);
+                Y.Assert.areEqual(1, fired6);
+        
+            },
+            
+            "test broadcast with default config": function () {
+                var et = new Y.EventTarget({broadcast: 2}),
+                    eventType = 'myEvent6';
+                et.publish(eventType, {
+                    fireOnce:  true
+                });
+                
+                var fired1 = 0,
+                    fired2 = 0,
+                    fired3 = 0,
+                    fired4 = 0,
+                    fired5 = 0,
+                    fired6 = 0
+                
+                et.on(eventType, function (e) {
+                    fired1++;
+                });
+                
+                Y.on(eventType, function (e) {
+                    fired2++;
+                });
+                
+                Y.Global.on(eventType, function (e) {
+                    fired3++;
+                });
+                
+                et.fire(eventType);
+                et.fire(eventType);
+                
+                et.on(eventType, function (e) {
+                    fired4++;
+                });
+                
+                Y.on(eventType, function (e) {
+                    fired5++;
+                });
+                
+                Y.Global.on(eventType, function (e) {
+                    fired6++;
+                });
+                
+                Y.Assert.areEqual(1, fired1);
+                Y.Assert.areEqual(1, fired2);
+                Y.Assert.areEqual(1, fired3);
+                Y.Assert.areEqual(1, fired4);
+                Y.Assert.areEqual(1, fired5);
+                Y.Assert.areEqual(1, fired6);
+        
+            },
+            
             "test config with multiple event type": function () {
                 var et = new Y.EventTarget(),
                     cfg = {},
-                    eventType1 = 'myEvent5',
+                    eventType1 = 'myEvent7',
                     eventType2 = 'anotherEvent1';
                 cfg[eventType1] = {
                     fireOnce: true,


### PR DESCRIPTION
 This is a fix for http://yuilibrary.com/projects/yui3/ticket/2530178.

 This one is currently caused by lazy publishing with default options when Y and Y.Global subscribe to the event.
It's solved by publishing on Y and Y.Global by passing 'fireOnce' option from original publish method only when 'broadcast' flag is set.

Test cases are added.
