### PR TITLE
Fix issue where nodes that were created after the widget was shown...

### DIFF
--- a/src/autocomplete/js/autocomplete-list.js
+++ b/src/autocomplete/js/autocomplete-list.js
@@ -609,9 +609,8 @@ List = Y.Base.create('autocompleteList', Y.Widget, [
         var boundingBox = this._boundingBox,
             target      = e.target;
 
-        if (target !== this._inputNode && target !== boundingBox &&
-                !boundingBox.one(target.get('id'))) {
-
+        if(target !== this._inputNode && target !== boundingBox && 
+                target.ancestor('#' + boundingBox.get('id'), true)){
             this.hide();
         }
     },


### PR DESCRIPTION
caused it to hide, because the test for nesting depended on ids. Fixed a bug in flickr autocomplete where clicking on "more search options" caused the menu to disappear. 
