### PR TITLE
the main github page for yui3 has broken links to the Shifter repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Links
   * [Contributor Info](http://yuilibrary.com/contribute/)
   * [Report a Bug](http://yuilibrary.com/yui/docs/tutorials/report-bugs/)
   * [![Build Status](https://secure.travis-ci.org/yui/yui3.png?branch=master)](http://travis-ci.org/yui/yui3)
-  * [Shifter, for building YUI](http://yui.github.com/yui/shifter/)
+  * [Shifter, for building YUI](http://yui.github.com/shifter/)
 
 
 Source Info


### PR DESCRIPTION
Fixed 2 broken links to Shfiter (http://yui.github.com/shifter/ instead of http://yui.github.com/shifter - missing trailing slash).

Thanks,

DS
