### PR TITLE
Model validate docs lead to confusion

### DIFF
--- a/src/app/docs/model/index.mustache
+++ b/src/app/docs/model/index.mustache
@@ -701,6 +701,7 @@ Y.PieModel = Y.Base.create('pieModel', Y.Model, [], {
     switch (attributes.type) {
     case 'rhubarb':
       callback('Eww. No. Not allowed.');
+      return;
 
     case 'maple custard':
       slices = Y.Lang.isValue(attributes.slices) ?
@@ -710,6 +711,7 @@ Y.PieModel = Y.Base.create('pieModel', Y.Model, [], {
         callback("Making fewer than 10 slices of maple custard pie would be " +
             "silly, because I'm just going to eat 8 of them as soon as it's " +
             "out of the oven.");
+        return;
       }
     }
 


### PR DESCRIPTION
From the docs it seems that the callbacks return an error message from the `validate` method and only fall through to the empty `callback()` if everything is valid. This isn't true however, and both the `callback(..)` with the error message and the empty `callback()` will be reached. The `return` is also used in the API docs example: http://yuilibrary.com/yui/docs/api/classes/Model.html#method_validate
