### PR TITLE
fix documentation typo in SVGDrawing.drawRoundRect

### DIFF
--- a/src/graphics/js/SVGDrawing.js
+++ b/src/graphics/js/SVGDrawing.js
@@ -284,7 +284,7 @@ SVGDrawing.prototype = {
     /**
      * Draws a rectangle with rounded corners.
      *
-     * @method drawRect
+     * @method drawRoundRect
      * @param {Number} x x-coordinate
      * @param {Number} y y-coordinate
      * @param {Number} w width


### PR DESCRIPTION
Fix typo in SVGDrawing.drawRoundRect documentation.
