### PR TITLE
fixes #2533048 - chart axis majorUnit "distance"

### DIFF
--- a/src/charts/js/AxisType.js
+++ b/src/charts/js/AxisType.js
@@ -320,7 +320,7 @@ Y.AxisType = Y.Base.create("baseAxis", Y.Axis, [], {
     {
         var units,
             majorUnit = this.get("styles").majorUnit,
-            len = this.get("length");
+            len = this.getLength();
         if(majorUnit.determinant === "count")
         {
             units = majorUnit.count;


### PR DESCRIPTION
majorUnit type "distance" was not working due because it was using an invalid attribute "length" - the fix is to call the parent class getLength function
