### PR TITLE
LazyModelList bug fixes

### DIFF
--- a/src/app/HISTORY.md
+++ b/src/app/HISTORY.md
@@ -6,6 +6,9 @@ App Framework Change History
 
 ### LazyModelList
 
+* Fixed: Changing an attribute on a revived model did not update the
+  corresponding property on the original object. [#528] [Ryan Grove]
+
 * Fixed: Revived models didn't have the same `clientId` as the original object.
   [#530] [Ryan Grove]
 

--- a/src/app/js/lazy-model-list.js
+++ b/src/app/js/lazy-model-list.js
@@ -65,6 +65,11 @@ var AttrProto = Y.Attribute.prototype,
     EVT_RESET = 'reset';
 
 Y.LazyModelList = Y.Base.create('lazyModelList', Y.ModelList, [], {
+    // -- Lifecycle ------------------------------------------------------------
+    initializer: function () {
+        this.after('*:change', this._afterModelChange);
+    },
+
     // -- Public Methods -------------------------------------------------------
 
     /**
@@ -433,6 +438,30 @@ Y.LazyModelList = Y.Base.create('lazyModelList', Y.ModelList, [], {
         }
 
         return model;
+    },
+
+    // -- Event Handlers -------------------------------------------------------
+
+    /**
+    Handles `change` events on revived models and updates the original objects
+    with the changes.
+
+    @method _afterModelChange
+    @param {EventFacade} e
+    @protected
+    **/
+    _afterModelChange: function (e) {
+        var changed = e.changed,
+            item    = this._clientIdMap[e.target.get('clientId')],
+            name;
+
+        if (item) {
+            for (name in changed) {
+                if (changed.hasOwnProperty(name)) {
+                    item[name] = changed[name].newVal;
+                }
+            }
+        }
     },
 
     // -- Default Event Handlers -----------------------------------------------

--- a/src/app/tests/unit/assets/lazy-model-list-test.js
+++ b/src/app/tests/unit/assets/lazy-model-list-test.js
@@ -247,6 +247,15 @@ lazyModelListSuite.add(new Y.Test.Case({
         Assert.areSame('model-foo', model.get('clientId'), 'revived model should have the same clientId as the original object');
     },
 
+    'Changing an attribute on a revived model should update the original object': function () {
+        this.list.add({foo: 'bar'});
+
+        var model = this.list.revive(0);
+        model.set('foo', 'baz');
+
+        Assert.areSame('baz', this.list.item(0).foo, 'original object should have the new value');
+    },
+
     '_isInList() should indicate whether an item is in the list': function () {
         var item = {foo: 'bar'};
 


### PR DESCRIPTION
- Fixed: Changing an attribute on a revived model did not update the corresponding property on the original object. [#528]
- Fixed: Revived models didn't have the same `clientId` as the original object. [#530]
