### PR TITLE
[WIP] Implement delegate change event for Internet Explorer < 9. Fixes #2531106

### DIFF
--- a/src/event/build.json
+++ b/src/event/build.json
@@ -79,6 +79,11 @@
             "jsfiles": [
                 "event-facade-dom-ie.js"
             ]
+        },
+        "event-delegate-change": {
+            "jsfiles": [
+                "event-delegate-change.js"
+            ]
         }
     }
 }

--- a/src/event/js/event-delegate-change.js
+++ b/src/event/js/event-delegate-change.js
@@ -1,0 +1,227 @@
+/**
+ * Adds event delegation change support to the library for Internet Explorer < 9
+ *
+ * @module event
+ * @submodule event-delegate-change
+ */
+
+var YObject = Y.Object,
+    YEvent = Y.Event,
+    YNode = Y.Node,
+    Selector = Y.Selector,
+
+    EVENT_BEFOREACTIVATE = 'beforeactivate',
+    EVENT_CHANGE = 'change';
+
+YEvent.define(
+    EVENT_CHANGE,
+    {
+        /**
+         * <p>Implementation logic for subscriptions done via <code>node.delegate(type, fn, filter)</code> or <code>Y.delegate(type, fn, container, filter)</code>.
+         *
+         * @method delegate
+         * @param node {Node} the node the subscription is being applied to
+         * @param subscription {Subscription} the object to track this subscription
+         * @param notifier {SyntheticEvent.Notifier} call notifier.fire(..) to trigger the execution of the subscribers
+         * @param filter {String|Function} Selector string or function that accepts an event object and returns null, a Node, or an array of Nodes matching the criteria for processing.
+         */
+        delegate: function (node, subscription, notifier, filter) {
+            this._attachEvents(node, subscription, notifier, filter);
+        },
+
+        /**
+         * Implementation logic for detaching subscriptions done via <code>node.on(type, fn)</code>.<br>
+         * This function cleans up any subscriptions made in the <code>on()</code> phase.
+         *
+         * @method detach
+         * @param node {Node} the node the subscription was applied to
+         * @param subscription {Subscription} the object tracking this subscription
+         * @param notifier {SyntheticEvent.Notifier} the Notifier used to trigger the execution of the subscribers
+         */
+        detach: function (node, subscription, notifier) {
+            this._detachEvents(node, subscription, notifier);
+        },
+
+        /**
+         * <p>Implementation logic for detaching subscriptions done via <code>node.delegate(type, fn, filter)</code> or
+         * <code>Y.delegate(type, fn, container, filter)</code>. <br>
+         * This function cleans up any subscriptions made in the <code>delegate()</code> phase.</p>
+         *
+         * @method detachDelegate
+         * @param node {Node} the node the subscription was applied to
+         * @param subscription {Subscription} the object tracking this subscription
+         * @param notifier {SyntheticEvent.Notifier} the Notifier used to trigger the execution of the subscribers
+         * @param filter {String|Function} Selector string or function that accepts an event object and returns null, a Node, or an array of Nodes matching the criteria for processing.
+         */
+        detachDelegate: function (node, subscription, notifier) {
+            this._detachEvents(node, subscription, notifier);
+        },
+
+        /**
+         * Implementation logic for subscriptions done via <code>node.on(type, fn)</code> or <code>Y.on(type, fn, target)</code>. <br>
+         *
+         * @method on
+         * @param node {Node} the node the subscription is being applied to
+         * @param subscription {Subscription} the object to track this subscription
+         * @param notifier {SyntheticEvent.Notifier} call notifier.fire(..) to trigger the execution of the subscribers
+         */
+        on: function (node, subscription, notifier) {
+            this._attachEvent(node, subscription, notifier);
+        },
+
+        /**
+         * Attaches one of "change" or "click" events to the supplied node and invokes the registered listeners on triggering the event
+         *
+         * @method _attachEvent
+         * @private
+         * @param node {Y.Node} The node to which events will be attached
+         * @param subscription {Subscription} The object tracking this subscription
+         * @param notifier {SyntheticEvent.Notifier} The triggering mechanism used by SyntheticEvents
+         * @param delegateNode {Y.Node} The node, on which the event has been delegated
+         * @param filter {String | Function} Selector string or function that accepts an event object and returns null, a Node, or an array of Nodes matching the criteria for processing.
+         */
+        _attachEvent: function(node, subscription, notifier, delegateNode, filter) {
+            var handles = this._prepareHandles(subscription, node),
+                type = this._getEventName(node),
+                self = this;
+
+            var fireFn = function(event) {
+                var result = true;
+
+                if (filter) {
+                    if (!event.stopped) {
+                        var delegateEl = YNode.getDOMNode(delegateNode);
+
+                        var tmpEl = YNode.getDOMNode(node);
+
+                        do {
+                            if (tmpEl && Selector.test(tmpEl, filter)) {
+                                event.currentTarget = Y.one(tmpEl);
+                                event.container = node;
+
+                                result = notifier.fire(event);
+                            }
+
+                            tmpEl = tmpEl.parentNode;
+                        }
+                        while (result !== false && !event.stopped && tmpEl && tmpEl !== delegateEl);
+
+                        result = ((result !== false) && (event.stopped !== 2));
+                    }
+                }
+                else {
+                    if (!event._stoppedWithFalse && notifier.fire(event) === false) {
+                        event._stoppedWithFalse = true;
+                    }
+                }
+
+                return result;
+            };
+
+            if (!YObject.owns(handles, type)) {
+                handles[type] = YEvent._attach([type, fireFn, node, notifier]);
+            }
+        },
+
+        /**
+         * Attaches "beforeactivate" event to the node and then one of "change" or "click" events
+         *
+         * @method _attachEvents
+         * @private
+         * @param node {Y.Node} The node to which events will be attached
+         * @param subscription {Subscription} The object tracking this subscription
+         * @param notifier {SyntheticEvent.Notifier} The triggering mechanism used by SyntheticEvents
+         * @param filter {String | Function} Selector string or function that accepts an event object and returns null, a Node, or an array of Nodes matching the criteria for processing.
+         */
+        _attachEvents: function(node, subscription, notifier, filter) {
+            var handles = this._prepareHandles(subscription, node),
+                self = this;
+
+            handles[EVENT_BEFOREACTIVATE] = node.delegate(
+                EVENT_BEFOREACTIVATE,
+                function(event) {
+                    var activeElement = event.target;
+
+                    self._attachEvent(activeElement, subscription, notifier, node, filter);
+                },
+                filter
+            );
+        },
+
+        /**
+         * Detaches all the nodes, registered to the supplied subscription
+         *
+         * @method _detachEvents
+         * @private
+         * @param node {Y.Node} The node the subscription was applied to
+         * @param subscription {Subscription} The object tracking this subscription
+         * @param notifier {SyntheticEvent.Notifier} The triggering mechanism used by SyntheticEvents
+         */
+        _detachEvents: function(node, subscription, notifier) {
+            Y.each(
+                subscription._handles,
+                function(events) {
+                    Y.each(
+                        events,
+                        function(handle, event) {
+                            handle.detach();
+                        }
+                    );
+                }
+            );
+
+            delete subscription._handles;
+        },
+
+        /**
+         * Retrieves the name of the native event which should be attached.
+         * For input elements of type "checkbox" and "radio", the event will be "click".
+         * For any others it will be "change"
+         *
+         * @method _getEventName
+         * @private
+         * @param activeElement {Y.Node} The element to check for the event
+         * @return {String} The name of the event
+         */
+        _getEventName: Y.cached(
+            function(activeElement) {
+                var eventName = EVENT_CHANGE,
+                    tagName = activeElement.get('tagName').toLowerCase(),
+                    type = activeElement.get('type').toLowerCase();
+
+                if (tagName === 'input' && (type === 'checkbox' || type === 'radio')) {
+                    eventName = 'click';
+                }
+
+                return eventName;
+            }
+        ),
+
+        /**
+         * Creates _handles property to the subscription if not exists.
+         * Creates an empty object in _handles property which belongs to the node, passed as argument
+         *
+         * @method _prepareHandles
+         * @private
+         * @param subscription {Function} The callback function
+         * @param node {Y.Node} The node for which the handles will be registered
+         * @return {Object} The value of the created handle object for the passed node
+         */
+        _prepareHandles: function(subscription, node) {
+            var handles;
+
+            if (!YObject.owns(subscription, '_handles')) {
+                subscription._handles = {};
+            }
+
+            handles = subscription._handles;
+
+            if (!YObject.owns(handles, node)) {
+                handles[node] = {};
+            }
+
+            return handles[node];
+        }
+    },
+    true
+);

--- a/src/event/meta/event.json
+++ b/src/event/meta/event.json
@@ -104,6 +104,19 @@
                    "trigger": "node-base",
                    "test": "ie-base-test.js"
                 }
+            },
+            "event-delegate-change": {
+                "requires": [
+                    "node-event-delegate",
+                    "event-synthetic"
+                ],
+                "after": [
+                    "event-base"
+                ],
+                "condition": {
+                    "trigger": "event-base-ie",
+                    "ua": "ie"
+                }
             }
         }
     }

--- a/src/event/tests/manual/event-delegate-change.html
+++ b/src/event/tests/manual/event-delegate-change.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <title>Delegate Change Events</title>
+        
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+        <script src="../../../../build/yui/yui.js"></script>
+
+    </head>
+
+    <body class="yui3-skin-sam">
+
+        <div id="mainWrapper">
+            <p>Normal select, will not prevent any listeners</p>
+            <select>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+            </select>
+
+            <p>Checkbox, will stop propagation</p>
+            <input type="checkbox" id="checkboxStopPropagation" />
+
+            <p>Checkbox, will stop immediate propagation</p>
+            <input type="checkbox" id="checkboxStopImmediatePropagation" />
+
+            <p>Normal input, will not prevent any listeners</p>
+            <input type="text" class="node-text" />
+
+            <p>Normal radio, will not prevent any listeners</p>
+            <input checked type="radio" name="group1" class="node-radio" />
+            <input type="radio" name="group1" class="node-radio" />
+            <input type="radio" name="group1" class="node-radio" />
+            <input type="radio" name="group1" class="node-radio" />
+
+            <p>Normal checkbox, will not prevent any listeners</p>
+            <input type="checkbox" class="node-checkbox" />
+
+            <p>Checkbox, will halt the event</p>
+            <input type="checkbox" class="node-checkbox" id="haltEventCheckbox" />
+
+            <p>Checkbox, the listener returns false</p>
+            <input type="checkbox" class="node-checkbox" id="returnFalseCheckbox" />
+
+            <div>
+                <p>Detach all listeners</p>
+                <button id="detachListeners">Detach</button>
+            </div>
+
+        </div>
+
+        <script>
+            var Y  = YUI();
+
+            YUI({filter:'raw', combine:false}).use('array-invoke', 'console', 'node-base', 'event-base', function(Y) {
+                new Y.Console().render();
+
+                var handles = [
+                    Y.delegate(
+                        'change',
+                        function() {
+                            Y.log('change event to input or select is fired..');
+                        },
+                        document.body,
+                        'input, select'
+                    ),
+
+                    Y.delegate(
+                        'change',
+                        function() {
+                            Y.log('Attached to a div - change event to input or select is fired..');
+                        },
+                        '#mainWrapper',
+                        'input, select'
+                    ),
+
+                    Y.one('#checkboxStopPropagation').on(
+                        'change',
+                        function(event) {
+                            Y.log('change event to checkbox is fired, stopping propagation');
+
+                            event.stopPropagation();
+                        }
+                    ),
+
+                    Y.one('#checkboxStopPropagation').on(
+                        'change',
+                        function(event) {
+                            Y.log('change event 2 to checkbox is fired..');
+                        }
+                    ),
+
+                    Y.one('#checkboxStopImmediatePropagation').on(
+                        'change',
+                        function(event) {
+                            Y.log('change event to checkbox is fired, stopping immediate propagation');
+
+                            event.stopImmediatePropagation();
+                        }
+                    ),
+
+                    Y.one('#checkboxStopImmediatePropagation').on(
+                        'change',
+                        function(event) {
+                            Y.log('change event to checkbox is fired, this should never log');
+                        }
+                    ),
+
+                    Y.one('#haltEventCheckbox').on(
+                        'change',
+                        function(event) {
+                            Y.log('Change event to checkbox is fired, halting the events. The second event listener to this checkbox should not execute.');
+
+                            event.halt(true);
+                        }
+                    ),
+
+                    Y.one('#haltEventCheckbox').on(
+                        'change',
+                        function(event) {
+                            Y.log('Second change event to checkbox, halting the events, this should never log');
+                        }
+                    ),
+
+                    Y.one('#returnFalseCheckbox').on(
+                        'change',
+                        function(event) {
+                            Y.log('Change event to checkbox, returning false. The second event listener to this checkbox should not execute.');
+
+                            return false;
+                        }
+                    ),
+
+                    Y.one('#returnFalseCheckbox').on(
+                        'change',
+                        function(event) {
+                            Y.log('Second change event to checkbox, returning false, this should never log');
+                        }
+                    )
+                ];
+
+                Y.one('#detachListeners').once('click', function(events) {
+                    Y.Array.invoke(handles, 'detach');
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/src/event/tests/unit/assets/event-delegate-change-tests.js
+++ b/src/event/tests/unit/assets/event-delegate-change-tests.js
@@ -1,0 +1,132 @@
+YUI.add('event-delegate-change-tests', function(Y) {
+    var suite = new Y.Test.Suite('Event: event-delegate-change'),
+        Assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'event-delegate-change',
+
+        setUp: function() {
+            var self = this;
+
+            this._fireResultStopPropagation = 0;
+
+            this._fireResultStopImmediatePropagation = 0;
+
+            this._fireResultBody = 0;
+
+            this._fireResultDIV = 0;
+
+            this._handles = [
+                Y.delegate(
+                    'change',
+                    function() {
+                        ++self._fireResultBody;
+                    },
+                    document.body,
+                    'input, select'
+                ),
+
+                Y.delegate(
+                    'change',
+                    function() {
+                        ++self._fireResultDIV;
+                    },
+                    '#mainWrapper',
+                    'input, select'
+                ),
+
+                Y.one('#checkboxStopPropagation').on(
+                    'change',
+                    function(event) {
+                        ++self._fireResultStopPropagation;
+
+                        event.stopPropagation();
+                    }
+                ),
+
+                Y.one('#checkboxStopPropagation').on(
+                    'change',
+                    function(event) {
+                        ++self._fireResultStopPropagation;
+                    }
+                ),
+
+                Y.one('#checkboxStopImmediatePropagation').on(
+                    'change',
+                    function(event) {
+                        ++self._fireResultStopImmediatePropagation;
+
+                        event.stopImmediatePropagation();
+                    }
+                ),
+
+                Y.one('#checkboxStopImmediatePropagation').on(
+                    'change',
+                    function(event) {
+                        ++self._fireResultStopImmediatePropagation;
+                    }
+                )
+            ];
+        },
+        
+        tearDown: function() {
+            this._fireResultStopPropagation = 0;
+
+            this._fireResultStopImmediatePropagation = 0;
+
+            this._fireResultBody = 0;
+
+            this._fireResultDIV = 0;
+
+            Y.Array.invoke(this._handles, 'detach');
+
+            this._handles.length = 0;
+        },
+
+        test_stop_propagation: function() {
+            Y.Event.simulate(document.getElementById('checkboxStopPropagation'), 'click');
+
+            Assert.isTrue(this._fireResultStopPropagation === 2);
+
+            Assert.isTrue(this._fireResultStopImmediatePropagation === 0);
+
+            Assert.isTrue(this._fireResultBody === 0);
+
+            Assert.isTrue(this._fireResultDIV === 0);
+        },
+
+        test_stop_immediate_propagation: function() {
+            Y.Event.simulate(document.getElementById('checkboxStopImmediatePropagation'), 'click');
+
+            Assert.isTrue(this._fireResultStopPropagation === 0);
+
+            Assert.isTrue(this._fireResultStopImmediatePropagation === 1);
+
+            Assert.isTrue(this._fireResultBody === 0);
+
+            Assert.isTrue(this._fireResultDIV === 0);
+        }
+
+        /**
+         * FIXME: This test fails, simulate 'click' does not bubble 'change' event in any browser
+         */
+        
+        /*
+        ,
+        test_normal_event_handling: function() {
+            Y.Event.simulate(document.getElementById('checkboxNormal'), 'click');
+
+            Assert.isTrue(this._fireResultStopPropagation === 0);
+
+            Assert.isTrue(this._fireResultStopImmediatePropagation === 0);
+
+            Assert.isTrue(this._fireResultBody === 1);
+
+            Assert.isTrue(this._fireResultDIV === 1);
+        }
+        */
+    }));
+
+    Y.Test.Runner.add(suite);
+
+});

--- a/src/event/tests/unit/event-delegate-change.html
+++ b/src/event/tests/unit/event-delegate-change.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+    <title>Event Delegate Change Tests</title>
+</head>
+<body class="yui3-skin-sam">
+
+    <div id="mainWrapper">
+        <p>Normal select, will not prevent any listeners</p>
+        <select id="selectElement">
+            <option>1</option>
+            <option>2</option>
+            <option>3</option>
+        </select>
+
+        <p>Checkbox, will stop propagation</p>
+        <input type="checkbox" id="checkboxStopPropagation" />
+
+        <p>Checkbox, will stop immediate propagation</p>
+        <input type="checkbox" id="checkboxStopImmediatePropagation" />
+
+        <p>Normal input, will not prevent any listeners</p>
+        <input type="text" class="node-text" />
+
+        <p>Normal radio, will not prevent any listeners</p>
+        <input checked type="radio" name="group1" class="node-radio" />
+        <input type="radio" name="group1" class="node-radio" />
+        <input type="radio" name="group1" class="node-radio" />
+        <input type="radio" name="group1" class="node-radio" />
+
+        <p>Normal checkbox, will not prevent any listeners</p>
+        <input id="checkboxNormal" type="checkbox" class="node-checkbox" />
+
+    </div>
+
+    <script type="text/javascript" src="../../../../build/yui/yui.js"></script>
+
+    <script>
+        YUI({
+            coverage: ['event-delegate-change'],
+            filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+            modules: {
+                'event-delegate-change-tests': {
+                    fullpath: './assets/event-delegate-change-tests.js',
+                    requires: [ 'array-invoke', 'event-delegate-change', 'test-console', 'test' ]
+                }
+            }
+        }).use('event-delegate-change-tests', function(Y) {
+            new Y.Test.Console().render();
+
+            Y.Test.Runner.setName('Event: event-delegate-change');
+
+            Y.Test.Runner.run();
+        });
+    </script>
+</body>
+</html>

--- a/src/loader/build.json
+++ b/src/loader/build.json
@@ -9,7 +9,7 @@
     "builds": {
         "loader-base": {
             "replace": {
-                "@GALLERY@": "gallery-2012.12.12-21-11",
+                "@GALLERY@": "gallery-2012.12.19-21-23",
                 "@TNT@": "4",
                 "@YUI2@": "2.9.0"
             },

--- a/src/loader/js/yui3.js
+++ b/src/loader/js/yui3.js
@@ -1316,6 +1316,20 @@ YUI.Env[Y.version].modules = YUI.Env[Y.version].modules || {
             "node-base"
         ]
     },
+    "event-delegate-change": {
+        "after": [
+            "event-base"
+        ],
+        "condition": {
+            "name": "event-delegate-change",
+            "trigger": "event-base-ie",
+            "ua": "ie"
+        },
+        "requires": [
+            "node-event-delegate",
+            "event-synthetic"
+        ]
+    },
     "event-flick": {
         "requires": [
             "node-base",
@@ -2561,4 +2575,4 @@ YUI.Env[Y.version].modules = YUI.Env[Y.version].modules || {
         ]
     }
 };
-YUI.Env[Y.version].md5 = 'd050a2294f84d3996bb46f592448f782';
+YUI.Env[Y.version].md5 = '299273b49e0bb93f3c00fbb04fcaa513';

--- a/src/loader/js/yui3.json
+++ b/src/loader/js/yui3.json
@@ -1259,6 +1259,20 @@
             "node-base"
         ]
     },
+    "event-delegate-change": {
+        "after": [
+            "event-base"
+        ],
+        "condition": {
+            "name": "event-delegate-change",
+            "trigger": "event-base-ie",
+            "ua": "ie"
+        },
+        "requires": [
+            "node-event-delegate",
+            "event-synthetic"
+        ]
+    },
     "event-flick": {
         "requires": [
             "node-base",

--- a/src/loader/tests/cli/loader.js
+++ b/src/loader/tests/cli/loader.js
@@ -1735,6 +1735,16 @@ suite.add(new YUITest.TestCase({
             //Testing A normal module
             Assert.isTrue((loader.sorted.indexOf("event-delegate")) > -1, "Module (event-delegate) not found in sorted array");
         },
+     "Testing event-delegate-change": function(data) {
+            var loader = new Y.Loader({
+                require: ["event-delegate-change"],
+                ignoreRegistered: true,
+                allowRollup: false
+            });
+            loader.calculate();
+            //Testing A normal module
+            Assert.isTrue((loader.sorted.indexOf("event-delegate-change")) > -1, "Module (event-delegate-change) not found in sorted array");
+        },
      "Testing event-flick": function(data) {
             var loader = new Y.Loader({
                 require: ["event-flick"],

--- a/src/simpleyui/js/concat.js
+++ b/src/simpleyui/js/concat.js
@@ -5430,8 +5430,14 @@ add('load', '5', {
 },
     "trigger": "node-base"
 });
-// graphics-canvas
+// event-delegate-change
 add('load', '6', {
+    "name": "event-delegate-change",
+    "trigger": "event-base-ie",
+    "ua": "ie"
+});
+// graphics-canvas
+add('load', '7', {
     "name": "graphics-canvas",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -5443,7 +5449,7 @@ add('load', '6', {
     "trigger": "graphics"
 });
 // graphics-canvas-default
-add('load', '7', {
+add('load', '8', {
     "name": "graphics-canvas-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -5455,7 +5461,7 @@ add('load', '7', {
     "trigger": "graphics"
 });
 // graphics-svg
-add('load', '8', {
+add('load', '9', {
     "name": "graphics-svg",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -5468,7 +5474,7 @@ add('load', '8', {
     "trigger": "graphics"
 });
 // graphics-svg-default
-add('load', '9', {
+add('load', '10', {
     "name": "graphics-svg-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -5481,7 +5487,7 @@ add('load', '9', {
     "trigger": "graphics"
 });
 // graphics-vml
-add('load', '10', {
+add('load', '11', {
     "name": "graphics-vml",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -5491,7 +5497,7 @@ add('load', '10', {
     "trigger": "graphics"
 });
 // graphics-vml-default
-add('load', '11', {
+add('load', '12', {
     "name": "graphics-vml-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -5501,7 +5507,7 @@ add('load', '11', {
     "trigger": "graphics"
 });
 // history-hash-ie
-add('load', '12', {
+add('load', '13', {
     "name": "history-hash-ie",
     "test": function (Y) {
     var docMode = Y.config.doc && Y.config.doc.documentMode;
@@ -5512,19 +5518,19 @@ add('load', '12', {
     "trigger": "history-hash"
 });
 // io-nodejs
-add('load', '13', {
+add('load', '14', {
     "name": "io-nodejs",
     "trigger": "io-base",
     "ua": "nodejs"
 });
 // scrollview-base-ie
-add('load', '14', {
+add('load', '15', {
     "name": "scrollview-base-ie",
     "trigger": "scrollview-base",
     "ua": "ie"
 });
 // selector-css2
-add('load', '15', {
+add('load', '16', {
     "name": "selector-css2",
     "test": function (Y) {
     var DOCUMENT = Y.config.doc,
@@ -5535,7 +5541,7 @@ add('load', '15', {
     "trigger": "selector"
 });
 // transition-timer
-add('load', '16', {
+add('load', '17', {
     "name": "transition-timer",
     "test": function (Y) {
     var DOCUMENT = Y.config.doc,
@@ -5551,20 +5557,20 @@ add('load', '16', {
     "trigger": "transition"
 });
 // widget-base-ie
-add('load', '17', {
+add('load', '18', {
     "name": "widget-base-ie",
     "trigger": "widget-base",
     "ua": "ie"
 });
 // yql-nodejs
-add('load', '18', {
+add('load', '19', {
     "name": "yql-nodejs",
     "trigger": "yql",
     "ua": "nodejs",
     "when": "after"
 });
 // yql-winjs
-add('load', '19', {
+add('load', '20', {
     "name": "yql-winjs",
     "trigger": "yql",
     "ua": "winjs",
@@ -6453,8 +6459,14 @@ add('load', '5', {
 },
     "trigger": "node-base"
 });
-// graphics-canvas
+// event-delegate-change
 add('load', '6', {
+    "name": "event-delegate-change",
+    "trigger": "event-base-ie",
+    "ua": "ie"
+});
+// graphics-canvas
+add('load', '7', {
     "name": "graphics-canvas",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -6466,7 +6478,7 @@ add('load', '6', {
     "trigger": "graphics"
 });
 // graphics-canvas-default
-add('load', '7', {
+add('load', '8', {
     "name": "graphics-canvas-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -6478,7 +6490,7 @@ add('load', '7', {
     "trigger": "graphics"
 });
 // graphics-svg
-add('load', '8', {
+add('load', '9', {
     "name": "graphics-svg",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -6491,7 +6503,7 @@ add('load', '8', {
     "trigger": "graphics"
 });
 // graphics-svg-default
-add('load', '9', {
+add('load', '10', {
     "name": "graphics-svg-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -6504,7 +6516,7 @@ add('load', '9', {
     "trigger": "graphics"
 });
 // graphics-vml
-add('load', '10', {
+add('load', '11', {
     "name": "graphics-vml",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -6514,7 +6526,7 @@ add('load', '10', {
     "trigger": "graphics"
 });
 // graphics-vml-default
-add('load', '11', {
+add('load', '12', {
     "name": "graphics-vml-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -6524,7 +6536,7 @@ add('load', '11', {
     "trigger": "graphics"
 });
 // history-hash-ie
-add('load', '12', {
+add('load', '13', {
     "name": "history-hash-ie",
     "test": function (Y) {
     var docMode = Y.config.doc && Y.config.doc.documentMode;
@@ -6535,19 +6547,19 @@ add('load', '12', {
     "trigger": "history-hash"
 });
 // io-nodejs
-add('load', '13', {
+add('load', '14', {
     "name": "io-nodejs",
     "trigger": "io-base",
     "ua": "nodejs"
 });
 // scrollview-base-ie
-add('load', '14', {
+add('load', '15', {
     "name": "scrollview-base-ie",
     "trigger": "scrollview-base",
     "ua": "ie"
 });
 // selector-css2
-add('load', '15', {
+add('load', '16', {
     "name": "selector-css2",
     "test": function (Y) {
     var DOCUMENT = Y.config.doc,
@@ -6558,7 +6570,7 @@ add('load', '15', {
     "trigger": "selector"
 });
 // transition-timer
-add('load', '16', {
+add('load', '17', {
     "name": "transition-timer",
     "test": function (Y) {
     var DOCUMENT = Y.config.doc,
@@ -6574,20 +6586,20 @@ add('load', '16', {
     "trigger": "transition"
 });
 // widget-base-ie
-add('load', '17', {
+add('load', '18', {
     "name": "widget-base-ie",
     "trigger": "widget-base",
     "ua": "ie"
 });
 // yql-nodejs
-add('load', '18', {
+add('load', '19', {
     "name": "yql-nodejs",
     "trigger": "yql",
     "ua": "nodejs",
     "when": "after"
 });
 // yql-winjs
-add('load', '19', {
+add('load', '20', {
     "name": "yql-winjs",
     "trigger": "yql",
     "ua": "winjs",

--- a/src/yui/js/load-tests.js
+++ b/src/yui/js/load-tests.js
@@ -87,8 +87,14 @@ add('load', '5', {
 },
     "trigger": "node-base"
 });
-// graphics-canvas
+// event-delegate-change
 add('load', '6', {
+    "name": "event-delegate-change",
+    "trigger": "event-base-ie",
+    "ua": "ie"
+});
+// graphics-canvas
+add('load', '7', {
     "name": "graphics-canvas",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -100,7 +106,7 @@ add('load', '6', {
     "trigger": "graphics"
 });
 // graphics-canvas-default
-add('load', '7', {
+add('load', '8', {
     "name": "graphics-canvas-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -112,7 +118,7 @@ add('load', '7', {
     "trigger": "graphics"
 });
 // graphics-svg
-add('load', '8', {
+add('load', '9', {
     "name": "graphics-svg",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -125,7 +131,7 @@ add('load', '8', {
     "trigger": "graphics"
 });
 // graphics-svg-default
-add('load', '9', {
+add('load', '10', {
     "name": "graphics-svg-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -138,7 +144,7 @@ add('load', '9', {
     "trigger": "graphics"
 });
 // graphics-vml
-add('load', '10', {
+add('load', '11', {
     "name": "graphics-vml",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -148,7 +154,7 @@ add('load', '10', {
     "trigger": "graphics"
 });
 // graphics-vml-default
-add('load', '11', {
+add('load', '12', {
     "name": "graphics-vml-default",
     "test": function(Y) {
     var DOCUMENT = Y.config.doc,
@@ -158,7 +164,7 @@ add('load', '11', {
     "trigger": "graphics"
 });
 // history-hash-ie
-add('load', '12', {
+add('load', '13', {
     "name": "history-hash-ie",
     "test": function (Y) {
     var docMode = Y.config.doc && Y.config.doc.documentMode;
@@ -169,19 +175,19 @@ add('load', '12', {
     "trigger": "history-hash"
 });
 // io-nodejs
-add('load', '13', {
+add('load', '14', {
     "name": "io-nodejs",
     "trigger": "io-base",
     "ua": "nodejs"
 });
 // scrollview-base-ie
-add('load', '14', {
+add('load', '15', {
     "name": "scrollview-base-ie",
     "trigger": "scrollview-base",
     "ua": "ie"
 });
 // selector-css2
-add('load', '15', {
+add('load', '16', {
     "name": "selector-css2",
     "test": function (Y) {
     var DOCUMENT = Y.config.doc,
@@ -192,7 +198,7 @@ add('load', '15', {
     "trigger": "selector"
 });
 // transition-timer
-add('load', '16', {
+add('load', '17', {
     "name": "transition-timer",
     "test": function (Y) {
     var DOCUMENT = Y.config.doc,
@@ -208,20 +214,20 @@ add('load', '16', {
     "trigger": "transition"
 });
 // widget-base-ie
-add('load', '17', {
+add('load', '18', {
     "name": "widget-base-ie",
     "trigger": "widget-base",
     "ua": "ie"
 });
 // yql-nodejs
-add('load', '18', {
+add('load', '19', {
     "name": "yql-nodejs",
     "trigger": "yql",
     "ua": "nodejs",
     "when": "after"
 });
 // yql-winjs
-add('load', '19', {
+add('load', '20', {
     "name": "yql-winjs",
     "trigger": "yql",
     "ua": "winjs",


### PR DESCRIPTION
Here is a commit to fix #2531106.

This is only the source, no build files were added. shifter --walk in src will do the trick but it adds too much noise. Is there a better way to build only event module and update the loader info in the same time?

Thanks,
