### PR TITLE
Added @deprecated tags to menunav and focusmanager

### DIFF
--- a/src/node-focusmanager/docs/component.json
+++ b/src/node-focusmanager/docs/component.json
@@ -5,7 +5,7 @@
     "author"     : "drgath",
 
     "tags": [
-        "utility", "node", "plugin", "focus", "keyboard", "navigation", "beta"
+        "utility", "node", "plugin", "focus", "keyboard", "navigation", "beta", "deprecated"
     ],
 
     "use": ["node-focusmanager"],

--- a/src/node-focusmanager/js/node-focusmanager.js
+++ b/src/node-focusmanager/js/node-focusmanager.js
@@ -27,6 +27,7 @@
 * </p>
 *
 * @module node-focusmanager
+* @deprecated
 */
 
 	//	Frequently used strings

--- a/src/node-menunav/docs/component.json
+++ b/src/node-menunav/docs/component.json
@@ -4,7 +4,7 @@
     "description": "Easily transform a list into an accessible and customizable drop-down menu.",
     "author"     : "drgath",
 
-    "tags": ["widget", "plugin", "beta", "menu", "menunav", "node", "dropdown"],
+    "tags": ["widget", "plugin", "beta", "menu", "menunav", "node", "dropdown", "deprecated"],
     "use" : ["node-menunav"],
 
     "examples": [

--- a/src/node-menunav/js/node-menunav.js
+++ b/src/node-menunav/js/node-menunav.js
@@ -77,6 +77,7 @@
 * </p>
 * 
 * @module node-menunav
+* @deprecated
 */
 
 


### PR DESCRIPTION
As voted on in [this yui-contrib thread](https://groups.google.com/forum/?fromgroups=#!topic/yui-contrib/I28zUGYPBoA), `node-menunav` and `node-focusmanager` are now deprecated.

Reviewers, please let me know if there are any additional steps required to officially deprecate a component.
### TODOs
- [ ] `@deprecated` details w/ version number.
- [ ] Updates to component user guides adding info about deprecation.
- [ ] Blog post forecasting deprecation.
- [ ] Log warns when using APIs.
- [ ] Update HISTORY.md files.
