### PR TITLE
Set the request parameter to be optional in a few places

### DIFF
--- a/src/datasource/js/datasource-local.js
+++ b/src/datasource/js/datasource-local.js
@@ -352,7 +352,7 @@ Y.extend(DSLocal, Y.Base, {
      * property described below.
      *
      * @method sendRequest
-     * @param request {Object} An object literal with the following properties:
+     * @param [request] {Object} An object literal with the following properties:
      *     <dl>
      *     <dt><code>request</code></dt>
      *     <dd>The request to send to the live data source, if any.</dd>

--- a/src/datasource/js/datasource-polling.js
+++ b/src/datasource/js/datasource-polling.js
@@ -30,7 +30,7 @@ Pollable.prototype = {
      *
      * @method setInterval
      * @param msec {Number} Length of interval in milliseconds.
-     * @param request {Object} An object literal with the following properties:
+     * @param [request] {Object} An object literal with the following properties:
      *     <dl>
      *     <dt><code>request</code></dt>
      *     <dd>The request to send to the live data source, if any.</dd>


### PR DESCRIPTION
You're allowed to pass nothing as the parameter to datasource and, by the transitive property, you can pass nothing to datasource-polling's setInterval method.
