### PR TITLE
Fixes #2532153: typo in cssbutton HTML

### DIFF
--- a/src/button/docs/partials/cssbutton-source.mustache
+++ b/src/button/docs/partials/cssbutton-source.mustache
@@ -1,5 +1,5 @@
 <!-- Include the cssbutton stylesheet -->
-<link ref="stylsheet" href="http://yui.yahooapis.com/{{yuiVersion}}/build/cssbutton/cssbutton.css">
+<link rel="stylesheet" href="http://yui.yahooapis.com/{{yuiVersion}}/build/cssbutton/cssbutton.css">
 
 <h4>Button Tags</h4>
 <button class='yui3-button'>&lt;button&gt;</button>


### PR DESCRIPTION
Should be 'rel="stylesheet"' and not 'ref="stylsheet"'.
