### PR TITLE
Fix #2533139 - Color tests failing in older IE's

### DIFF
--- a/src/color/js/color-base.js
+++ b/src/color/js/color-base.js
@@ -181,7 +181,8 @@ Y.Color = {
         // parse with regex and return "matches" array
         var type = Y.Color.findType(str).toUpperCase(),
             regex,
-            arr;
+            arr,
+            lastItem;
 
         if (type === 'HEX' && str.length < 5) {
             type = 'HEX3';
@@ -196,8 +197,8 @@ Y.Color = {
 
             if (arr.length) {
                 arr.shift();
-
-                if (typeof arr[arr.length - 1] === 'undefined') {
+                lastItem = arr[arr.length - 1];
+                if (typeof lastItem === 'undefined' || lastItem === '') {
                     arr[arr.length - 1] = 1;
                 }
             }


### PR DESCRIPTION
regex.exec() was returning values of (empty String) instead of undefined in IE.

This fix corrects some failing tests in older IE's where they appear to be returning an empty string instead of `undefined`.

http://yuilibrary.com/projects/yui3/ticket/2533139

_updated by @davglass_
