### PR TITLE
Unable to upload any number of files after (uploading a single file+ cancelling it) x 2

### DIFF
--- a/src/uploader/js/uploader-html5.js
+++ b/src/uploader/js/uploader-html5.js
@@ -1,4 +1,3 @@
-
     /**
      * This module provides a UI for file selection and multiple file upload capability using
      * HTML5 XMLHTTPRequest Level 2 as a transport engine.


### PR DESCRIPTION
Using the demo here, http://yuilibrary.com/yui/docs/uploader/uploader-multiple.html ,

and along with setting "appendNewFiles: false" on Uploader instantiation, this will take care of the bug:

BUG 1237
    status: open
    problem: Unable to upload any number of files
    steps to reproduce:
        1. add a single file
        2. upload it
        3. cancel it
        4. repeat steps 1-3 once
        5. add another single file
        6. click upload
