### PR TITLE
YQL Query example tests

### DIFF
--- a/src/yql/docs/assets/simple-yql-tests.js
+++ b/src/yql/docs/assets/simple-yql-tests.js
@@ -1,0 +1,36 @@
+YUI.add('simple-yql-tests', function (Y) {
+
+    var suite = new Y.Test.Suite('simple yql example test suite'),
+        Assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'Example tests',
+        'example should have rendered an enclosing div': function () {
+            var test = this;
+            test.wait(function () {
+                var mod = Y.one('.mod');
+
+                Assert.isNotNull(mod, 'Enclosure missing: network problem?');
+            }, 3000);
+        },
+
+        'example should have correct zip code in header': function () {
+            var header = Y.one('.mod h2');
+
+            Assert.areEqual(header.getHTML(), 'Weather for 90210', 'Header has incorrect text');
+        },
+
+        'example should return well-formatted weather data': function () {
+            var imgNode = Y.all('.mod img'),
+                boldNodes = Y.all('.mod b'),
+                links = Y.all('.mod a');
+
+            Assert.areEqual(imgNode.size(), 1, 'Failed to render image');
+            Assert.areEqual(boldNodes.size(), 2, 'Failed to render bold text');
+            Assert.areEqual(links.size(), 2, 'Failed to render external links');
+        }
+    }));
+
+    Y.Test.Runner.add(suite);
+
+}, '@VERSION@', { requires: [ 'yql', 'node', 'test' ] });

--- a/src/yql/docs/assets/yql-requery-tests.js
+++ b/src/yql/docs/assets/yql-requery-tests.js
@@ -1,0 +1,40 @@
+YUI.add('yql-requery-tests', function (Y) {
+
+    var suite = new Y.Test.Suite('yql requery example test suite'),
+        Assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'Example tests',
+        'example should have an enclosing div': function () {
+            var enclosure = Y.one('#res');
+
+            Assert.isNotNull(enclosure, 'Enclosure missing');
+            Y.assert(!enclosure.hasChildNodes(), 'Enclosure has initial nodes');
+        },
+
+        'example should return Flickr pictures after queries': function () {
+            var test = this,
+                firstNumber;
+            test.wait(function () {
+                var queryNode   = Y.one('#res h2 em'),
+                    content     = queryNode.getHTML();
+                
+                firstNumber = parseInt(content.match(/\d+\.?\d*/g), 10);
+
+                Assert.isNumber(firstNumber, 'Query number not found');
+            }, 10000);
+
+            test.wait(function () {
+                var queryNode   = Y.one('#res h2 em'),
+                    content     = queryNode.getHTML(),
+                    nextNumber  = parseInt(content.math(/\d+\.?d*/g), 10);
+
+                Assert.isNumber(nextNumber, 'Next number not found');
+                Assert.areNotEqual(firstNumber, nextNumber,
+                    'Queries have different query numbers');
+            }, 10000);
+        }
+    }));
+
+    Y.Test.Runner.add(suite);
+}, '@VERSION@', { requires: [ 'yql', 'node', 'test' ] });


### PR DESCRIPTION
Looking for some review on this example test because of some strange stack overflow error I get when performing asynchronous tests on the requery-example:

```
window.onerror called: failed.
window.onerror fired
Expected: undefined (undefined)
Actual: Uncaught RangeError: Maximum call stack size exceeded (string)
```

I'm not 100% sure when it's coming from, or if it's a YQL thing.  Removing the asynchronous tests removes the problem, however.
