### PR TITLE
made the unit test robust by stop progagating real mouse/touch events du...

### DIFF
--- a/src/gesture-simulate/tests/unit/gesture-simulate.html
+++ b/src/gesture-simulate/tests/unit/gesture-simulate.html
@@ -10,17 +10,16 @@
             height: 250px;
             background-color: yellowgreen;
         }
+        #glasspane {
+            width: 600px;
+            height: 250px;
+            background-color: blue;
+        }
     </style>
 </head>
 <body class="yui3-skin-sam">
-    <div id="touchable">Test Area. Do not mouseover/touch, or tests will fail due to incorrect event counts (TODO: Cover with another element to prevent user events).</div>
     <div id="log"></div>
-    <div id="c"></div>
-    <div id="inst">
-        <h3>WARNING:</h3>    
-        If this test manually started, make sure the mouse doesn't enter the above test area by accident. On a device, do not touch the test area. 
-        It will interrupt the tests, which makes the test run invalid. 
-    </div>
+    <div id="touchable"><div id="glasspane"></div></div>
     <script>
     YUI({
         filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'min',
@@ -33,6 +32,19 @@
         }
     }).use('gesture-simulate-tests', 'test-console', function (Y) {
         new Y.Test.Console({render: '#log'});
+        
+        // The console collapse button disabled. If the button is pressed during
+        // the tests, the tests will produce invalid results. It affects the 
+        // coordination calculation. 
+        // 
+        // It appeared thete is no console property to disable the button. I 
+        // tried CSS display:none as well but it made the console widget UI 
+        // incorrect. So I ended up this way.  
+        var btn = Y.one(".yui3-console-collapse"),
+            parent = btn.get("parentNode");
+            parent.insertBefore("<div>Collapse Disabled</div>", btn);
+            btn.remove();
+        
         Y.Test.Runner.setName('Gesture Simulate');
         Y.Test.Runner.run();
     });


### PR DESCRIPTION
...ring the tests and cacluating the expected coordination in a range based on the relative top/left corner of the test area.

Tested Configuration:
- iOS: 5.0 
- Android:  2.2.3, 4.1.1 
- Mac: FF/Chrome/Safari
- Windows XP: IE8/Chrome

The changes are only for unit tests.
