### PR TITLE
Mouse events do not participate in gestures on touch-enabled devices

### DIFF
--- a/src/event/js/event-facade-dom-touch.js
+++ b/src/event/js/event-facade-dom-touch.js
@@ -137,10 +137,10 @@ if (Y.Node.DOM_EVENTS) {
 
 //Add properties to Y.EVENT.GESTURE_MAP based on feature detection.
 if ((win && ("ontouchstart" in win)) && !(Y.UA.chrome && Y.UA.chrome < 6)) {
-    GESTURE_MAP.start = "touchstart";
-    GESTURE_MAP.end = "touchend";
-    GESTURE_MAP.move = "touchmove";
-    GESTURE_MAP.cancel = "touchcancel";
+    GESTURE_MAP.start = ["touchstart", "mousedown"];
+    GESTURE_MAP.end = ["touchend", "mouseup"];
+    GESTURE_MAP.move = ["touchmove", "mousemove"];
+    GESTURE_MAP.cancel = ["touchcancel", "mousecancel"];
 }
 
 


### PR DESCRIPTION
Some devices (like Windows 8 PCs) are touch enabled... but they also have a mouse! The result of only listening to touch events when feature detecting is that drag and drop for these devices seems broken using mouse.

The patch seems to correct the issue and not break anything. The PR is mostly to make you aware of the issue.

<!---
@huboard:{"order":662.5}
-->
