### PR TITLE
[wip] skin.order.loader.enhancements

### DIFF
--- a/src/loader/js/loader.js
+++ b/src/loader/js/loader.js
@@ -42,36 +42,6 @@ var NOT_FOUND = {},
         path += '.' + (type || CSS);
 
         return path;
-    },
-    MOD_SKINS = {
-        'autocomplete-list': 'night,sam',
-        calendarnavigator: 'sam,night',
-        'calendar-base': 'night,sam',
-        calendar: 'night,sam',
-        'console-filters': 'sam',
-        'datatable-base': 'night,sam',
-        console: 'sam',
-        'datatable-base-deprecated': 'night,sam',
-        'datatable-sort': 'night,sam',
-        'datatable-message': 'night,sam',
-        'datatable-scroll': 'night,sam',
-        dial: 'sam,night',
-        'node-flick': 'sam',
-        'node-menunav': 'sam,night',
-        overlay: 'sam,night',
-        panel: 'night,sam',
-        'resize-base': 'night,sam',
-        'scrollview-base': 'night,sam',
-        'scrollview-list': 'night,sam',
-        test: 'sam',
-        'scrollview-scrollbars': 'night,sam',
-        'slider-base': 'audio,capsule,audio-light,capsule-dark,night,round,sam,sam-dark,round-dark',
-        tabview: 'night,sam',
-        'test-console': 'sam',
-        'widget-base': 'sam,night',
-        'widget-modality': 'night,sam',
-        'widget-stack': 'sam,night',
-        'widget-buttons': 'night,sam'
     };
 
 
@@ -963,14 +933,19 @@ Y.Loader.prototype = {
      * @private
      */
     _removeSkins: function(mod) {
+        var i,
+            l,
+            reqMod;
+
         if (mod) {
-            YArray.each(mod.expanded || [], function (reqModName, index) {
-                var reqMod = this.getModule(reqModName);
+            l = mod.expanded && mod.expanded.length : 0;
+            for (i = 0; i < l; i++) {
+                reqMod = this.getModule(mod.expanded[i]);
                 if (reqMod && reqMod.skin) {
                     // required module is a skin module; remove it
-                    mod.expanded.splice(index, 1);
+                    mod.expanded.splice(i, 1);
                 }
-            }, this);
+            }
         }
     },
 
@@ -984,14 +959,20 @@ Y.Loader.prototype = {
      * already been loaded.
      */
     _setSkins: function(mod) {
-        var skinmods = [];
+        var skinmods = [],
+            skins = this._getSkins(mod),
+            l = skins ? skins.length : 0;
+            i,
+            skinmod;
 
-        YArray.each(this._getSkins(mod), function(skinname) {
-            var skinmod = this._addSkin(skinname, mod.name);
-            if (!this.isCSSLoaded(skinmod, this._boot)) {
-                skinmods.push(skinmod);
+        if (skins && l) {
+            for (i = 0; i < l; i++) {
+                skinmod = this._addSkin(skins[i], mod.name);
+                if (!this.isCSSLoaded(skinmod, this._boot)) {
+                    skinmods[skinmods.length] = skinmod;
+                }
             }
-        }, this);
+        }
 
         return skinmods;
     },
@@ -1231,18 +1212,13 @@ Y.Loader.prototype = {
             };
         }
 
-<<<<<<< HEAD
-        if (o.skinnable && o.ext) {
+        if (o.skinnable && o.ext && o.temp) {
             this._removeSkins(o);
             skinnames = this._setSkins(o);
-            YArray.each(skinnames, function(skinname) {
-                o.requires.unshift(skinname);
-            });
-=======
-        if (o.skinnable && o.ext && o.temp) {
-            skinname = this._addSkin(this.skin.defaultSkin, name);
-            o.requires.unshift(skinname);
->>>>>>> d1b10faf71cb5235b2320837d8ec40cbf0cd188f
+            l = skinnames ? skinnames.length : 0;
+            for (i = 0; i < len; i++) {
+                o.requires.unshift(skinnames[i]);
+            }
         }
         
         if (o.requires.length) {

--- a/src/loader/scripts/meta_join.js
+++ b/src/loader/scripts/meta_join.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs'),
     path = require('path'),
+    skins = require('yui3skins'),
     exists = fs.existsSync || path.existsSync,
     base = path.join(__dirname, '../../'),
     jsonOut = path.join(__dirname, '../', 'js', 'yui3.json'),
@@ -90,103 +91,114 @@ var out = sortObject(json);
 
 console.log('Writing JSON', jsonOut);
 
-var jsonStr = JSON.stringify(out, null, 4);
+skins.scan(base, null, function(skinHash) {
+    var modName, modSkins;
 
-fs.writeFileSync(jsonOut, jsonStr, 'utf8');
-
-console.log('Done, processing conditionals.');
-
-md5sum.update(jsonOut);
-var sum = md5sum.digest('hex');
-
-console.log('Using MD5:', sum);
-
-var header = fs.readFileSync(path.join(__dirname, '../template/meta.js'), 'utf8');
-
-header = header.replace(MD5_TOKEN, sum).replace('join.py', 'join.js');
-
-var tests = [];
-var allTests = [];
-
-Object.keys(out).forEach(function(name) {
-    var mod = out[name],
-        file;
-    if (mod.condition) {
-        var cond = sortObject(mod.condition);
-        if (conds[mod.condition.name]) {
-            var cName = mod.condition.name;
-            file = conds[cName];
-            if (exists(file)) {
-                var test = fs.readFileSync(file, 'utf8');
-                mod.condition.test = file;
-                cond.test = test;
-                tests.push({ key: file, test: test });
-            } else {
-                console.error('Failed to locate test file: ', file);
-                process.exit(1);
+    for (modName in skinHash) {
+        if (skinHash.hasOwnProperty(modName)) {
+            if (out[modName] && !out[modName].skins) {
+                out[modName].skins = skinHash[modName];
             }
         }
-        allTests.push(cond);
     }
+
+    var jsonStr = JSON.stringify(out, null, 4);
+
+    fs.writeFileSync(jsonOut, jsonStr, 'utf8');
+
+    console.log('Done, processing conditionals.');
+
+    md5sum.update(jsonOut);
+    var sum = md5sum.digest('hex');
+
+    console.log('Using MD5:', sum);
+
+    var header = fs.readFileSync(path.join(__dirname, '../template/meta.js'), 'utf8');
+
+    header = header.replace(MD5_TOKEN, sum).replace('join.py', 'join.js');
+
+    var tests = [];
+    var allTests = [];
+
+    Object.keys(out).forEach(function(name) {
+        var mod = out[name],
+            file;
+        if (mod.condition) {
+            var cond = sortObject(mod.condition);
+            if (conds[mod.condition.name]) {
+                var cName = mod.condition.name;
+                file = conds[cName];
+                if (exists(file)) {
+                    var test = fs.readFileSync(file, 'utf8');
+                    mod.condition.test = file;
+                    cond.test = test;
+                    tests.push({ key: file, test: test });
+                } else {
+                    console.error('Failed to locate test file: ', file);
+                    process.exit(1);
+                }
+            }
+            allTests.push(cond);
+        }
+    });
+
+    var jsonStr = JSON.stringify(out, null, 4);
+
+    tests.forEach(function(info) {
+        jsonStr = jsonStr.replace('"' + info.key + '"', info.test);
+    });
+
+    jsonStr = jsonStr.replace(/}\n,/g, '},').replace(/}\n\n,/g, '},');
+
+    var jsStr = header.replace(TEMPLATE_TOKEN, jsonStr);
+
+    console.log('Writing JS file', jsOut);
+
+    fs.writeFileSync(jsOut, jsStr, 'utf8');
+
+    console.log('Done writing JS file');
+
+    allTests.sort(function(a, b) {
+        var nameA = a.name.toLowerCase(),
+            nameB = b.name.toLowerCase();
+
+        if (nameA < nameB) {
+            return -1;
+        }
+        if (nameA > nameB) {
+            return 1;
+        }
+        return 0
+    });
+
+
+    header = fs.readFileSync(path.join(__dirname, '../template/load-tests-template.js'), 'utf8');
+    header = header.replace('join.py', 'join.js');
+
+    tests = [];
+
+    allTests.forEach(function(cond, key) {
+        var test = cond.test;
+        if (test) {
+            cond.test = '~~COND~~';
+        }
+        var o = JSON.stringify(cond, null, 4);
+        if (test) {
+            o = o.replace('"~~COND~~"', test);
+        }
+        tests.push("// " + cond.name);
+        tests.push("add('load', '" + key + "', " + o + ");");
+    });
+
+    header += tests.join('\n');
+    header= header.replace(/}\n,/g, '},');
+    header= header.replace(/}\n\n,/g, '},');
+
+    var loadTests = path.join(__dirname, '../../yui/js/load-tests.js');
+
+    console.log('Writing load tests file', loadTests);
+
+    fs.writeFileSync(loadTests, header, 'utf8');
+
+    console.log('Done!');
 });
-
-var jsonStr = JSON.stringify(out, null, 4);
-
-tests.forEach(function(info) {
-    jsonStr = jsonStr.replace('"' + info.key + '"', info.test);
-});
-
-jsonStr = jsonStr.replace(/}\n,/g, '},').replace(/}\n\n,/g, '},');
-
-var jsStr = header.replace(TEMPLATE_TOKEN, jsonStr);
-
-console.log('Writing JS file', jsOut);
-
-fs.writeFileSync(jsOut, jsStr, 'utf8');
-
-console.log('Done writing JS file');
-
-allTests.sort(function(a, b) {
-    var nameA = a.name.toLowerCase(),
-        nameB = b.name.toLowerCase();
-
-    if (nameA < nameB) {
-        return -1;
-    }
-    if (nameA > nameB) {
-        return 1;
-    }
-    return 0
-});
-
-
-header = fs.readFileSync(path.join(__dirname, '../template/load-tests-template.js'), 'utf8');
-header = header.replace('join.py', 'join.js');
-
-tests = [];
-
-allTests.forEach(function(cond, key) {
-    var test = cond.test;
-    if (test) {
-        cond.test = '~~COND~~';
-    }
-    var o = JSON.stringify(cond, null, 4);
-    if (test) {
-        o = o.replace('"~~COND~~"', test);
-    }
-    tests.push("// " + cond.name);
-    tests.push("add('load', '" + key + "', " + o + ");");
-});
-
-header += tests.join('\n');
-header= header.replace(/}\n,/g, '},');
-header= header.replace(/}\n\n,/g, '},');
-
-var loadTests = path.join(__dirname, '../../yui/js/load-tests.js');
-
-console.log('Writing load tests file', loadTests);
-
-fs.writeFileSync(loadTests, header, 'utf8');
-
-console.log('Done!');
-

--- a/src/loader/tests/unit/assets/loader-tests.js
+++ b/src/loader/tests/unit/assets/loader-tests.js
@@ -1687,7 +1687,6 @@ YUI.add('loader-tests', function(Y) {
             ArrayAssert.itemsAreEqual(expected, sorted, 'Failed to calculate second set of modules');
 
         },
-<<<<<<< HEAD:src/loader/tests/loader-tests.js
         'test: skin.order should fall back to the defaultSkin when a module does not support any of the skins in skin.order': function() {
             var loader = new Y.Loader({
                     base: '',
@@ -1722,8 +1721,10 @@ YUI.add('loader-tests', function(Y) {
                         order: 'night'
                     }
                 }),
-                out = loader.resolve(true);
+                out = loader.resolve(true),
+                css = out.css.join(' ');
 
+            Assert.isTrue(css.indexOf('assets/skins/sam/bar.css') > -1);
 
         },
         'test: skin.order should not fetch any skin if a module supplies mod.skins and none of them are available in skin.order or skin.defaultSkin': function() {
@@ -1989,35 +1990,35 @@ YUI.add('loader-tests', function(Y) {
                     };
                 },
 
-                // loader 1
-                loader1 = new Y.Loader(getConfig({
-                    defaultSkin: 'baz'
-                })),
-                loader1resolved = loader1.resolve(true),
-                css1 = loader1resolved.css.join(' '),
-                // loader 2
-                loader2 = new Y.Loader(getConfig({
-                    order: 'round-dark'
-                })),
-                loader2resolved = loader2.resolve(true),
-                css2 = loader2resolved.css.join(' '),
-                // loader 3
-                loader3 = new Y.Loader(getConfig({
-                    defaultSkin: 'buz'
-                })),
-                loader3resolved = loader3.resolve(true);
+            // loader 1
+            loader1 = new Y.Loader(getConfig({
+                defaultSkin: 'baz'
+            })),
+            loader1resolved = loader1.resolve(true),
+            css1 = loader1resolved.css.join(' '),
+            // loader 2
+            loader2 = new Y.Loader(getConfig({
+                order: 'round-dark'
+            })),
+            loader2resolved = loader2.resolve(true),
+            css2 = loader2resolved.css.join(' '),
+            // loader 3
+            loader3 = new Y.Loader(getConfig({
+                defaultSkin: 'buz'
+            })),
+            loader3resolved = loader3.resolve(true);
 
-                // loader 1 assertions
-                Assert.isTrue(css1.indexOf('foo/assets/skins/baz/foo.css') > -1, 'loader1 should fetch baz skin for foo');
-                Assert.areSame(1, loader1resolved.css.length, 'loader1 should request only 1 skin');
-                // loader 2 assertions
-                Assert.isTrue(css2.indexOf('foo/assets/skins/round-dark/foo.css') > -1, 'loader2 should fetch round-dark skin for foo');
-                Assert.isTrue(css2.indexOf('slider-base/assets/skins/round-dark/slider-base.css') > -1, 'loader2 should fetch round-dark skin for slider-base');
-                Assert.isTrue(css2.indexOf('widget-stack/assets/skins/sam/widget-stack.css') > -1, 'loader2 should fetch sam skin for widget-stack');
-                Assert.areSame(-1, css2.indexOf('baz'), 'loader2 should not load baz skin for any module');
-                // loader 3 assertions
-                ArrayAssert.isEmpty(loader3resolved.css, 'loader3 should not fetch any skins');
-=======
+            // loader 1 assertions
+            Assert.isTrue(css1.indexOf('foo/assets/skins/baz/foo.css') > -1, 'loader1 should fetch baz skin for foo');
+            Assert.areSame(1, loader1resolved.css.length, 'loader1 should request only 1 skin');
+            // loader 2 assertions
+            Assert.isTrue(css2.indexOf('foo/assets/skins/round-dark/foo.css') > -1, 'loader2 should fetch round-dark skin for foo');
+            Assert.isTrue(css2.indexOf('slider-base/assets/skins/round-dark/slider-base.css') > -1, 'loader2 should fetch round-dark skin for slider-base');
+            Assert.isTrue(css2.indexOf('widget-stack/assets/skins/sam/widget-stack.css') > -1, 'loader2 should fetch sam skin for widget-stack');
+            Assert.areSame(-1, css2.indexOf('baz'), 'loader2 should not load baz skin for any module');
+            // loader 3 assertions
+            ArrayAssert.isEmpty(loader3resolved.css, 'loader3 should not fetch any skins');
+        },
         'testing configFn for bug #2532498': function() {
             var loader = new Y.Loader({
                     filter: "debug",
@@ -2391,10 +2392,9 @@ YUI.add('loader-tests', function(Y) {
                 var len = item.split('/').length;
                 Assert.areEqual(2, len, 'Failed to call configFn on ' + item);
             });
->>>>>>> d1b10faf71cb5235b2320837d8ec40cbf0cd188f:src/loader/tests/unit/assets/loader-tests.js
         }
     });
-    
+
     var name = 'Loader';
     if (typeof TestName != 'undefined') {
         name = TestName;


### PR DESCRIPTION
Loader enhancement that adds an `order` property to the `skin` property of config (http://yuilibrary.com/yui/docs/api/classes/config.html#property_skin). Preserves backwards compatibility, and adds the ability to have a fallback system when specifying skins and does not require
the user of the framework to have to remember which modules support which skins:

```
YUI({
    skin: {
        order: 'night,sam'
    }
}).use('test', 'calendar', function (Y) {...});
```

This tells the framework to load the first available skin in the ordered list of
skins for each module in the `use` call. So for calendar it will load the
**night** skin because calendar supports it and for test it will load the
**sam** skin since it is the only skin that it supports.

Since the `defaultSkin` is always included as the last skin in the ordered list,
you can also write (because the default skin is **sam**):

```
YUI({
    skin: {
        order: 'night'
    }
}).use('test', 'calendar', function (Y) {...});
```

For a more extreme example, look at slider-base, it is the only module that supports
9 skins so we could write the following and the framework will load the skins in
that order of preference. Later on, when calendar supports **round** or
**round-dark**, there would be no changes needed to the code below.

```
YUI({
    skin: {
        order: 'round,round-dark,night,sam-dark'
    }
}).use('test', 'calendar', 'slider-base', function (Y) {...});
```

The addition of the `skins.order` property is backwards compatible which means
that changing the `defaultSkin` and using `overrides` still works as expected.

Metadata for skins (see MOD_SKINS in Loader.js 46-75) generated by [comp_skins](https://github.com/ryanvanoss/comp_skins) and could be added to build files (a la requires metadata).

You can play with skin order and overrides here: http://23.21.81.23/yui3configurator/index.php, and run the existing unit tests, along with the additional tests from this pull request, here: http://23.21.81.23/yui/tests/loader/tests/index.html.

Configurator source code available here: https://github.com/ryanvanoss/yui3configurator
