### PR TITLE
JSON - update meta files to load shims for android 2.3.4

### DIFF
--- a/src/json/meta/parse-native-test.js
+++ b/src/json/meta/parse-native-test.js
@@ -12,6 +12,7 @@ function (Y) {
     if ( nativeSupport ) {
         try {
             nativeSupport = ( Native.parse( '{"ok":false}', workingNative ) ).ok;
+            nativeSupport = ( null === Native.parse(null) );
         }
         catch ( e ) {
             nativeSupport = false;

--- a/src/json/meta/stringify-native-test.js
+++ b/src/json/meta/stringify-native-test.js
@@ -8,6 +8,7 @@ function (Y) {
     if ( nativeSupport ) {
         try {
             nativeSupport = ( '0' === Native.stringify(0) );
+            nativeSupport = ( '[{}]' === Native.stringify([/some regex/]) );
         } catch ( e ) {
             nativeSupport = false;
         }


### PR DESCRIPTION
Potential fix for trac2533148. The main point of this is to capture work done while debugging.

I added new tests to the json parse and stringify meta files. Used tests that were actually failing. There may be better tests to use. 

This fix resolves all issues with parse and stringify with android 2.3.4. It has been tested in ie 6, 7, 8, 9, 10 (both 10s)
latest: ff, safari, chrome and opera
android 4.1.1
android 2.3.4

All tests pass and the shims are only loaded for ie 6, 7 and android 2.3.4.

Ultimately, the shim will need to load for stringify in android 2.3.4.
An alternate solution for the parse failures would be to add the sugar back into the parse method. Something like the below:
    if(typeof arguments[0] !== 'string') {
        arguments[0] = arguments[0] + '';
    }
