### PR TITLE
Add support for IE10 CSS transitions & events

### DIFF
--- a/src/transition/js/transition-native.js
+++ b/src/transition/js/transition-native.js
@@ -25,11 +25,13 @@ var CAMEL_VENDOR_PREFIX = '',
 
     VENDORS = [
         'Webkit',
-        'Moz'
+        'Moz',
+        'ms'
     ],
 
     VENDOR_TRANSITION_END = {
-        Webkit: 'webkitTransitionEnd'
+        Webkit: 'webkitTransitionEnd',
+        ms: 'MSTransitionEnd'
     },
 
 /**


### PR DESCRIPTION
Added MS prefix to set of supported vendors for Transition events. Added MSTransitionEnd event to list of transition end events.

Combine this with my earlier change to the meta/transtion-test.js file to use native CSS transitions in IE10.
