### PR TITLE
Remove calendar's overpromising docs.

### DIFF
--- a/src/calendar/docs/index.mustache
+++ b/src/calendar/docs/index.mustache
@@ -336,7 +336,7 @@ allow it to be easily hidden, shown, and associated with other UI elements.</p>
 <ul class="spaced">
   <li>
     <p>
-    The calendar is currently not enabled with popup functionality: it will be released as a calendar plugin in 3.5
+    The calendar is currently not enabled with popup functionality.
     </p>
   </li>
 </ul>


### PR DESCRIPTION
Known issue: no popup functionality in calendar. Promised in 3.5.x, obviously this hasn't happened.
