### PR TITLE
Focusmanagerfix

### DIFF
--- a/src/node-focusmanager/js/node-focusmanager.js
+++ b/src/node-focusmanager/js/node-focusmanager.js
@@ -475,7 +475,7 @@ Y.extend(NodeFocusManager, Y.Plugin.Base, {
 			sNodeName = oTarget.get("nodeName").toLowerCase();
 
 		if (event.keyCode === 13 && (!clickableElements[sNodeName] ||
-				(sNodeName === "a" && !oTarget.getAttribute("href"))) && this._isDescendant(event.target)) {
+				(sNodeName === "a" && !oTarget.getAttribute("href"))) && this._isDescendant(oTarget)) {
 
 			Y.log(("Firing click event for node:" + oTarget.get("id")), "info", "nodeFocusManager");
 


### PR DESCRIPTION
When using two FocusManager instances on nested nodes, the outer instance fires simulated click events on the inner node too, resulting in two simulated click fired on the inner nodes when the enter keypress event occurs. Now we check if the keypress event target is one of the instance descendants before simulating the click event.
