### PR TITLE
Apply CSS Grid changes for Chome 25 to App Transitions

### DIFF
--- a/src/app/HISTORY.md
+++ b/src/app/HISTORY.md
@@ -4,7 +4,10 @@ App Framework Change History
 3.9.0
 -----
 
-* No changes.
+### App
+
+* Applied the same changes from CSS Grids to App Transitions to support changes
+  in how Chrome 25 renders `word-spacing`.
 
 
 3.8.1

--- a/src/app/css/app-transitions.css
+++ b/src/app/css/app-transitions.css
@@ -4,16 +4,26 @@
     position: relative;
     white-space: nowrap;
     letter-spacing: -0.31em; /* webkit: collapse white-space between units */
-    word-spacing: -0.43em; /* IE < 8 && gecko: collapse white-space between units */
+    text-rendering: optimizespeed; /* Webkit: fixes text-rendering: optimizeLegibility */
+}
+/* Opera as of 12 on Windows needs word-spacing.
+   The ".opera-only" selector is used to prevent actual prefocus styling
+   and is not required in markup.
+*/
+.opera-only :-o-prefocus,
+.yui3-app-transitioning .yui3-app-views,
+.yui3-app-views.yui3-app-transitioning {
+    word-spacing: -0.43em;
 }
 .yui3-app-transitioning .yui3-app-views > *,
 .yui3-app-views.yui3-app-transitioning > * {
     display: inline-block;
-    width: 100%;
-    vertical-align: top;
-    white-space: normal;
     letter-spacing: normal;
     word-spacing: normal;
+    vertical-align: top;
+    text-rendering: auto;
+    width: 100%;
+    white-space: normal;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;


### PR DESCRIPTION
**Note:** App Transitions only targets modern browsers that support native CSS3 transitions. This is why the IE rules are not included.
