### PR TITLE
Improve performance of Y.Attribute#getAttrs()

### DIFF
--- a/src/attribute/js/AttributeCore.js
+++ b/src/attribute/js/AttributeCore.js
@@ -699,7 +699,7 @@
 
                 if (!modifiedOnly || this._getStateVal(attr) != this._state.get(attr, INIT_VALUE)) {
                     // Go through get, to honor cloning/normalization
-                    obj[attr] = this._getAttr(attr);
+                    obj[attr] = this.get(attr);
                 }
             }
 


### PR DESCRIPTION
There was an unnecessary extra attribute retrieval per attribute, which caused a major performance hit. This change removes the unnecessary retrieval and adds a few other micro-optimizations.
### Running Locally

The built attribute modules are intentionally not included in order to keep the diffs clean. Before testing this change, you'll need to build them:

``` bash
$ cd src/attribute && ant all
```
