### PR TITLE
Allow models to be added to a ModelList at instantiation time

### DIFF
--- a/src/app/HISTORY.md
+++ b/src/app/HISTORY.md
@@ -15,6 +15,13 @@ App Framework Change History
 * ModelSync.REST's `serialize()` method now receives the `action` which the
   `sync()` method was invoked with. [Ticket #2532625]
 
+### ModelList
+
+* You may now add models to a ModelList at instantiation time by providing an
+  Object, array of Objects, Model instance, array of Model instances, or another
+  ModelList instance in the `items` property of the config object passed to
+  ModelList's constructor. This change also applies to LazyModelList.
+
 
 3.6.0
 -----

--- a/src/app/docs/model-list/index.mustache
+++ b/src/app/docs/model-list/index.mustache
@@ -33,8 +33,20 @@ list.add([
 ```
 
 <p>
-If you already have existing `Y.Model` instances, you can add those instead of
-passing in new objects.
+Alternatively, you can specify the models you want to add in an `items` config parameter that you pass to ModelList's constructor. Adding items this way won't cause an [[#List Events|`add` event]] to be fired.
+</p>
+
+```
+var list = new Y.ModelList({
+  items: [
+    {name: 'Model One', arbitraryData: 'foo'},
+    {name: 'Model Two', arbitraryData: 'bar'}
+  ]
+});
+```
+
+<p>
+If you already have existing `Y.Model` instances, you can add those instead of passing in new objects.
 </p>
 
 ```
@@ -156,6 +168,26 @@ You can even pass another ModelList instance to `add()` to add all the models fr
 // Assuming `cheesecakes` is another ModelList instance, we can add all its
 // models to the `pies` list like this.
 pies.add(cheesecakes);
+```
+
+<p>
+To add one or more models to a list at instantiation time, specify them in the `items` property of the config object passed to ModelList's constructor. When models are added this way, the `add` event is not fired.
+</p>
+
+```
+// Create a new list containing a single model.
+var pies = new Y.ModelList({items: {type: 'pecan'}});
+
+// Create a new list containing multiple models.
+var pies = new Y.ModelList({
+  items: [
+    {type: 'apple'},
+    {type: 'maple custard'}
+  ]
+});
+
+// Create a new list containing the contents of another list.
+var pies = new Y.ModelList({items: otherList});
 ```
 
 <p>

--- a/src/app/js/model-list.js
+++ b/src/app/js/model-list.js
@@ -23,6 +23,10 @@ defined, models are sorted in insertion order).
 @extends Base
 @uses ArrayList
 @constructor
+@param {Object} config Config options.
+    @param {Model|Model[]|ModelList|Object|Object[]} config.items Model
+        instance, array of model instances, or ModelList to add to this list on
+        init. The `add` event will not be fired for models added on init.
 @since 3.4.0
 **/
 
@@ -189,6 +193,10 @@ Y.ModelList = Y.extend(ModelList, Y.Base, {
         this.after('*:idChange', this._afterIdChange);
 
         this._clear();
+
+        if (config.items) {
+            this.add(config.items, {silent: true});
+        }
     },
 
     destructor: function () {

--- a/src/app/tests/unit/assets/model-list-test.js
+++ b/src/app/tests/unit/assets/model-list-test.js
@@ -25,6 +25,35 @@ modelListSuite.add(new Y.Test.Case({
         delete this.list;
     },
 
+    'constructor: should add a model instance, array of model instances, or ModelList instance to the list when passed in the `items` config property': function () {
+        var a = new Y.Model({name: 'a'}),
+            b = new Y.Model({name: 'b'}),
+            list;
+
+        list = new Y.ModelList({items: {name: 'a'}});
+        Assert.areSame(1, list.size(), 'list should contain one model');
+        Assert.areSame('a', list.item(0).get('name'), 'single model as object should be added correctly on init');
+
+        list = new Y.ModelList({items: [{name: 'a'}, {name: 'b'}]});
+        Assert.areSame(2, list.size(), 'list should contain two models');
+        Assert.areSame('a', list.item(0).get('name'), 'first model of multiple models as objects should be added correctly on init');
+        Assert.areSame('b', list.item(1).get('name'), 'second model of multiple models as objects should be added correctly on init');
+
+        list = new Y.ModelList({items: a});
+        Assert.areSame(1, list.size(), 'list should contain one model');
+        Assert.areSame('a', list.item(0).get('name'), 'single model should be added correctly on init');
+
+        list = new Y.ModelList({items: [a, b]});
+        Assert.areSame(2, list.size(), 'list should contain two models');
+        Assert.areSame('a', list.item(0).get('name'), 'first model of multiple models should be added correctly on init');
+        Assert.areSame('b', list.item(1).get('name'), 'second model of multiple models should be added correctly on init');
+
+        list = new Y.ModelList({items: new Y.ModelList({items: [a, b]})});
+        Assert.areSame(2, list.size(), 'list should contain two models');
+        Assert.areSame('a', list.item(0).get('name'), 'first model of ModelList should be added correctly on init');
+        Assert.areSame('b', list.item(1).get('name'), 'second model of ModelList should be added correctly on init');
+    },
+
     'destructor should detach all models from the list': function () {
         var model = new Y.Model();
 


### PR DESCRIPTION
This change allows models to be added to a ModelList at instantiation time by passing them in the `items` config property:

``` js
// Add models to a list at instantiation time, with no `add` event.
var list = new Y.ModelList({
    items: [
        {name: 'first model'},
        {name: 'second model'}
    ]
});

// Add models from another list.
var list = new Y.ModelList({items: otherModelList});
```

I chose the name `items` instead of `models` to avoid confusion since there's already a singular `model` config property and it's used to refer to a Model class, not a model instance.

This change is automatically inherited by LazyModelList, so it gets the same enhancement at no cost.
### Running Locally

The built `model-list` module is intentionally not included in order to keep the diffs clean. Before testing this change, you'll need to build it:

``` bash
$ cd src/app && ant all
```
