### PR TITLE
Router: More helpful error when named callback doesn't exist. Fixes #513

### DIFF
--- a/src/app/js/router.js
+++ b/src/app/js/router.js
@@ -636,7 +636,7 @@ Y.Router = Y.extend(Router, Y.Base, {
         res = self._getResponse(req);
 
         req.next = function (err) {
-            var callback, route;
+            var callback, name, route;
 
             if (err) {
                 // Special case "route" to skip to the next route handler
@@ -650,10 +650,11 @@ Y.Router = Y.extend(Router, Y.Base, {
 
             } else if ((callback = callbacks.shift())) {
                 if (typeof callback === 'string') {
-                    if (callback in self) {
-                        callback = self[callback];
-                    } else {
-                        Y.error('Router: Callback not found: ' + callback, null, 'router');
+                    name     = callback;
+                    callback = self[name];
+
+                    if (!callback) {
+                        Y.error('Router: Callback not found: ' + name, null, 'router');
                     }
                 }
 


### PR DESCRIPTION
This change provides a more helpful error message when a named router callback isn't found on the router instance.
