### PR TITLE
Update src/app/js/view.js

### DIFF
--- a/src/app/js/view.js
+++ b/src/app/js/view.js
@@ -253,7 +253,7 @@ Y.View = Y.extend(View, Y.Base, {
     **/
     detachEvents: function () {
         Y.Array.each(this._attachedViewEvents, function (handle) {
-            if ( handle ) {
+            if (handle) {
                 handle.detach();
             }
         });


### PR DESCRIPTION
If you have a view with events that do not match a method, thus failing to attach, a null entry is pushed on the _attachedViewEvents list.

This means that when it comes time to detach, (null).detach is called.

I'm playing around with a pattern with mixing in additional functionality, events may or may not be able to be handled.

The other option is to not push null events onto _attachedViewEvents, but this is more defensive (in case an event is removed some other fashion?)
