### PR TITLE
Add dropped file infomation to uploader drop event

### DIFF
--- a/src/uploader/js/uploader-html5.js
+++ b/src/uploader/js/uploader-html5.js
@@ -222,7 +222,13 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
         * Signals that an object has been dropped over the uploader's associated drag-and-drop area.
         *
         * @event drop
-        * @param event {Event} The event object for the `drop`.
+        * @param event {Event} The event object for the `drop` with the
+        *                      following payload:
+        *  <dl>
+        *      <dt>fileList</dt>
+        *          <dd>An `Array` of files dropped by the user, encapsulated
+        *              in Y.FileHTML5 objects.</dd>
+        *  </dl>
         */
         this.publish("drop");
 
@@ -381,7 +387,7 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
                         this.fire("fileselect", {fileList: parsedFiles});
                     }
 
-                    this.fire("drop");
+                    this.fire("drop", {fileList: parsedFiles});
                     break;
             }
         }


### PR DESCRIPTION
Currently YUI UploaderHTML5 provides attached file information along with "fileselect" event but doesn't provide the same information along with "drop" event. The change here is to expose fileList data in "drop" event so uploader client and differentiate between files selected from file dialog and dropped files.
