### PR TITLE
Closes #2532368: timeout test for DataSource.Get

### DIFF
--- a/src/datasource/tests/datasource-get-tests.js
+++ b/src/datasource/tests/datasource-get-tests.js
@@ -132,6 +132,7 @@ suite.add(new Y.Test.Case({
             Assert.isUndefined(e.data, "error: Expected undefined data.");
             Assert.isObject(e.response, "error: Expected normalized response object.");
             Assert.isObject(e.error, "error: Expected error.");
+            Assert.areSame(e.error.message, "Planned failure");
             errorCallback = true;
         });
 
@@ -170,6 +171,7 @@ suite.add(new Y.Test.Case({
             Assert.isUndefined(e.data, "error: Expected undefined data.");
             Assert.isObject(e.response, "error: Expected normalized response object.");
             Assert.isObject(e.error, "error: Expected error.");
+            Assert.areSame(e.error.message, "Planned timeout");
             timeoutCallback = true;
         });
 


### PR DESCRIPTION
It's basically the same thing as the test for onError, since the code is exactly the same in DataSource.Get.  The only major difference is that config.onTimeout is used instead of config.onFailure.  Is there any 'timeout' specific things I should assert for?

Tested successfully on all the baseline browsers except for IE6 so far.

Pinging @davglass and @lsmith for verification.
