### PR TITLE
Remove overpromising documentation.

### DIFF
--- a/src/calendar/docs/index.mustache
+++ b/src/calendar/docs/index.mustache
@@ -336,7 +336,7 @@ allow it to be easily hidden, shown, and associated with other UI elements.</p>
 <ul class="spaced">
   <li>
     <p>
-    The calendar is currently not enabled with popup functionality: it will be released as a calendar plugin in 3.5
+    The calendar is currently not enabled with popup functionality.
     </p>
   </li>
 </ul>


### PR DESCRIPTION
Clearly the calendar popup plugin hasn't been written yet. Best not to have documentation promising that it will be written some time ago.
