### PR TITLE
Fixes 'not win8 app' test for IE6/7

### DIFF
--- a/src/yui/tests/unit/assets/ua-tests.js
+++ b/src/yui/tests/unit/assets/ua-tests.js
@@ -63,7 +63,12 @@ YUI.add('ua-tests', function(Y) {
         },
         tearDown: function() {
             if (window && window.Windows && window.Windows.YUI) {
-                delete window.Windows;
+                try {
+                    delete window.Windows;
+                } catch (e) {
+                    // For IE6, IE7
+                    window.Windows = undefined;
+                }
             }
         },
         'test: win8 app': function() {


### PR DESCRIPTION
IE6/7 was barfing deleting the mock `window.Windows` object we set up
for the prior 'win8 app' test, resulting in 'Unexpected event error'
in the log, and since the `window.Windows` mock object stuck around,
'not win8 app' returned true, instead of false in IE6/7.

Tested in IE6, 7, 8, 9 and regression tested in FF, Safari, Chrome
