### PR TITLE
Added ignore exceptions for a few ScrollView Paginator unit tests

### DIFF
--- a/src/scrollview/tests/unit/scrollview-paginator-unit-test.html
+++ b/src/scrollview/tests/unit/scrollview-paginator-unit-test.html
@@ -65,10 +65,10 @@
                 _should: {
                     ignore: {
                         // Ignore PhantomJS because of lack of gesture simulation support/issues
-                        "Move x should advance 1 page right": (Y.UA.phantomjs),
-                        "Move left on X should snap back": (Y.UA.phantomjs),
-                        "optimizeMemory should hide nodes not near the viewport" : (Y.UA.phantomjs || Y.UA.ie),
-                        "Disabled scrollviews should not advance page index on flick" : (Y.UA.phantomjs),
+                        "Move x should advance 1 page right": (Y.UA.phantomjs || (Y.UA.ie >= 10)),
+                        "Move left on X should snap back": (Y.UA.phantomjs || (Y.UA.ie >= 10)),
+                        "optimizeMemory should hide nodes not near the viewport" : (Y.UA.phantomjs || (Y.UA.ie >= 9)),
+                        "Disabled scrollviews should not advance page index on flick" : (Y.UA.phantomjs || (Y.UA.ie >= 10)),
 
                         // TODO: Fix for IE (#2533100)
                         "Dual axis should allow scrolling on both X & Y axes" : (Y.UA.ie),


### PR DESCRIPTION
Submitting this on behalf of @derek:

The failing tests in IE10 are a known issue and require a deeper look into gesture-simulate (I don't have the bandwidth to do that between now at the 3.9.0 release). Since the manual tests work, @derek suggested that we pull in this commit until these issues can be looked into. 

I think it's important to look into the root issue here, so hopefully we'll be able to take out these ignores soon..
