### PR TITLE
Fixing the logic that assigns default values for duration and easing in _uiScrollTo

### DIFF
--- a/src/scrollview/js/scrollview-base.js
+++ b/src/scrollview/js/scrollview-base.js
@@ -637,8 +637,8 @@ Y.ScrollView = Y.extend(ScrollView, Y.Widget, {
      */
     _uiScrollTo : function(x, y, duration, easing) {
         // TODO: This doesn't seem right. This is not UI logic. 
-        duration = duration || this._snapToEdge ? 400 : 0;
-        easing = easing || this._snapToEdge ? ScrollView.SNAP_EASING : null;
+        duration = duration || (this._snapToEdge ? 400 : 0);
+        easing = easing || (this._snapToEdge ? ScrollView.SNAP_EASING : null);
 
         this.scrollTo(x, y, duration, easing);
     },


### PR DESCRIPTION
As reported in the forums (http://yuilibrary.com/forum/viewtopic.php?p=32607#p32607), `ScrollViewPaginator.prototype.scrollTo` is ignoring the values passed for duration and easing of the transition. This is because of a badly written ternary operator in `ScrollView.prototype._uiScrollTo`. A default value is declared for duration as

``` JavaScript
duration = duration || this._snapToEdge ? 400 : 0;
```

The intent behind this line seems to be to do this:

``` JavaScript
duration = duration || (this._snapToEdge ? 400 : 0);
```

This fixes ticket http://yuilibrary.com/projects/yui3/ticket/2532334.

I'm not sure what to do about this comment though:

```
// TODO: This doesn't seem right. This is not UI logic. 
```

:tongue:
