### PR TITLE
Making sortable datatableheaders unselectable

### DIFF
--- a/src/datatable/assets/skins/night/datatable-sort-skin.css
+++ b/src/datatable/assets/skins/night/datatable-sort-skin.css
@@ -54,6 +54,12 @@
     position: relative;
     padding-right: 15px;
     position: relative;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .yui3-skin-night .yui3-datatable-sort-indicator {

--- a/src/datatable/assets/skins/sam/datatable-sort-skin.css
+++ b/src/datatable/assets/skins/sam/datatable-sort-skin.css
@@ -14,6 +14,12 @@
     position: relative;
     padding-right: 15px;
     position: relative;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .yui3-skin-sam .yui3-datatable-sort-indicator {

--- a/src/datatable/js/sort.js
+++ b/src/datatable/js/sort.js
@@ -224,7 +224,7 @@ Y.mix(Sortable.prototype, {
     @value '<div class="{className}" tabindex="0"><span class="{indicatorClass}"></span></div>'
     @since 3.5.0
     **/
-    SORTABLE_HEADER_TEMPLATE: '<div class="{className}" tabindex="0"><span class="{indicatorClass}"></span></div>',
+    SORTABLE_HEADER_TEMPLATE: '<div class="{className}" tabindex="0" unselectable="on"><span class="{indicatorClass}"></span></div>',
 
     /**
     Reverse the current sort direction of one or more fields currently being


### PR DESCRIPTION
By adding unselectable='on' to SORTABLE_HEADER_TEMPLATE
and changing the css of .yui3-skin-sam .yui3-datatable-sort-liner
