### PR TITLE
Array.unique(): remove deprecated sort param, add optional test function [Ticket #2527901]

### DIFF
--- a/src/collection/HISTORY.md
+++ b/src/collection/HISTORY.md
@@ -4,6 +4,13 @@ Collection Change History
 3.6.0
 -----
 
+* [!] The `sort` parameter of `Array.unique()` has been removed. This parameter
+  was deprecated in YUI 3.3.0.
+
+* `Array.unique()` now accepts an optional test function as its second
+  parameter. This function can perform custom comparison logic to determine
+  whether two values should be considered equal. [Ticket #2527901]
+
 * The `every()`, `filter()`, `map()`, and `reduce()` functions now work
   correctly on array-like objects in ES5 browsers. [Ticket #2531652]
 

--- a/src/collection/js/array-extras.js
+++ b/src/collection/js/array-extras.js
@@ -53,52 +53,58 @@ A.lastIndexOf = L._isNative(ArrayProto.lastIndexOf) ?
     };
 
 /**
-Returns a copy of the specified array with duplicate items removed.
+Returns a copy of the input array with duplicate items removed.
+
+Note: If the input array only contains strings, the `Y.Array.dedupe()` method is
+a much faster alternative.
 
 @method unique
-@param {Array} a Array to dedupe.
-@return {Array} Copy of the array with duplicate items removed.
+@param {Array} array Array to dedupe.
+@param {Function} [testFn] Custom function to use to test the equality of two
+    values. A truthy return value indicates that the values are equal. A falsy
+    return value indicates that the values are not equal.
+
+    @param {Any} testFn.a First value to compare.
+    @param {Any} testFn.b Second value to compare.
+    @param {Number} testFn.index Index of the current item in the original
+        array.
+    @param {Array} testFn.array The original array.
+    @return {Boolean} _true_ if the items are equal, _false_ otherwise.
+
+@return {Array} Copy of the input array with duplicate items removed.
 @static
 **/
-A.unique = function(a, sort) {
-    // Note: the sort param is deprecated and intentionally undocumented since
-    // YUI 3.3.0. It never did what the API docs said it did (see the older
-    // comment below as well).
+A.unique = function (array, testFn) {
     var i       = 0,
-        len     = a.length,
+        len     = array.length,
         results = [],
-        item, j;
+        j, match, result, resultLen, value;
 
-    for (; i < len; ++i) {
-        item = a[i];
+    // Note the label here. It's used to jump out of the inner loop when a value
+    // is not unique.
+    outerLoop: for (; i < len; i++) {
+        value = array[i];
 
-        // This loop iterates over the results array in reverse order and stops
-        // if it finds an item that matches the current input array item (a
-        // dupe). If it makes it all the way through without finding a dupe, the
-        // current item is pushed onto the results array.
-        for (j = results.length; j > -1; --j) {
-            if (item === results[j]) {
-                break;
+        // For each value in the input array, iterate through the result array
+        // and check for uniqueness against each result value.
+        for (j = 0, resultLen = results.length; j < resultLen; j++) {
+            result = results[j];
+
+            // If the test function returns true or there's no test function and
+            // the value equals the current result item, stop iterating over the
+            // results and continue to the next value in the input array.
+            if (testFn) {
+                if (testFn.call(array, value, result, i, array)) {
+                    continue outerLoop;
+                }
+            } else if (value === result) {
+                continue outerLoop;
             }
         }
 
-        if (j === -1) {
-            results.push(item);
-        }
-    }
-
-    // Note: the sort option doesn't really belong here... I think it was added
-    // because there was a way to fast path the two operations together.  That
-    // implementation was not working, so I replaced it with the following.
-    // Leaving it in so that the API doesn't get broken.
-    if (sort) {
-        Y.log('The sort parameter is deprecated and will be removed in a future version of YUI.', 'warn', 'deprecated');
-
-        if (L.isNumber(results[0])) {
-            results.sort(A.numericSort);
-        } else {
-            results.sort();
-        }
+        // If we get this far, that means the current value is not already in
+        // the result array, so add it.
+        results.push(value);
     }
 
     return results;

--- a/src/collection/tests/array-extras-test.js
+++ b/src/collection/tests/array-extras-test.js
@@ -1,8 +1,9 @@
 YUI.add('array-extras-test', function (Y) {
 
-var Assert      = Y.Assert,
-    ArrayAssert = Y.ArrayAssert,
-    A           = Y.Array,
+var Assert       = Y.Assert,
+    ArrayAssert  = Y.ArrayAssert,
+    A            = Y.Array,
+    ObjectAssert = Y.ObjectAssert,
 
     suite;
 
@@ -355,15 +356,41 @@ suite.add(new Y.Test.Case({
         Assert.areSame(2, calls);
     },
 
-    testUnique: function() {
-        var obj = {};
+    'unique() should return a copy of an array with duplicate items removed': function() {
+        var array = [],
+            obj   = {};
 
-        ArrayAssert.itemsAreSame([2, 1, 3, 5, 4], A.unique([2, 1, 2, 3, 5, 4, 4]));
-        ArrayAssert.itemsAreSame(['foo', null, obj, false], A.unique(['foo', 'foo', null, null, obj, obj, undefined, false, false]));
+        Assert.areNotSame(array, A.unique(array), 'returned array should be a copy');
+
+        ArrayAssert.itemsAreSame(
+            [2, 1, 3, 5, 4],
+            A.unique([2, 1, 2, 3, 5, 4, 4])
+        );
+
+        ArrayAssert.itemsAreSame(
+            ['foo', null, obj, undefined, false],
+            A.unique(['foo', 'foo', null, null, obj, obj, undefined, false, false])
+        );
     },
 
-    testUniqueWithSort: function() {
-        ArrayAssert.itemsAreSame([1, 2, 3, 4, 5], A.unique([2, 1, 2, 3, 5, 4, 4], true));
+    'unique() should support a custom test function': function () {
+        var obj    = {},
+            values = [{value: 'a'}, {value: 'a'}, {value: 'b'}],
+            results;
+
+        results = A.unique(values, function (a, b, index, array) {
+            Assert.isObject(a, '`a` should be an object');
+            Assert.isObject(b, '`b` should be an object');
+            Assert.isNumber(index, '`index` should be a number');
+            Assert.areSame(values, array, '`array` should be the input array');
+            Assert.areSame(values, this, '`this` should be the input array');
+
+            return a.value === b.value;
+        });
+
+        Assert.areSame(2, results.length);
+        Assert.areSame('a', results[0].value);
+        Assert.areSame('b', results[1].value);
     }
 }));
 


### PR DESCRIPTION
The sort parameter was deprecated back in 3.3.0, so it's time for it to go.

The optional test function makes it possible to perform custom comparison logic to determine whether two values should be considered equal.
