### PR TITLE
Fixes #2532955 - Touch events break when YUI.Charts are used

### DIFF
--- a/src/charts/js/ChartBase.js
+++ b/src/charts/js/ChartBase.js
@@ -611,7 +611,11 @@ ChartBase.prototype = {
                 Y.delegate("touchend", Y.bind(this._markerEventDispatcher, this), cb, markerClassName);
                 //hide active tooltip if the chart is touched
                 Y.on("touchend", Y.bind(function(e) {
-                    e.halt(true);
+                    //only halt the event if it originated from the chart
+                    if(cb.contains(e.target))
+                    {
+                        e.halt(true);
+                    }
                     if(this._activeMarker)
                     {
                         this._activeMarker = null;


### PR DESCRIPTION
"touchend" events were being captured and halted globally -- instead, only halt when the event originated from the chart

Original pull request: https://github.com/yui/yui3/pull/341
