### PR TITLE
Y.Tree: Add a `src` option to all methods that trigger events.

### DIFF
--- a/src/tree/HISTORY.md
+++ b/src/tree/HISTORY.md
@@ -1,6 +1,15 @@
 Tree Change History
 ===================
 
+@VERSION@
+-----
+
+* Added a `src` option to all methods that trigger events. This value is passed
+  along to the event facade of the resulting event, and can be used to
+  distinguish between changes caused by different sources (such as
+  user-initiated changes vs. programmatic changes). [Ryan Grove]
+
+
 3.9.0
 -----
 

--- a/src/tree/js/extensions/tree-node-openable.js
+++ b/src/tree/js/extensions/tree-node-openable.js
@@ -22,6 +22,10 @@ NodeOpenable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `close` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     close: function (options) {
@@ -48,6 +52,10 @@ NodeOpenable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `open` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     open: function (options) {
@@ -63,6 +71,10 @@ NodeOpenable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, events will be
             suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     toggleOpen: function (options) {

--- a/src/tree/js/extensions/tree-node-selectable.js
+++ b/src/tree/js/extensions/tree-node-selectable.js
@@ -33,6 +33,10 @@ NodeSelectable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `select` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     select: function (options) {
@@ -47,6 +51,10 @@ NodeSelectable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `unselect` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     unselect: function (options) {

--- a/src/tree/js/extensions/tree-openable.js
+++ b/src/tree/js/extensions/tree-openable.js
@@ -21,6 +21,7 @@ Fired when a node is closed.
 
 @event close
 @param {Tree.Node} node Node being closed.
+@param {String} src Source of the event.
 @preventable _defCloseFn
 **/
 var EVT_CLOSE = 'close';
@@ -30,6 +31,7 @@ Fired when a node is opened.
 
 @event open
 @param {Tree.Node} node Node being opened.
+@param {String} src Source of the event.
 @preventable _defOpenFn
 **/
 var EVT_OPEN = 'open';
@@ -51,11 +53,18 @@ Openable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `close` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     closeNode: function (node, options) {
         if (node.canHaveChildren && node.isOpen()) {
-            this._fireTreeEvent(EVT_CLOSE, {node: node}, {
+            this._fireTreeEvent(EVT_CLOSE, {
+                node: node,
+                src : options && options.src
+            }, {
                 defaultFn: this._defCloseFn,
                 silent   : options && options.silent
             });
@@ -71,11 +80,18 @@ Openable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `open` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     openNode: function (node, options) {
         if (node.canHaveChildren && !node.isOpen()) {
-            this._fireTreeEvent(EVT_OPEN, {node: node}, {
+            this._fireTreeEvent(EVT_OPEN, {
+                node: node,
+                src : options && options.src
+            }, {
                 defaultFn: this._defOpenFn,
                 silent   : options && options.silent
             });
@@ -93,6 +109,10 @@ Openable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, events will be
             suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     toggleOpenNode: function (node, options) {

--- a/src/tree/js/extensions/tree-selectable.js
+++ b/src/tree/js/extensions/tree-selectable.js
@@ -90,6 +90,10 @@ Selectable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `select` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     selectNode: function (node, options) {
@@ -98,7 +102,10 @@ Selectable.prototype = {
         // in cases such as a node being added to this tree with its selected
         // state already set to true.
         if (!this._selectedMap[node.id]) {
-            this._fireTreeEvent(EVT_SELECT, {node: node}, {
+            this._fireTreeEvent(EVT_SELECT, {
+                node: node,
+                src : options && options.src
+            }, {
                 defaultFn: this._defSelectFn,
                 silent   : options && options.silent
             });
@@ -114,6 +121,10 @@ Selectable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `unselect` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     unselect: function (options) {
@@ -134,11 +145,18 @@ Selectable.prototype = {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `unselect` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     unselectNode: function (node, options) {
         if (node.isSelected() || this._selectedMap[node.id]) {
-            this._fireTreeEvent(EVT_UNSELECT, {node: node}, {
+            this._fireTreeEvent(EVT_UNSELECT, {
+                node: node,
+                src : options && options.src
+            }, {
                 defaultFn: this._defUnselectFn,
                 silent   : options && options.silent
             });

--- a/src/tree/js/tree-node.js
+++ b/src/tree/js/tree-node.js
@@ -203,6 +203,10 @@ TreeNode.prototype = {
             and means they can't be reused.
         @param {Boolean} [options.silent=false] If `true`, `remove` events will
             be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @return {Tree.Node[]} Array of removed child nodes.
     **/
     empty: function (options) {
@@ -272,6 +276,10 @@ TreeNode.prototype = {
             parent.
         @param {Boolean} [options.silent=false] If `true`, the `add` event will
             be suppressed.
+        @param {String} [options.src='insert'] Source of the change, to be
+            passed along to the event facade of the resulting event. This can be
+            used to distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
 
     @return {Tree.Node[]} Node or array of nodes that were inserted.
     **/
@@ -364,6 +372,10 @@ TreeNode.prototype = {
             garbage collection and means they can't be reused.
         @param {Boolean} [options.silent=false] If `true`, the `remove` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     remove: function (options) {

--- a/src/tree/js/tree.js
+++ b/src/tree/js/tree.js
@@ -56,6 +56,7 @@ var Lang = Y.Lang,
     @event clear
     @param {Tree.Node} rootNode New root node of this tree (the old root node is
         always destroyed when a tree is cleared).
+    @param {String} src Source of the event.
     @preventable _defClearFn
     **/
     EVT_CLEAR = 'clear',
@@ -68,6 +69,7 @@ var Lang = Y.Lang,
         being removed from this tree.
     @param {Tree.Node} node Node being removed.
     @param {Tree.Node} parent Parent node from which the node will be removed.
+    @param {String} src Source of the event.
     @preventable _defRemoveFn
     **/
     EVT_REMOVE = 'remove';
@@ -237,11 +239,16 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, the `clear` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     clear: function (rootNode, options) {
         return this._fireTreeEvent(EVT_CLEAR, {
-            rootNode: this.createNode(rootNode || this._rootNodeConfig)
+            rootNode: this.createNode(rootNode || this._rootNodeConfig),
+            src     : options && options.src
         }, {
             defaultFn: this._defClearFn,
             silent   : options && options.silent
@@ -295,6 +302,10 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
     @param {Object} [options] Options.
         @param {Boolean} [options.silent=false] If `true`, `remove` events will
             be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting events. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @chainable
     **/
     destroyNode: function (node, options) {
@@ -342,6 +353,10 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
             and means they can't be reused.
         @param {Boolean} [options.silent=false] If `true`, `remove` events will
             be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting events. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @return {Tree.Node[]} Array of removed child nodes.
     **/
     emptyNode: function (node, options) {
@@ -386,6 +401,10 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
             parent.
         @param {Boolean} [options.silent=false] If `true`, the `add` event will
             be suppressed.
+        @param {String} [options.src='insert'] Source of the change, to be
+            passed along to the event facade of the resulting event. This can be
+            used to distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
 
     @return {Tree.Node[]} Node or array of nodes that were inserted.
     **/
@@ -478,6 +497,10 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
             garbage collection and means they can't be reused.
         @param {Boolean} [options.silent=false] If `true`, the `remove` event
             will be suppressed.
+        @param {String} [options.src] Source of the change, to be passed along
+            to the event facade of the resulting event. This can be used to
+            distinguish between changes triggered by a user and changes
+            triggered programmatically, for example.
     @return {Tree.Node} Node that was removed.
     **/
     removeNode: function (node, options) {

--- a/src/tree/tests/unit/assets/tree-openable-test.js
+++ b/src/tree/tests/unit/assets/tree-openable-test.js
@@ -145,6 +145,21 @@ suite.add(new Y.Test.Case({
         this.tree.closeNode(node);
     },
 
+    'closeNode() should pass along a custom `src`': function () {
+        var node = this.tree.children[0],
+            fired;
+
+        this.tree.openNode(node);
+
+        this.tree.once('close', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.closeNode(node, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
+    },
+
     'openNode() should fire an `open` event': function () {
         var node = this.tree.children[0],
             fired;
@@ -197,6 +212,21 @@ suite.add(new Y.Test.Case({
         this.tree.openNode(node);
     },
 
+    'openNode() should pass along a custom `src`': function () {
+        var node = this.tree.children[0],
+            fired;
+
+        this.tree.closeNode(node);
+
+        this.tree.once('open', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.openNode(node, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
+    },
+
     'toggleOpenNode() should not fire any events if options.silent is truthy': function () {
         var node = this.tree.children[0];
 
@@ -210,6 +240,19 @@ suite.add(new Y.Test.Case({
 
         this.tree.toggleOpenNode(node, {silent: true});
         this.tree.toggleOpenNode(node, {silent: true});
+    },
+
+    'toggleOpenNode() should pass along a custom `src`': function () {
+        var node = this.tree.children[0],
+            fired;
+
+        this.tree.once('open', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.toggleOpenNode(node, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
     },
 
     '`close` event should be preventable': function () {

--- a/src/tree/tests/unit/assets/tree-selectable-test.js
+++ b/src/tree/tests/unit/assets/tree-selectable-test.js
@@ -198,6 +198,19 @@ suite.add(new Y.Test.Case({
         this.tree.selectNode(node, {silent: true});
     },
 
+    'selectNode() should pass along a `src`': function () {
+        var node = this.tree.children[0],
+            fired;
+
+        this.tree.once('select', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.selectNode(node, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
+    },
+
     'unselectNode() should fire an `unselect` event': function () {
         var node = this.tree.children[0],
             fired;
@@ -233,6 +246,21 @@ suite.add(new Y.Test.Case({
         });
 
         this.tree.unselectNode(node, {silent: true});
+    },
+
+    'unselectNode() should pass along a `src`': function () {
+        var node = this.tree.children[0],
+            fired;
+
+        this.tree.selectNode(node);
+
+        this.tree.once('unselect', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.unselectNode(node, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
     },
 
     '`select` event should be preventable': function () {

--- a/src/tree/tests/unit/assets/tree-test.js
+++ b/src/tree/tests/unit/assets/tree-test.js
@@ -573,6 +573,16 @@ treeSuite.add(new Y.Test.Case({
         this.tree.clear(null, {silent: true});
     },
 
+    'clear() should pass along a custom `src`': function () {
+        this.tree.once('clear', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.clear(null, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
+    },
+
     'destroyNode() should fire a `remove` event': function () {
         var node = this.tree.children[0],
             fired;
@@ -593,6 +603,19 @@ treeSuite.add(new Y.Test.Case({
         });
 
         this.tree.destroyNode(node, {silent: true});
+    },
+
+    'destroyNode() should pass along a custom `src`': function () {
+        var node = this.tree.children[0],
+            fired;
+
+        this.tree.once('remove', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.destroyNode(node, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
     },
 
     'prependNode() should fire an `add` event with src "prepend"': function () {
@@ -684,6 +707,20 @@ treeSuite.add(new Y.Test.Case({
         });
 
         this.tree.removeNode(this.tree.children[1], {silent: true});
+    },
+
+    'removeNode() should pass along a custom `src`': function () {
+        var node = this.tree.children[1],
+            test = this,
+            fired;
+
+        this.tree.once('remove', function (e) {
+            fired = true;
+            Assert.areSame('foo', e.src, 'src should be set');
+        });
+
+        this.tree.removeNode(node, {src: 'foo'});
+        Assert.isTrue(fired, 'event should fire');
     },
 
     '`add` event should be preventable': function () {


### PR DESCRIPTION
This value is passed along to the event facade of the resulting event, and can be used to distinguish between changes caused by different sources (such as user-initiated changes vs. programmatic changes).

This is a low-risk change with full test coverage, but I totes understand if it's too late for 3.9.0. Let me know.
