### PR TITLE
Fixed incorrect YUIDoc for 'step' attribute

### DIFF
--- a/src/node-flick/js/NodeFlick.js
+++ b/src/node-flick/js/NodeFlick.js
@@ -112,11 +112,11 @@
         },
 
         /**
-         * The constraining box relative to which the flick animation and bounds should be calculated.
+         * Time between flick animation frames.
          *
-         * @attribute boundingBox
-         * @type Node
-         * @default parentNode
+         * @attribute step
+         * @type Number
+         * @default 10
          */
         step : {
             value:10


### PR DESCRIPTION
The YUIDoc for the 'step' attribute had been copy/pasted from the 'boundingBox' attribute.
