### PR TITLE
Remove specified OS within package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "description": "YUI 3 Source",
     "author": "Dav Glass <davglass@gmail.com>",
     "bugs": { "url" : "http://yuilibrary.com/projects/yui3/" },
-    "os": ["darwin", "linux", "win32"],
     "engines": {
         "node" : ">=0.4.0"
     },


### PR DESCRIPTION
Currently, `yui` require `os` within `package.json`, but I think that we don't have any reason to require specified `os`.

What do you think?

```
$ uname -v
FreeBSD 8.1-RELEASE #0: Mon Jul 19 02:36:49 UTC 2010     root@mason.cse.buffalo.edu:/usr/obj/usr/src/sys/GENERIC
```

```
$ npm install yui
```

```
npm ERR! Unsupported
npm ERR! Not compatible with your operating system or architecture: yui@3.5.1
npm ERR! Valid OS:    darwin,linux,win32
npm ERR! Valid Arch:  any
npm ERR! Actual OS:   freebsd
npm ERR! Actual Arch: x64
npm ERR! 
npm ERR! System FreeBSD 8.1-RELEASE
npm ERR! command "node" "/usr/local/bin/npm" "install" "yui"
npm ERR! cwd /usr/home/okuryu/work
npm ERR! node -v v0.6.17
npm ERR! npm -v 1.1.21
npm ERR! code EBADPLATFORM
npm ERR! message Unsupported
npm ERR! errno {}
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /usr/home/okuryu/work/npm-debug.log
npm not ok
```
