### PR TITLE
Removed IO call, and waitForIOResponse flag from async queue event tests

### DIFF
--- a/src/async-queue/tests/unit/assets/async-queue-tests.js
+++ b/src/async-queue/tests/unit/assets/async-queue-tests.js
@@ -674,15 +674,7 @@ suite.add(new Y.Test.Case({
                 {
                     fn: function () {
                         results.push("N");
-                        Y.io(Y.guid() + '.html', { // 404
-                            on : {
-                                failure : function () {
-                                    results.push("T");
-                                }
-                            }
-                        });
-                    },
-                    waitForIOResponse : true
+                    }
                 });
 
         q.on('execute',function () { results.push("(onExec)"); });


### PR DESCRIPTION
Looks like it wasn't doing anything with the flag or the call in the test,
and it was breaking when running in the Win 8 App env.

grep'd through code also and nothing under build seems to be doing anything
with the waitForIOResponse flag either.

Tests pass in Chrome/Gecko/IE10 and Win 8 App env.
