### PR TITLE
Correct name for the Widget render event

### DIFF
--- a/src/widget/js/Widget.js
+++ b/src/widget/js/Widget.js
@@ -550,7 +550,7 @@ Y.extend(Widget, Y.Base, {
               * after rendering is complete.
               * </p>
               *
-              * @event widget:render
+              * @event render
               * @preventable _defRenderFn
               * @param {EventFacade} e The Event Facade
               */


### PR DESCRIPTION
This is an old documentation bug. The Widget "render" event is documented as `widget:render` instead of just `render`.
