### PR TITLE
Avoid processing columns if there aren't any to allow empty tables.

### DIFF
--- a/src/datatable/js/table.js
+++ b/src/datatable/js/table.js
@@ -414,7 +414,9 @@ Y.namespace('DataTable').TableView = Y.Base.create('table', Y.View, [], {
             }
         }
 
-        process(columns);
+        if (columns) {
+            process(columns);
+        }
 
         /**
         Array of the columns that correspond to those with value cells in the


### PR DESCRIPTION
I'm getting "Cannot read property 'length' of undefined" error while instantiating an empty DataTable.  This used to be possible in YUI 3.5.
