### PR TITLE
Support for IE10 MSTransition prefix

### DIFF
--- a/src/transition/meta/transition-test.js
+++ b/src/transition/meta/transition-test.js
@@ -4,7 +4,7 @@ function (Y) {
         ret = true;
 
     if (node && node.style) {
-        ret = !('MozTransition' in node.style || 'WebkitTransition' in node.style);
+        ret = !('MozTransition' in node.style || 'WebkitTransition' in node.style || 'MSTransition' in node.style);
     } 
 
     return ret;


### PR DESCRIPTION
Added logic to use native CSS transition module if the MSTransition attribute exists.
