### PR TITLE
Editor example tests

### DIFF
--- a/src/editor/docs/assets/editor-events-tests.js
+++ b/src/editor/docs/assets/editor-events-tests.js
@@ -1,0 +1,22 @@
+YUI.add('editor-events-tests', function (Y) {
+
+    var suite = new Y.Test.Suite('editor events example test suite'),
+        Assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'Example tests',
+        'Example should have rendered an iframe for Editor': function () {
+            var editorFrame = Y.one('#editor iframe');
+
+            Assert.isNotNull(editorFrame, 'Editor iframe is missing');
+        },
+
+        'Example should have rendered a console for logging': function () {
+            var consoleNode = Y.one('#console .yui3-console');
+
+            Assert.isNotNull(consoleNode, 'Console widget is missing');
+        }
+    }));
+
+    Y.Test.Runner.add(suite);
+}, '@VERSION@', { requires: [ 'node', 'test' ] });

--- a/src/editor/docs/assets/editor-exec-tests.js
+++ b/src/editor/docs/assets/editor-exec-tests.js
@@ -1,0 +1,53 @@
+YUI.add('editor-exec-tests', function (Y) {
+    
+    var suite = new Y.Test.Suite('editor exec example test suite'),
+        Assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'Example tests',
+        'Example should have rendered clickable buttons': function () {
+            var btnContainer = Y.one('#buttons'),
+                fooButton  = Y.one('#buttons #foo'),
+                barButton  = Y.one('#buttons #bar'),
+                bazButton  = Y.one('#buttons #baz');
+
+            Assert.isNotNull(btnContainer, 'Buttons container is missing');
+            Assert.isNotNull(fooButton, 'Bold tags button is missing');
+            Assert.isNotNull(barButton, 'Italic tags button is missing');
+            Assert.isNotNull(bazButton, 'Class `foo` tags button is missing');
+        },
+
+        'Editor instance should have rendered': function () {
+            var editorFrame = Y.one('#editor iframe');
+
+            Assert.isNotNull(editorFrame, 'Editor iframe is missing');
+        },
+
+        'Clicking should result in different outputs': function () {
+            var fooButton  = Y.one('#buttons #foo'),
+                barButton  = Y.one('#buttons #bar'),
+                bazButton  = Y.one('#buttons #baz');
+
+            fooButton.simulate('click');
+            
+            Assert.areEqual(Y.one('#out').getHTML(),
+                'You clicked on Foo',
+                'Foo button output is unexpected');
+
+            barButton.simulate('click');
+
+            Assert.areEqual(Y.one('#out').getHTML(),
+                'You clicked on Bar',
+                'Bar button output is unexpected');
+
+            bazButton.simulate('click');
+
+            Assert.areEqual(Y.one('#out').getHTML(),
+                'You clicked on Baz',
+                'Baz button output is unexpected');
+        }
+    }));
+
+    Y.Test.Runner.add(suite);
+}, '@VERSION@', { requires: [ 'node', 'node-event-simulate', 'test' ] });
+

--- a/src/editor/docs/assets/editor-instance-tests.js
+++ b/src/editor/docs/assets/editor-instance-tests.js
@@ -1,0 +1,53 @@
+YUI.add('editor-instance-tests', function (Y) {
+    
+    var suite = new Y.Test.Suite('editor instance example test suite'),
+        Assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'Example tests',
+        'Example should have rendered clickable buttons': function () {
+            var btnContainer = Y.one('#buttons'),
+                bTagsButton  = Y.one('#buttons #btags'),
+                iTagsButton  = Y.one('#buttons #itags'),
+                cTagsButton  = Y.one('#buttons #ctags');
+
+            Assert.isNotNull(btnContainer, 'Buttons container is missing');
+            Assert.isNotNull(bTagsButton, 'Bold tags button is missing');
+            Assert.isNotNull(iTagsButton, 'Italic tags button is missing');
+            Assert.isNotNull(cTagsButton, 'Class `foo` tags button is missing');
+        },
+
+        'Editor instance should have rendered': function () {
+            var editorFrame = Y.one('#editor iframe');
+
+            Assert.isNotNull(editorFrame, 'Editor iframe is missing');
+        },
+
+        'Clicking should result in different outputs': function () {
+            var bTagsButton  = Y.one('#buttons #btags'),
+                iTagsButton  = Y.one('#buttons #itags'),
+                cTagsButton  = Y.one('#buttons #ctags');
+
+            bTagsButton.simulate('click');
+            
+            Assert.areEqual(Y.one('#out').getHTML(),
+                'There are (2) B tags in the iframe.',
+                'Bold tags output is unexpected');
+
+            iTagsButton.simulate('click');
+
+            Assert.areEqual(Y.one('#out').getHTML(),
+                'There are (1) I tags in the iframe.',
+                'Italic tags output is unexpected');
+
+            cTagsButton.simulate('click');
+
+            Assert.areEqual(Y.one('#out').getHTML(),
+                'There are (2) items with class foo in the iframe.',
+                'Foo tags output is unexpected');
+        }
+    }));
+
+    Y.Test.Runner.add(suite);
+}, '@VERSION@', { requires: [ 'node', 'node-event-simulate', 'test' ] });
+

--- a/src/editor/docs/assets/editor-nodechange-tests.js
+++ b/src/editor/docs/assets/editor-nodechange-tests.js
@@ -1,0 +1,22 @@
+YUI.add('editor-nodechange-tests', function (Y) {
+
+    var suite = new Y.Test.Suite('editor nodechange example test suite'),
+        Assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'Example tests',
+        'Example should have rendered an iframe for Editor': function () {
+            var editorFrame = Y.one('#editor iframe');
+
+            Assert.isNotNull(editorFrame, 'Editor iframe is missing');
+        },
+
+        'Example should have rendered a console for logging': function () {
+            var consoleNode = Y.one('#console .yui3-console');
+
+            Assert.isNotNull(consoleNode, 'Console widget is missing');
+        }
+    }));
+
+    Y.Test.Runner.add(suite);
+}, '@VERSION@', { requires: [ 'node', 'test' ] });


### PR DESCRIPTION
Mostly straightforward button clicking, but the editor-nodechange and editor-events only test for the rendering of the Editor and Log Console.
