### PR TITLE
scrollview-scrollbars causes js error in IE7 when contentSize = widgetSize

### DIFF
--- a/src/scrollview/js/scrollbars-plugin.js
+++ b/src/scrollview/js/scrollbars-plugin.js
@@ -327,6 +327,8 @@ Y.namespace("Plugin").ScrollViewScrollbars = Y.extend(ScrollbarsPlugin, Y.Plugin
         } else if (scrollbarPos < 0) {
             scrollbarSize = scrollbarPos + scrollbarSize;
             scrollbarPos = 0;
+        } else if (isNaN(scrollbarPos)) {
+            scrollbarPos = 0;
         }
 
         middleChildSize = (scrollbarSize - (firstChildSize + lastChildSize));


### PR DESCRIPTION
Here is a special case. When we create a scrollView like this:

var SC = new Y.ScrollView({axis: 'y', render: true});

And, sometimes the content size is same as scrollView size......then,
this cause javascript error in IE7 . we traced the code found scrollview-scrollbars try
to setStyle top to 'NaNpx' . Later a suggested patch will be attached.
