### PR TITLE
callback arg missing from validate method

### DIFF
--- a/src/app/docs/model/index.mustache
+++ b/src/app/docs/model/index.mustache
@@ -695,7 +695,7 @@ To indicate success, call the provided `callback()` function with no arguments f
 Y.PieModel = Y.Base.create('pieModel', Y.Model, [], {
   // ... prototype methods and properties ...
 
-  validate: function (attributes) {
+  validate: function (attributes, callback) {
     var slices;
 
     switch (attributes.type) {


### PR DESCRIPTION
As pointed out by t_smith in IRC. http://yuilibrary.com/yui/docs/api/classes/Model.html#method_validate
