### PR TITLE
Fix Scrollview-Paginator tests that were breaking on IE10

### DIFF
--- a/src/scrollview/tests/unit/scrollview-paginator-unit-test.html
+++ b/src/scrollview/tests/unit/scrollview-paginator-unit-test.html
@@ -236,26 +236,23 @@
 
                 "Move x should advance 1 page right": function() {
 
-
                     var Test = this,
                         scrollview = renderNewScrollview('x');
-
-                    scrollview.once('scrollEnd', function(){
-                        Test.resume(function(){
-                            Y.Assert.areEqual(1, scrollview.pages.get('index'));
-                            Y.Assert.areEqual(0, scrollview.get('scrollY'));
-                            Y.Assert.areEqual(300, scrollview.get('scrollX'));
-                        })
-                    });
 
                     scrollview.get('contentBox').simulateGesture('move', {
                         path: {
                             xdist: -500
                         },
                         duration: DURATION
+                    }, function () {
+                        Y.later(WAIT, null, function(){
+                            Y.Assert.areEqual(1, scrollview.pages.get('index'));
+                            Y.Assert.areEqual(0, scrollview.get('scrollY'));
+                            Y.Assert.areEqual(300, scrollview.get('scrollX'));
+                        });
                     });
 
-                    Test.wait(WAIT);
+                    
                 },
 
 
@@ -267,22 +264,20 @@
                         scrollview = renderNewScrollview('x'),
                         distance = 100;
                         
-                    scrollview.once('scrollEnd', function(){
-                        Test.resume(function(){
-                            Y.Assert.areEqual(0, scrollview.pages.get('index'));
-                            Y.Assert.areEqual(0, scrollview.get('scrollY'));
-                            Y.Assert.areEqual(0, scrollview.get('scrollX'));
-                        })
-                    });
-
                     scrollview.get('contentBox').simulateGesture('move', {
                         path: {
                             xdist: distance
                         },
                         duration: SLOW_DURATION
+                    }, function () {
+                        Y.later(LONG_WAIT, null, function(){
+                            Y.Assert.areEqual(0, scrollview.pages.get('index'));
+                            Y.Assert.areEqual(0, scrollview.get('scrollY'));
+                            Y.Assert.areEqual(0, scrollview.get('scrollX'));
+                        });
                     });
 
-                    Test.wait(LONG_WAIT);
+                    
                 },
 
                 "optimizeMemory should hide nodes not near the viewport": function() {
@@ -389,17 +384,14 @@
 
                     scrollview.set('disabled', true);
 
-                    Y.later('100', null, function(){
-                        Test.resume(function(){
+                    scrollview.get('contentBox').simulateGesture('move', {
+                        path: {
+                            xdist: -500
+                        },
+                        duration: DURATION
+                    }, function () {
+                        Y.later(LONG_WAIT, null, function() {
                             scrollview.set('disabled', false);
-
-                            scrollview.once('scrollEnd', function(){
-                                Test.resume(function(){
-                                    Y.Assert.areEqual(1, scrollview.pages.get('index'));
-                                    Y.Assert.areEqual(0, scrollview.get('scrollY'));
-                                    Y.Assert.areEqual(300, scrollview.get('scrollX'));
-                                })
-                            });
 
                             Y.Assert.areEqual(0, scrollview.pages.get('index'));
                             Y.Assert.areEqual(0, scrollview.get('scrollY'));
@@ -410,20 +402,18 @@
                                     xdist: -500
                                 },
                                 duration: DURATION
-                            });
+                            }, function () {
+                                Y.later(WAIT, null, function() {
+                                    Y.Assert.areEqual(1, scrollview.pages.get('index'));
+                                    Y.Assert.areEqual(0, scrollview.get('scrollY'));
+                                    Y.Assert.areEqual(300, scrollview.get('scrollX'));
+                                });
+                            }); 
+                        });
 
-                            Test.wait(WAIT);
-                        })
                     });
 
-                    scrollview.get('contentBox').simulateGesture('move', {
-                        path: {
-                            xdist: -500
-                        },
-                        duration: DURATION
-                    });
-
-                    Test.wait(WAIT);
+                    
                 }
 
                 /*


### PR DESCRIPTION
These tests work on IE6-10, FF, Chrome, iOS6 but have not been tested on Android2.3 and 4.x yet.

```
Move x should advance 1 page right: failed.
Timeout: wait() called but resume() never called.

Move left on X should snap back: failed.
Timeout: wait() called but resume() never called.

Disabled scrollviews should not advance page index on flick: failed.
Timeout: wait() called but resume() never called.
```

I got around them by passing in callbacks to the `simulateGesture()` method, instead of calling `wait()` and `resume()`. 

These tests have all passed in IE6-10, Chrome, FF, Safari, iOS6.1, but I don't have an Android device so I couldn't test it on 2.3 and 4.x. If you do have one, you can hit [this localtunnel URL](http://44mv.localtunnel.com/yui3/src/scrollview/tests/unit/scrollview-paginator-unit-test.html) and help me test it. Thanks!
