### PR TITLE
Clarified possible return of null from node.one()

### DIFF
--- a/src/node/js/node-core.js
+++ b/src/node/js/node-core.js
@@ -613,11 +613,14 @@ Y.mix(Y_Node.prototype, {
     },
 
     /**
-     * Retrieves a Node instance of nodes based on the given CSS selector.
+     * Retrieves a single Node instance, the first element matching the given 
+     * CSS selector.
+     * Returns null if no match found.
      * @method one
      *
      * @param {string} selector The CSS selector to test against.
-     * @return {Node} A Node instance for the matching HTMLElement.
+     * @return {Node | null} A Node instance for the matching HTMLElement or null 
+     * if no match found.
      */
     one: function(selector) {
         return Y.one(Y.Selector.query(selector, this._node, true));


### PR DESCRIPTION
Documentation change to make it clear that null (not undefined) will be returned by calls to node.one() that do not have a successful match.
