### PR TITLE
Fix #2532594. Save objectified data to config if initially a string.

### DIFF
--- a/src/io/js/io-base.js
+++ b/src/io/js/io-base.js
@@ -632,7 +632,7 @@ IO.prototype = {
             u = uri,
             response = {};
 
-        config = config ? Y.Object(config) : {};
+        config = Y.merge(config);
         transaction = io._create(config, id);
         method = config.method ? config.method.toUpperCase() : 'GET';
         sync = config.sync;


### PR DESCRIPTION
mention @ericf
