### PR TITLE
fixes #2533165 slider unit test fails in IE9

### DIFF
--- a/src/slider/tests/manual/basic.html
+++ b/src/slider/tests/manual/basic.html
@@ -48,12 +48,19 @@ s.set('min', 10);
 s.render('#slider');
 
 s.on('railMouseDown', function (e) {
-    console.log(e);
+    /*removing this because IE9 just stops here if you don't have the developer tools open, 
+    * it makes you think mousedown on the rail is broken in a manual test, 
+    * but it's just that it doesn't know what to do when there's 
+    * a console command with no console. Y.log() doesn't have this problem.
+    */
+    //console.log(e); 
+    Y.log(e + 'this is a Y.log');
 });
 
 s.rail.on(['mousedown', 'mouseup', 'click'], function (e) {
     e.type;
-    console.log(e);
+    //console.log(e); // using Y.log() instead for IE 9
+    Y.log(e + 'this is a Y.log');
 });
 
 report.set('innerHTML',s.get('value'));

--- a/src/slider/tests/unit/assets/slider-tests.js
+++ b/src/slider/tests/unit/assets/slider-tests.js
@@ -518,7 +518,8 @@ suite.add( new Y.Test.Case({
                 width    : '300px',
                 clickableRail: true
             }),
-            railRegion, where, fired;
+            railRegion, fake_event, fired,
+            noop = function() {};
 
         slider.on('railMouseDown', function () {
             fired = true;
@@ -527,18 +528,20 @@ suite.add( new Y.Test.Case({
         slider.render('#testbed');
 
         railRegion = slider.rail.get('region');
-        where = {
+        fake_event = {
             clientX: railRegion.left + Math.floor(railRegion.width / 2),
-            clientY: railRegion.top + Math.floor(railRegion.height / 2)
+            clientY: railRegion.top + Math.floor(railRegion.height / 2),
+            pageX: railRegion.left + Math.floor(railRegion.width / 2),
+            pageY: railRegion.top + Math.floor(railRegion.height / 2),
+            halt: noop
         };
+
 
         slider.on('railMouseDown', function (e) {
             fired = true;
         });
 
-        slider.rail.simulate('mousedown', where);
-        slider.rail.simulate('mouseup', where);
-        slider.rail.simulate('click', where);
+        slider._onRailMouseDown(fake_event);
 
         Y.Assert.isTrue(fired, "railMouseDown didn't fire for clickableRail: true");
 
@@ -559,9 +562,7 @@ suite.add( new Y.Test.Case({
 
         slider.render('#testbed');
 
-        slider.rail.simulate('mousedown', where);
-        slider.rail.simulate('mouseup', where);
-        slider.rail.simulate('click', where);
+        slider._onRailMouseDown(fake_event);
 
         Y.Assert.isFalse(fired, "railMouseDown fired for clickableRail: false");
 
@@ -688,7 +689,8 @@ suite.add( new Y.Test.Case({
                 max   : 100,
                 value : 50
             }),
-            position, fired, railRegion, where;
+            position, fired, railRegion, fake_event,
+            noop = function() {};
 
         function thumbPosition() {
             return parseInt(slider.thumb.getStyle('left'), 10);
@@ -697,9 +699,12 @@ suite.add( new Y.Test.Case({
         slider.render( "#testbed" );
 
         railRegion = slider.rail.get('region');
-        where = {
+        fake_event = {
             clientX: railRegion.left + Math.floor(railRegion.width / 2),
-            clientY: railRegion.top + Math.floor(railRegion.height / 2)
+            clientY: railRegion.top + Math.floor(railRegion.height / 2),
+            pageX: railRegion.left + Math.floor(railRegion.width / 2),
+            pageY: railRegion.top + Math.floor(railRegion.height / 2),
+            halt: noop
         };
 
         Y.Assert.areNotSame(0, thumbPosition());
@@ -708,16 +713,14 @@ suite.add( new Y.Test.Case({
 
         Y.Assert.areSame(0, thumbPosition());
 
-        slider.on('railMouseDown', function (e) {
+        slider.on('railMouseDown', function (fake_event) {
             fired = true;
         });
 
-        slider.rail.simulate('mousedown', where);
-        slider.rail.simulate('mouseup', where);
-        slider.rail.simulate('click', where);
+        slider._onRailMouseDown(fake_event);
 
-        Y.Assert.isTrue(fired);
-        Y.Assert.isTrue( (thumbPosition() > 0) );
+        Y.Assert.isTrue(fired, "Failed to fire: railMouseDown");
+        Y.Assert.isTrue( (thumbPosition() > 0), "Failed to find thumPosition > 0" );
     }
 }));
 


### PR DESCRIPTION
I tested the unit test
yui3/src/slider/tests/unit/assets/slider-tests.js
and all tests pass in the following VM browsers/OS:
IE6 - WinXP
IE7 - WinXP
IE8 - WinXP
IE9 - WinXP
IE10 - Win8

and current versions of these browsers natively on mac
Firefox
Chrome
Safari
