### PR TITLE
Give MatrixUtil a proper @class definition

### DIFF
--- a/src/matrix/js/MatrixUtil.js
+++ b/src/matrix/js/MatrixUtil.js
@@ -1,3 +1,10 @@
+/**
+ * Matrix utilities.
+ *
+ * @class MatrixUtil
+ * @module matrix
+ **/
+
 var MatrixUtil = {
         /**
          * Used as value for the _rounding method.


### PR DESCRIPTION
This is pretty important, since without it MatrixUtil's methods and properties seem to get attached to the docs for other classes where they don't belong.

For example, note the random MatrixUtil methods listed in the docs for Plugin.Flick: http://yuilibrary.com/yui/docs/api/classes/Plugin.Flick.html
