### PR TITLE
date: Fix unit tests

### DIFF
--- a/src/date/tests/unit/assets/date-tests.js
+++ b/src/date/tests/unit/assets/date-tests.js
@@ -29,6 +29,17 @@ YUI.add('date-tests', function(Y) {
         return hour < 12 ? ampm[lang][0] : ampm[lang][1];
     };
 
+    var xPad=function(x, pad, r) {
+        if (typeof r === "undefined") {
+            r = 10;
+        }
+        pad = pad + "";
+        for (; parseInt(x, 10) < r && r > 1; r /= 10) {
+            x = pad + x;
+        }
+        return x.toString();
+    };
+
     // Set up the page
     var LANG = Y.Lang,
         ASSERT = Y.Assert,
@@ -134,6 +145,12 @@ YUI.add('date-tests', function(Y) {
 
             output = Y.Date.format(date, {format:"%Z"});
             var tz = date.toString().replace(/^.*:\d\d( GMT[+-]\d+)? \(?([A-Za-z ]+)\)?\d*$/, "$2").replace(/[a-z ]/g, "");
+            if (tz.length > 4) {
+                var o = date.getTimezoneOffset();
+                var H = xPad(parseInt(Math.abs(o/60), 10), 0);
+                var M = xPad(Math.abs(o%60), 0);
+                tz = (o > 0 ? "-" : "+") + H + M;
+            }
             ASSERT.areSame(tz, output, 'Expected %Z format.');
 
             output = Y.Date.format(date, {format:"%"});


### PR DESCRIPTION
This fixes is the test case to pass the tests in your own environment. Currently tests for date result on my box is just below.

```
[okuryu.local] (yui3@master) $ yeti src/date/tests/unit/*.html
  Agent connected: Chrome (25.0.1364.172) / Mac OS from 127.0.0.1
✓ Testing started on Chrome (25.0.1364.172) / Mac OS
✗ Date on Chrome (25.0.1364.172) / Mac OS
   in Date Format U.S. Tests
     testUS: Expected %r format.
       Expected: 08:24:00 AM (string)
       Actual: 08:24:00 PM (string)
   in Date Format French Tests
     testFrench: Expected %r format.
       Expected: 08:24:00 AM (string)
       Actual: 08:24:00 PM (string)
   in Date Format Korean Tests
     testKorean: Expected %r format.
       Expected: 08:24:00 오전 (string)
       Actual: 08:24:00 오후 (string)
   in Date Format Punjabi Tests
     testPunjabi: Expected %r format.
       Expected: 08:24:00 ਸਵੇਰੇ (string)
       Actual: 08:24:00 ਸ਼ਾਮ (string)
   in Date Format Tests
     testFormats: Expected %R format.
       Expected: 08:24 (string)
       Actual: 20:24 (string)

✓ Agent completed: Chrome (25.0.1364.172) / Mac OS
✗ Failures: 5 of 22 tests failed. (1.74 seconds)
```

My guess is that it be attributed to the difference of time zone.

```
[okuryu.local] (yui3@fix-date-tests) $ node
> new Date(819199440000)
Sun Dec 17 1995 20:24:00 GMT+0900 (JST)
>
```

So I think that all tests should pass independently of the environment.
