### PR TITLE
Enable filtering of messages sans log category.

### DIFF
--- a/src/yui/js/yui-log.js
+++ b/src/yui/js/yui-log.js
@@ -42,7 +42,8 @@ INSTANCE.log = function(msg, cat, src, silent) {
     // or the event call stack contains a consumer of the yui:log event
     if (c.debug) {
         // apply source filters
-        if (src) {
+        src = src || "";
+        if (typeof src !== "undefined") {
             excl = c.logExclude;
             incl = c.logInclude;
             if (incl && !(src in incl)) {


### PR DESCRIPTION
I had a problem where some modules had log statements that did not specify a log category, this made them unfilterable by logInclude and logExclude. The purpose of this change is to enable me to filter these messages using an empty string log category. e.g. "": true
