### PR TITLE
Fix #497

### DIFF
--- a/src/datatable/js/mutable.js
+++ b/src/datatable/js/mutable.js
@@ -377,10 +377,10 @@ Y.mix(Mutable.prototype, {
         if (model && isObject(data)) {
             args = toArray(arguments, 1, true);
 
-            model.setAttrs.apply(model, args);
+            model.setAttrs(args);
 
             if (sync && !model.isNew()) {
-                model.save.apply(model, args);
+                model.save(args);
             }
         }
 


### PR DESCRIPTION
Datatable override its model's `name` attribute with model's name with calling `modifyRow`
