### PR TITLE
invoke contentready once View is attached to DOM

### DIFF
--- a/src/app/js/app-base.js
+++ b/src/app/js/app-base.js
@@ -794,6 +794,9 @@ AppBase = Y.Base.create('app', Y.Base, [View, Router, PjaxBase], {
         if (callback) {
             callback.call(this, newView);
         }
+        if (Y.Lang.isFunction(newView.contentready)) {
+            newView.contentready.call(newView);
+        }
     },
 
     // -- Protected Event Handlers ---------------------------------------------


### PR DESCRIPTION
Several of YUI widgets require invoking widget.render() method to paint the widget, widget.render() will not work if HTML markup is not available

Purposed path invokes contentready method in class View once HTML took place and ready, allowing developers to use widget.render() at right moment
