### PR TITLE
Remove hardcoded position:absolute in autocomplete-list

### DIFF
--- a/src/autocomplete/js/autocomplete-list.js
+++ b/src/autocomplete/js/autocomplete-list.js
@@ -148,12 +148,6 @@ List = Y.Base.create('autocompleteList', Y.Widget, [
             boundingBox.plug(Y.Plugin.Shim);
         }
 
-        // Force position: absolute on the boundingBox. This works around a
-        // potential CSS loading race condition in Gecko that can cause the
-        // boundingBox to become relatively positioned, which is all kinds of
-        // no good.
-        boundingBox.setStyle('position', 'absolute');
-
         this._ariaNode    = ariaNode;
         this._boundingBox = boundingBox;
         this._contentBox  = contentBox;


### PR DESCRIPTION
I removed the position:absolute call in autocomplete list. The original comment attached to it was:

> Force position: absolute on the boundingBox. This works around a potential CSS loading race condition in Gecko that can cause the boundingBox to become relatively positioned, which is all kinds of no good.

Dav's loader rewrite should have resolved all race conditions with css loading, especially when it comes to core YUI3 modules. On the other hand, leaving this line in makes it very difficult to code around if a developer wants to include autocomplete results inline rather than as a pseudo-select box.
