### PR TITLE
Remove unnecessary semicolon in TabView CSS

### DIFF
--- a/src/tabview/assets/tabview.css
+++ b/src/tabview/assets/tabview.css
@@ -19,4 +19,4 @@
     display: inline-block;
     margin-right: 0.5em;
     zoom: 1;
-};
+}


### PR DESCRIPTION
There was a stray semicolon at the end of TabView's CSS for some reason. It broke things. I removed it. Yay!
