### PR TITLE
Fix build.xml for calendar, file, uploader to support multiple targets

### DIFF
--- a/src/calendar/build.xml
+++ b/src/calendar/build.xml
@@ -5,10 +5,29 @@
 <project name="Calendar" default="local">
     <description>Calendar Build File</description>
 
+    <macrodef name="build-submodules">
+        <attribute name="target"/>
+        <sequential>
+            <ant antfile="calendar-base.xml" target="@{target}" />
+            <ant antfile="calendarnavigator.xml" target="@{target}" />
+            <ant antfile="calendar.xml" target="@{target}" />
+        </sequential>
+    </macrodef>
+
+    <target name="local">
+        <build-submodules target="local"/>
+    </target>
+    <target name="deploy">
+        <build-submodules target="deploy"/>
+    </target>
     <target name="all">
-    	<ant antfile="calendar-base.xml" target="all" />
-    	<ant antfile="calendarnavigator.xml" target="all" />
-    	<ant antfile="calendar.xml" target="all" />
+        <build-submodules target="all"/>
+    </target>
+    <target name="clean">
+        <build-submodules target="clean"/>
+    </target>
+    <target name="tests">
+        <build-submodules target="clean"/>
     </target>
 
 </project>

--- a/src/file/build.xml
+++ b/src/file/build.xml
@@ -5,9 +5,28 @@
 <project name="File" default="local">
     <description>File Build File</description>
 
+    <macrodef name="build-submodules">
+        <attribute name="target"/>
+        <sequential>
+            <ant antfile="file-flash.xml" target="@{target}" />
+            <ant antfile="file-html5.xml" target="@{target}" />
+            <ant antfile="file.xml" target="@{target}" />
+        </sequential>
+    </macrodef>
+
+    <target name="local">
+        <build-submodules target="local"/>
+    </target>
+    <target name="deploy">
+        <build-submodules target="deploy"/>
+    </target>
     <target name="all">
-    	<ant antfile="file-flash.xml" target="all" />
-    	<ant antfile="file-html5.xml" target="all" />   	
-     	<ant antfile="file.xml" target="all" />
+        <build-submodules target="all"/>
+    </target>
+    <target name="clean">
+        <build-submodules target="clean"/>
+    </target>
+    <target name="tests">
+        <build-submodules target="clean"/>
     </target>
 </project>

--- a/src/uploader/build.xml
+++ b/src/uploader/build.xml
@@ -5,10 +5,29 @@
 <project name="Uploader" default="local">
     <description>Uploader Build File</description>
 
+    <macrodef name="build-submodules">
+        <attribute name="target"/>
+        <sequential>
+    	    <ant antfile="uploader-queue.xml" target="@{target}" />
+    	    <ant antfile="uploader-html5.xml" target="@{target}" />   	
+    	    <ant antfile="uploader-flash.xml" target="@{target}" />
+    	    <ant antfile="uploader.xml" target="@{target}" />
+        </sequential>
+    </macrodef>
+
+    <target name="local">
+        <build-submodules target="local"/>
+    </target>
+    <target name="deploy">
+        <build-submodules target="deploy"/>
+    </target>
     <target name="all">
-    	<ant antfile="uploader-queue.xml" target="all" />
-    	<ant antfile="uploader-html5.xml" target="all" />   	
-    	<ant antfile="uploader-flash.xml" target="all" />
-    	<ant antfile="uploader.xml" target="all" />
+        <build-submodules target="all"/>
+    </target>
+    <target name="clean">
+        <build-submodules target="clean"/>
+    </target>
+    <target name="tests">
+        <build-submodules target="clean"/>
     </target>
 </project>


### PR DESCRIPTION
The build.xml of calendar, file and uploader components only accepts right now the "all" target rather than all the available on the subcomponents (clean, local...)
