### PR TITLE
Update Widget.getSkinName() to allow multiple skin prefixes

### DIFF
--- a/src/widget/js/WidgetSkin.js
+++ b/src/widget/js/WidgetSkin.js
@@ -8,29 +8,32 @@
 var BOUNDING_BOX = "boundingBox",
     CONTENT_BOX = "contentBox",
     SKIN = "skin",
+    CLASS_NAME_PREFIX = 'classNamePrefix',
     CLASS_NAME_DELIMITER = 'classNameDelimiter',
-    CONFIG = Y.config,
-    _getClassName = Y.ClassNameManager.getClassName;
+    CONFIG = Y.config;
 
 /**
  * Returns the name of the skin that's currently applied to the widget.
  * This is only really useful after the widget's DOM structure is in the
- * document, either by render or by progressive enhancement.  Searches up
- * the Widget's ancestor axis for a class yui3-skin-(name) or
- * prefix-skin-(name) if prefix is supplied, and returns the
- * (name) portion.  Otherwise, returns null.
+ * document, either by render or by progressive enhancement.
+ *
+ * Searches up the Widget's ancestor axis for a class [prefix][delim]skin[delim]name
+ * and returns the <name> portion.  Otherwise, returns null.
  *
  * @method getSkinName
  * @for Widget
  * @param {String} prefix The prefix of the skin to look for (default is yui3)
+ * @param {String} delim  The delimiter of the skin to look for (default is -)
  * @return {String} the name of the skin, or null (yui3-skin-sam => sam)
  */
 
-Y.Widget.prototype.getSkinName = function (prefix) {
+Y.Widget.prototype.getSkinName = function (prefix, delimiter) {
     var root = this.get( CONTENT_BOX ) || this.get( BOUNDING_BOX ),
-        className = ( prefix )? _getClassName( prefix + CONFIG[CLASS_NAME_DELIMITER] + SKIN, true ) : _getClassName( SKIN ),
-        search = new RegExp( '\\b' + className + '-(\\S+)' ),
-        match;
+      sPrefix = prefix || CONFIG[CLASS_NAME_PREFIX],
+      sDelimiter = delimiter || CONFIG[CLASS_NAME_DELIMITER],
+      className = sPrefix + sDelimiter + SKIN + sDelimiter,
+      search = new RegExp( '\\b' + className + '(\\S+)' ),
+      match;
 
     if ( root ) {
         root.ancestor( function ( node ) {

--- a/src/widget/tests/unit/widget.html
+++ b/src/widget/tests/unit/widget.html
@@ -73,11 +73,11 @@
         }
     </style>
 </head>
-<body class="yui3-skin-sam wf2-skin-toad">
+<body class="yui3-skin-sam wf2-skin-toad wf3~skin~blue">
 
     <p><input type="button" value="Run Tests" id="btnRun" disabled="true"><span id="automationmsg" class="msg-hidden">Currently running tests, with logging disabled to speed up automation. Button will be enabled once complete.</span></p>
 
-    <div id="testbed" class="yui3-skin-foo wf2-skin-frog"></div>
+    <div id="testbed" class="yui3-skin-foo wf2-skin-frog wf3~skin~pink"></div>
 
     <div id="widgetRenderContainer" style="height:300px;width:300px"></div>
     <div id="customWidgetRenderContainer"></div>
@@ -1985,12 +1985,13 @@
 
                 Y.Assert.isNull( w.getSkinName() );
                 Y.Assert.isNull( w.getSkinName( 'wf2' ) );
+                Y.Assert.isNull( w.getSkinName( 'wf3', '~' ) );
 
                 w.destroy();
             },
 
             "getSkinName should return name from BB if available": function () {
-                var bb = Y.Node.create( '<div class="yui3-skin-foo wf2-skin-bar"><div></div></div>' ),
+                var bb = Y.Node.create( '<div class="yui3-skin-foo wf2-skin-bar wf3~skin~baz"><div></div></div>' ),
                     cb = bb.one( 'div' ),
                     w = new Y.Widget( {
                         boundingBox: bb,
@@ -1999,6 +2000,7 @@
 
                 Y.Assert.areEqual( "foo", w.getSkinName() );
                 Y.Assert.areEqual( "bar", w.getSkinName( 'wf2' ) );
+                Y.Assert.areEqual( "baz", w.getSkinName( 'wf3', '~' ) );
 
                 w.destroy();
             },
@@ -2009,15 +2011,19 @@
 
                 Y.Assert.areEqual( "sam", w.getSkinName() );
                 Y.Assert.areEqual( "toad", w.getSkinName( 'wf2' ) );
+                Y.Assert.areEqual( "blue", w.getSkinName( 'wf3', '~' ) );
 
                 body.removeClass( "yui3-skin-sam" );
                 body.removeClass( "wf2-skin-toad" );
+                body.removeClass( "wf3~skin~blue" );
 
                 Y.Assert.isNull( w.getSkinName() );
                 Y.Assert.isNull( w.getSkinName( 'wf2' ) );
+                Y.Assert.isNull( w.getSkinName( 'wf3', '~' ) );
 
                 body.addClass( "yui3-skin-sam" );
                 body.addClass( "wf2-skin-toad" );
+                body.addClass( "wf3~skin~blue" );
 
                 w.destroy();
             },
@@ -2028,9 +2034,11 @@
 
                 body.addClass( "yui3-skin-sam" );
                 body.addClass( "wf2-skin-toad" );
+                body.addClass( "wf3~skin~blue" );
 
                 Y.Assert.areEqual( "foo", w.getSkinName() );
                 Y.Assert.areEqual( "frog", w.getSkinName( 'wf2' ) );
+                Y.Assert.areEqual( "pink", w.getSkinName( 'wf3', '~' ) );
 
                 w.destroy();
             },
@@ -2038,7 +2046,6 @@
             "getSkinName should return null if prefix parameter contains invalid characters": function() {
                 var w = new Y.Widget().render();
 
-                // Y.Assert.isNull( w.getSkinName( /b.*S+/ ) );
                 w.getSkinName( "(\S+)" );
 
                 w.destroy();


### PR DESCRIPTION
WF uses YUI3 to build its own framework. We are using most of YUI3 widgets but we also need to have our developers working on custom WF widgets. And to make things clear, we need to prefix our widgets skin differently than the YUI ones.

For example, we could use yui3-skin-night on a page, but we may also need to have to that same page a custom WF widget with the skin wf2-skin-toad.

Since it's only possible to change the 'yui3' prefix globally with the configuration, we took the approach of extending the capability of getSkinName: if a prefix is given, the behavior is the same as before except that the search will be made on 'prefix-skin' instead of the default 'yui3-skin'. Of course, if no prefix is given, the default remains 'yui3-skin' which ensure backward compatibility with YUI3.

Let me know if that's something that has any interest to you guys!
Thanks a lot!
Arno
