### PR TITLE
Normalize Transition durations to ms before updating the node's style.

### DIFF
--- a/src/transition/js/transition-native.js
+++ b/src/transition/js/transition-native.js
@@ -285,9 +285,9 @@ Transition.prototype = {
     },
 
     _prepDur: function(dur) {
-        dur = parseFloat(dur);
+        dur = parseFloat(dur) * 1000;
 
-        return dur + 's';
+        return dur + 'ms';
     },
 
     _runNative: function(time) {

--- a/src/transition/tests/transition.html
+++ b/src/transition/tests/transition.html
@@ -840,6 +840,53 @@ YUI({
         }));
 
         suite.add(new Y.Test.Case({
+            name: 'Transition Duration Tests',
+
+            'A 1ms `duration` should call the callback async': function() {
+                var node   = Y.one('.demo'),
+                    test   = this,
+                    called = 0;
+
+                node.transition({
+                    height  : 0,
+                    duration: 0.001
+                }, function (e) {
+                    test.resume(function () {
+                        called += 1;
+
+                        Y.Assert.areSame(1, called);
+                    });
+                });
+
+                Y.Assert.areSame(0, called);
+
+                test.wait(1000);
+            },
+
+            'A 0ms `duration` should call the callback async': function() {
+                var node   = Y.one('.demo'),
+                    test   = this,
+                    called = 0;
+
+                node.transition({
+                    height  : 0,
+                    duration: 0
+                }, function (e) {
+                    test.resume(function () {
+                        called += 1;
+
+                        Y.Assert.areSame(1, called);
+                    });
+                });
+
+                Y.Assert.areSame(0, called);
+
+                test.wait(1000);
+            }
+
+        }));
+
+        suite.add(new Y.Test.Case({
             name: 'toggleView Tests',
 
             'should force state with boolean first arg': function() {


### PR DESCRIPTION
Instead of relying on browsers to correctly round floating point numbers it is best to normalize down to ms so we can hopefully be using integers.

IE10 has an issue with durations under 10ms, when they are represented in seconds, i.e. `transition-duration: 0.001s`. Normalizing to ms fixed the issue in IE, and works across YUI's Target Environments.

@msweeney can you think of any reason why normalizing to milliseconds would be a problem?
