### PR TITLE
Fix #2530500

### DIFF
--- a/src/charts/js/Axis.js
+++ b/src/charts/js/Axis.js
@@ -1149,7 +1149,11 @@ Y.Axis = Y.Base.create("axis", Y.Widget, [Y.AxisBase], {
         var dist;
         if(majorUnit.determinant === "count")
         {
-            dist = uiLen/(len - 1);
+            if(!this.get("calculateEdgeOffset")) 
+            {
+                len = len - 1;
+            }
+            dist = uiLen/len;
         }
         else if(majorUnit.determinant === "distance")
         {

--- a/src/charts/js/AxisBase.js
+++ b/src/charts/js/AxisBase.js
@@ -273,7 +273,13 @@ Y.AxisBase = Y.Base.create("axisBase", Y.Base, [Y.Renderer], {
      */
     getEdgeOffset: function(ct, l)
     {
-        return 0;
+        var edgeOffset;
+        if(this.get("calculateEdgeOffset")) {
+            edgeOffset = l/ct;
+        } else {
+            edgeOffset = 0;
+        }
+        return edgeOffset;
     },
 
     /**
@@ -402,6 +408,16 @@ Y.AxisBase = Y.Base.create("axisBase", Y.Base, [Y.Renderer], {
     }
 }, {
     ATTRS: {
+        /**
+         * Determines whether and offset is automatically calculated for the edges of the axis.
+         *
+         * @attr calculateEdgeOffset
+         * @type Boolean
+         */
+        calculateEdgeOffset: {
+            value: false
+        },
+        
         labelFunction: {
             valueFn: function() {
                 return this.formatLabel;

--- a/src/charts/js/CartesianChart.js
+++ b/src/charts/js/CartesianChart.js
@@ -551,6 +551,7 @@ Y.CartesianChart = Y.Base.create("cartesianChart", Y.Widget, [Y.ChartBase], {
             axes = {},
             axesAttrs = {
                 edgeOffset: "edgeOffset",
+                calculateEdgeOffset: "calculateEdgeOffset",
                 position: "position",
                 overlapGraph:"overlapGraph",
                 labelFunction:"labelFunction",

--- a/src/charts/js/CategoryAxis.js
+++ b/src/charts/js/CategoryAxis.js
@@ -16,29 +16,6 @@
  */
 Y.CategoryAxis = Y.Base.create("categoryAxis", Y.Axis, [Y.CategoryImpl], {
     /**
-     * Returns the distance between major units on an axis.
-     *
-     * @method getMajorUnitDistance
-     * @param {Number} len Number of ticks
-     * @param {Number} uiLen Size of the axis.
-     * @param {Object} majorUnit Hash of properties used to determine the majorUnit
-     * @return Number
-     */
-    getMajorUnitDistance: function(len, uiLen, majorUnit)
-    {
-        var dist;
-        if(majorUnit.determinant === "count")
-        {
-            dist = uiLen/len;
-        }
-        else if(majorUnit.determinant === "distance")
-        {
-            dist = majorUnit.distance;
-        }
-        return dist;
-    },
-
-    /**
      * Returns a string corresponding to the first label on an
      * axis.
      *

--- a/src/charts/js/CategoryImpl.js
+++ b/src/charts/js/CategoryImpl.js
@@ -24,6 +24,16 @@ CategoryImpl.NAME = "categoryImpl";
 
 CategoryImpl.ATTRS = {
     /**
+     * Determines whether and offset is automatically calculated for the edges of the axis.
+     *
+     * @attr calculateEdgeOffset
+     * @type Boolean
+     */
+    calculateEdgeOffset: {
+        value: true
+    }
+        
+    /**
      * Method used for formatting a label. This attribute allows for the default label formatting method to overridden.
      * The method use would need to implement the arguments below and return a `String` or `HTMLElement`.
      * <dl>
@@ -150,20 +160,6 @@ CategoryImpl.prototype = {
     getTotalMajorUnits: function(majorUnit, len)
     {
         return this.get("data").length;
-    },
-
-    /**
-     * Gets the distance that the first and last ticks are offset from there respective
-     * edges.
-     *
-     * @method getEdgeOffset
-     * @param {Number} ct Number of ticks on the axis.
-     * @param {Number} l Length (in pixels) of the axis.
-     * @return Number
-     */
-    getEdgeOffset: function(ct, l)
-    {
-        return l/ct;
     },
 
     /**


### PR DESCRIPTION
This pull request allows TimeAxis to render with calculated offsets for either edge like a CategoryAxis. Conversely, the CategoryAxis can now render without offsets. I created an attribute calculateEdgeOffset which defaults to true for CategoryAxis and false for all other axes. If set to true, the axis will calculate edge offsets. 

I plan to merge this next week sometime after the latest release.
