### PR TITLE
Add category and source to Y.log() calls in event-touch.

### DIFF
--- a/build/event-touch/event-touch-debug.js
+++ b/build/event-touch/event-touch-debug.js
@@ -24,7 +24,7 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
 
     var i,l, etCached, et,touchCache;
 
-    Y.log("Calling facade._touch() with e = " + e);
+    Y.log("Calling facade._touch() with e = " + e, "info", "event-touch");
 
     if (e.touches) {
         Y.log("Found e.touches. Replicating on facade");
@@ -46,7 +46,7 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
     }
 
     if (e.targetTouches) {
-        Y.log("Found e.targetTouches. Replicating on facade");
+        Y.log("Found e.targetTouches. Replicating on facade", "info", "event-touch");
 
         /**
          * Array of individual touch events still in contact with the touch
@@ -64,12 +64,12 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
 
             this.targetTouches[i] = etCached || new Y.DOMEventFacade(et, currentTarget, wrapper);
             
-            if (etCached) { Y.log("Found native event in touches. Using same facade in targetTouches"); }
+            if (etCached) { Y.log("Found native event in touches. Using same facade in targetTouches", "info", "event-touch"); }
         }
     }
 
     if (e.changedTouches) {
-        Y.log("Found e.changedTouches. Replicating on facade");        
+        Y.log("Found e.changedTouches. Replicating on facade", "info", "event-touch");
 
         /**
         An array of event-specific touch events.
@@ -94,7 +94,7 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
 
             this.changedTouches[i] = etCached || new Y.DOMEventFacade(et, currentTarget, wrapper);
             
-            if (etCached) { Y.log("Found native event in touches. Using same facade in changedTouches"); }
+            if (etCached) { Y.log("Found native event in touches. Using same facade in changedTouches", "info", "event-touch"); }
         }
     }
 

--- a/src/event/js/event-facade-dom-touch.js
+++ b/src/event/js/event-facade-dom-touch.js
@@ -22,7 +22,7 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
 
     var i,l, etCached, et,touchCache;
 
-    Y.log("Calling facade._touch() with e = " + e);
+    Y.log("Calling facade._touch() with e = " + e, "info", "event-touch");
 
     if (e.touches) {
         Y.log("Found e.touches. Replicating on facade");
@@ -44,7 +44,7 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
     }
 
     if (e.targetTouches) {
-        Y.log("Found e.targetTouches. Replicating on facade");
+        Y.log("Found e.targetTouches. Replicating on facade", "info", "event-touch");
 
         /**
          * Array of individual touch events still in contact with the touch
@@ -62,12 +62,12 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
 
             this.targetTouches[i] = etCached || new Y.DOMEventFacade(et, currentTarget, wrapper);
             
-            if (etCached) { Y.log("Found native event in touches. Using same facade in targetTouches"); }
+            if (etCached) { Y.log("Found native event in touches. Using same facade in targetTouches", "info", "event-touch"); }
         }
     }
 
     if (e.changedTouches) {
-        Y.log("Found e.changedTouches. Replicating on facade");        
+        Y.log("Found e.changedTouches. Replicating on facade", "info", "event-touch");
 
         /**
         An array of event-specific touch events.
@@ -92,7 +92,7 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
 
             this.changedTouches[i] = etCached || new Y.DOMEventFacade(et, currentTarget, wrapper);
             
-            if (etCached) { Y.log("Found native event in touches. Using same facade in changedTouches"); }
+            if (etCached) { Y.log("Found native event in touches. Using same facade in changedTouches", "info", "event-touch"); }
         }
     }
 


### PR DESCRIPTION
event-touch is very verbose (it logs a message on every mouse movement) and the lack of category and source in the log() calls made it impossible to filter them out.
