### PR TITLE
Methods defined in the node-data submodule will now appear on Y.Node

### DIFF
--- a/src/node/js/node-data.js
+++ b/src/node/js/node-data.js
@@ -15,6 +15,7 @@ Y.mix(Y.Node.prototype, {
 
     /**
     * @method getData
+    * @for Node
     * @description Retrieves arbitrary data stored on a Node instance.
     * If no data is associated with the Node, it will attempt to retrieve
     * a value from the corresponding HTML data attribute. (e.g. node.getData('foo')
@@ -83,6 +84,7 @@ Y.mix(Y.Node.prototype, {
 
     /**
     * @method setData
+    * @for Node
     * @description Stores arbitrary data on a Node instance.
     * This is not stored with the DOM node.
     * @param {string} name The name of the field to set. If no name
@@ -103,6 +105,7 @@ Y.mix(Y.Node.prototype, {
 
     /**
     * @method clearData
+    * @for Node
     * @description Clears internally stored data.
     * @param {string} name The name of the field to clear. If no name
     * is given, all data is cleared.
@@ -124,6 +127,7 @@ Y.mix(Y.Node.prototype, {
 Y.mix(Y.NodeList.prototype, {
     /**
     * @method getData
+    * @for NodeList
     * @description Retrieves arbitrary data stored on each Node instance
     * bound to the NodeList.
     * @see Node
@@ -139,6 +143,7 @@ Y.mix(Y.NodeList.prototype, {
 
     /**
     * @method setData
+    * @for NodeList
     * @description Stores arbitrary data on each Node instance bound to the
     *  NodeList. This is not stored with the DOM node.
     * @param {string} name The name of the field to set. If no name
@@ -153,6 +158,7 @@ Y.mix(Y.NodeList.prototype, {
 
     /**
     * @method clearData
+    * @for NodeList
     * @description Clears data on all Node instances bound to the NodeList.
     * @param {string} name The name of the field to clear. If no name
     * is given, all data is cleared.


### PR DESCRIPTION
The getData method appears on the Y instance in the [API docs](http://yuilibrary.com/yui/docs/api/classes/YUI.html#method_getData), but it should appear on Y.Node. This pull fixes that issue by adding `@for` declarations for each method in the node-data.js file.

This may also fix the issue where the node-data module does not appear in the API docs module list.
