### PR TITLE
TabView shouldn't make assumptions about labels

### DIFF
--- a/src/tabview/js/tab.js
+++ b/src/tabview/js/tab.js
@@ -110,17 +110,21 @@ Y.Tab = Y.Base.create('tab', Y.Widget, [Y.WidgetChild], {
     },
 
     _defLabelSetter: function(label) {
-        this.get('contentBox').setContent(label);
+        this.get('contentBox').setHTML(label);
         return label;
     },
 
+    _defLabelGetter: function(label) {
+        return this.get('contentBox').getHTML();
+    },
+
     _defContentSetter: function(content) {
-        this.get('panelNode').setContent(content);
+        this.get('panelNode').setHTML(content);
         return content;
     },
 
     _defContentGetter: function(content) {
-        return this.get('panelNode').getContent();
+        return this.get('panelNode').getHTML();
     },
 
     // find panel by ID mapping from label href
@@ -167,6 +171,7 @@ Y.Tab = Y.Base.create('tab', Y.Widget, [Y.WidgetChild], {
          */
         label: { 
             setter: '_defLabelSetter',
+            getter: '_defLabelGetter',
             validator: Lang.isString
         },
 

--- a/src/tabview/js/tabview.js
+++ b/src/tabview/js/tabview.js
@@ -129,7 +129,6 @@ var _queries = Y.TabviewBase._queries,
                 tabview.add({
                     boundingBox: node,
                     contentBox: node.one(DOT + _classNames.tabLabel),
-                    label: node.one(DOT + _classNames.tabLabel).get('text'),
                     panelNode: panelNode
                 });
             });


### PR DESCRIPTION
This is a very common question in the forums.

At first I thought it was agreed that components should escape content to prevent XSS vulnerabilities, but `tabview.add({ label: '<span>foo</span>' })` seems to be working. However, progressive enhancement is still removing HTML.

This patch changes the way tabs are added from markup. Instead of reading the content of the label and resetting it (which resets the label HTML and breaks existing node references) it just sets the `contentBox`. Then `Tab` is changed to have a getter that returns the html inside the content box, just like the `content` attribute does with the panel node.

This question is still open though: do we allow HTML by default or do we add an extra `HTMLTab` subclass of `Tab`?
