### PR TITLE
Documentation enhancement for DataTable's column formatting and allowHTML

### DIFF
--- a/src/datatable/docs/datatable-formatting.mustache
+++ b/src/datatable/docs/datatable-formatting.mustache
@@ -61,7 +61,12 @@ function calculate(o) {
 }
 
 var table = new Y.DataTable({
-    columns: [ "id", "name", { key: "profit", formatter: calculate } ],
+    columns: [
+        { key: "id", formatter: "<a href=\"#{value}\">{value}</a>",
+            allowHTML : true },
+        "name",
+        { key: "profit", formatter: calculate }
+    ],
     data   : [
         { id: "ga-3475", name: "gadget",   price: 6.99, cost: 4.99 },
         { id: "sp-9980", name: "sprocket", price: 3.75, cost: 2.75 },

--- a/src/datatable/docs/index.mustache
+++ b/src/datatable/docs/index.mustache
@@ -307,13 +307,22 @@ var table = new Y.DataTable({
 </p>
 
 <p>
+    `formatter` will automatically escape HTML for safe displaying unless the
+    `allowHTML` option is set to true in the column definition.
+</p>
+
+<p>
     For best performance, <strong><a href="#formatter-vs-nodeformatter">avoid
     `nodeFormatter`s unless absolutely necessary</a></strong>.
 </p>
 
 ```
 var columns = [
-    'item',
+    {
+        key: 'item',
+        formatter: '<a href="#{value}">{value}</a>',
+        allowHTML: true // Must be set or the html will be escaped
+    },
     {
         key: 'cost',
         formatter: '${value}' // formatter template string
@@ -387,7 +396,11 @@ var columns = [
 <script>
 YUI().use('datatable-base', function (Y) {
     var columns = [
-        'item',
+        {
+            key: 'item',
+            formatter: '<a href="#{value}">{value}</a>',
+            allowHTML: true // Must be set or the html will be escaped
+        },
         {
             key: 'cost',
             formatter: '${value}' // formatter template string
@@ -448,7 +461,9 @@ YUI().use('datatable-base', function (Y) {
 <p>
     The parameters passed to `formatter` functions and `nodeFormatter`
     functions are described in <a href="#formatter-props">Appendix B</a> and <a
-    href="#nodeformatter-props">Appendix C</a>, respectively.
+    href="#nodeformatter-props">Appendix C</a>, respectively. Also look for
+    what can be passed in to the columns in
+    <a href="#column-config">Appendix A</a>.
 </p>
 
 <p>

--- a/src/datatable/docs/partials/datatable-formatting-source.mustache
+++ b/src/datatable/docs/partials/datatable-formatting-source.mustache
@@ -18,7 +18,8 @@ YUI().use("datatype-date", "datatable-base", function (Y) {
         return "$" + (o.data.price - o.data.cost).toFixed(2);
     },
     colsFunction = [
-        "id",
+        { key: "id", formatter: "<a href=\"#{value}\">{value}</a>",
+            allowHTML : true },
         "name",
         { key: "profit", formatter: calculate }
     ],
@@ -28,7 +29,7 @@ YUI().use("datatype-date", "datatable-base", function (Y) {
         {id:"wi-0650", name:"widget", price:4.25, cost:3.25}
     ],
     dtFunction = new Y.DataTable({columns:colsFunction, data:dataFunction,
-        caption:"Data formatting with custom function"}).render("#function"),
+        caption:"Data formatting with custom function and HTML formatter"}).render("#function"),
     formatDates = function(o){
         return o.value &&
             Y.DataType.Date.format(o.value, {format:"%m/%d/%Y"});


### PR DESCRIPTION
![I couldn't find out how to leave the HTML unescaped in column formatters.](http://cdn.memegenerator.net/instances/400x/19459643.jpg)

![I spent quite a bit of time reading the documentation, but was unable to find the answer after looking in the obvious places](http://cdn.memegenerator.net/instances/400x/19459748.jpg)

![Luke helpfully pointed out I can just fix it my damn self.](http://cdn.memegenerator.net/instances/400x/19459831.jpg)

![So I thought I would help by fixing what confused me](http://cdn.memegenerator.net/instances/400x/19459592.jpg)

![And now I feel good about myself!](http://cdn.memegenerator.net/instances/400x/19459899.jpg)
