### PR TITLE
JSON - potential fix for trac2533149

### DIFF
--- a/src/json/js/parse.js
+++ b/src/json/js/parse.js
@@ -1,8 +1,5 @@
 var _JSON = Y.config.global.JSON;
 
-Y.namespace('JSON').parse = function () {
-    if(typeof arguments[0] !== 'string') {
-        arguments[0] = arguments[0] + '';
-    }
-    return _JSON.parse.apply(_JSON, arguments);
+Y.namespace('JSON').parse = function (obj, reviver, space) {
+    return _JSON.parse((typeof obj === 'string' ? obj : obj + ''), reviver, space);
 };


### PR DESCRIPTION
This pull request ensures the string passed to json.parse is of type string. The logic was taken from earlier iterations of the module. This, or something similar, could be used to fix #2533149. This fix would make the parse meta changes from https://github.com/yui/yui3/pull/495 unnecessary. This fix does not address issues with stringify in android 2.3.4.

This has been tested in ie 6, 7, 8, 9, 10 (both 10s)
latest: ff, safari, chrome and opera
android 4.1.1
android 2.3.4 (still fails for 2 stringify tests)
