### PR TITLE
Remove Node 0.9 from Travis build targets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
     - "0.8"
-    - "0.9"
     - "0.10"
 branches:
     only:


### PR DESCRIPTION
Because Travis is broken and can't build anything on 0.9.
