### PR TITLE
ModelList: Ignore bubbled idChange events from models not in the current list. [Fixes #2532240]

### DIFF
--- a/src/app/HISTORY.md
+++ b/src/app/HISTORY.md
@@ -16,6 +16,11 @@ App Framework Change History
   (or an array of indices). You no longer need to specify the actual model
   instance(s), although that's still supported as well.
 
+* Fixed an issue where a list that received bubbled events from a model would
+  assume the model was in the list if its `id` changed, even if the model
+  actually wasn't in the list and was merely bubbling events to the list.
+  [Ticket #2532240]
+
 ### Router
 
 * The `req` object passed to routes now has a `pendingRoutes` property that

--- a/src/app/js/model-list.js
+++ b/src/app/js/model-list.js
@@ -1111,12 +1111,28 @@ Y.ModelList = Y.extend(ModelList, Y.Base, {
     @protected
     **/
     _afterIdChange: function (e) {
-        if (Lang.isValue(e.prevVal)) {
-            delete this._idMap[e.prevVal];
+        var newVal  = e.newVal,
+            prevVal = e.prevVal,
+            target  = e.target;
+
+        if (Lang.isValue(prevVal)) {
+            if (this._idMap[prevVal] === target) {
+                delete this._idMap[prevVal];
+            } else {
+                // The model that changed isn't in this list. Probably just a
+                // bubbled change event from a nested Model List.
+                return;
+            }
+        } else {
+            // The model had no previous id. Verify that it exists in this list
+            // before continuing.
+            if (this.indexOf(target) === -1) {
+                return;
+            }
         }
 
-        if (Lang.isValue(e.newVal)) {
-            this._idMap[e.newVal] = e.target;
+        if (Lang.isValue(newVal)) {
+            this._idMap[newVal] = target;
         }
     },
 

--- a/src/app/tests/model-list-test.js
+++ b/src/app/tests/model-list-test.js
@@ -1282,6 +1282,36 @@ modelListSuite.add(new Y.Test.Case({
         list.remove(list.add([{}, {}]), {silent: true});
 
         Assert.areSame(0, list.size());
+    },
+
+    'list should update its id map when a model id changes': function () {
+        var list      = this.createList(),
+            bareModel = list.add({}),
+            idModel   = list.add({id: 1});
+
+        Assert.areSame(idModel, list.getById(1), 'model should initially be retrievable by id');
+
+        bareModel.set('id', 0);
+        idModel.set('id', 4);
+
+        Assert.areSame(bareModel, list.getById(0), 'model with no previous id should be retrievable by its new id');
+        Assert.areSame(idModel, list.getById(4), 'model with previous id should be retrievable by its new id');
+    },
+
+    'list should ignore id changes for models not in the list': function () {
+        var list      = this.createList(),
+            otherList = this.createList(),
+            bareModel = otherList.add({}),
+            idModel   = otherList.add({id: 1});
+
+        bareModel.addTarget(list);
+        idModel.addTarget(list);
+
+        bareModel.set('id', 0);
+        idModel.set('id', 4);
+
+        Assert.isNull(list.getById(0), 'model with no previous id should not suddenly appear in this list');
+        Assert.isNull(list.getById(4), 'model with previous id should not suddenly appear in this list');
     }
 }));
 


### PR DESCRIPTION
See http://yuilibrary.com/projects/yui3/ticket/2532240

Also added a test for the basic id change behavior, which apparently wasn't being tested.
