### PR TITLE
Tree: Add traverseNode() and findNode() methods

### DIFF
--- a/src/tree/HISTORY.md
+++ b/src/tree/HISTORY.md
@@ -1,6 +1,18 @@
 Tree Change History
 ===================
 
+@VERSION@
+-----
+
+* Added `Tree#findNode()` and `Tree.Node#find()` methods, which pass the
+  specified node and each of its descendants to a callback function and returns
+  the first node for which the callback returns a truthy value. [Ryan Grove]
+
+* Added `Tree#traverseNode()` and `Tree.Node#traverse()` methods, which pass the
+  specified node and each of its descendants to a callback function in
+  depth-first order. [Ryan Grove]
+
+
 3.9.1
 -----
 

--- a/src/tree/js/tree-node.js
+++ b/src/tree/js/tree-node.js
@@ -214,6 +214,36 @@ TreeNode.prototype = {
     },
 
     /**
+    Performs a depth-first traversal of this node, passing it and each of its
+    descendants to the specified _callback_, and returning the first node for
+    which the callback returns a truthy value.
+
+    Traversal will stop as soon as a truthy value is returned from the callback.
+
+    See `Tree#traverseNode()` for more details on how depth-first traversal
+    works.
+
+    @method find
+    @param {Object} [options] Options.
+        @param {Number} [options.depth] Depth limit. If specified, descendants
+            will only be traversed to this depth before backtracking and moving
+            on.
+    @param {Function} callback Callback function to call with the traversed
+        node and each of its descendants. If this function returns a truthy
+        value, traversal will be stopped and the current node will be returned.
+
+        @param {Tree.Node} callback.node Node being traversed.
+
+    @param {Object} [thisObj] `this` object to use when executing _callback_.
+    @return {Tree.Node|null} Returns the first node for which the _callback_
+        returns a truthy value, or `null` if the callback never returns a truthy
+        value.
+    **/
+    find: function (options, callback, thisObj) {
+        return this.tree.findNode(this, options, callback, thisObj);
+    },
+
+    /**
     Returns `true` if this node has one or more child nodes.
 
     @method hasChildren
@@ -437,6 +467,43 @@ TreeNode.prototype = {
         }
 
         return obj;
+    },
+
+    /**
+    Performs a depth-first traversal of this node, passing it and each of its
+    descendants to the specified _callback_.
+
+    If the callback function returns `Tree.STOP_TRAVERSAL`, traversal will be
+    stopped immediately. Otherwise, it will continue until the deepest
+    descendant of _node_ has been traversed, or until each branch has been
+    traversed to the optional maximum depth limit.
+
+    Since traversal is depth-first, that means nodes are traversed like this:
+
+                1
+              / | \
+             2  8  9
+            / \     \
+           3   7    10
+         / | \      / \
+        4  5  6    11 12
+
+    @method traverse
+    @param {Object} [options] Options.
+        @param {Number} [options.depth] Depth limit. If specified, descendants
+            will only be traversed to this depth before backtracking and moving
+            on.
+    @param {Function} callback Callback function to call with the traversed
+        node and each of its descendants.
+
+        @param {Tree.Node} callback.node Node being traversed.
+
+    @param {Object} [thisObj] `this` object to use when executing _callback_.
+    @return {Mixed} Returns `Tree.STOP_TRAVERSAL` if traversal was stopped;
+        otherwise returns `undefined`.
+    **/
+    traverse: function (options, callback, thisObj) {
+        return this.tree.traverseNode(this, options, callback, thisObj);
     },
 
     // -- Protected Methods ----------------------------------------------------

--- a/src/tree/js/tree.js
+++ b/src/tree/js/tree.js
@@ -267,6 +267,7 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
     @return {Tree.Node} New node.
     **/
     createNode: function (config) {
+        /*jshint boss:true */
         config || (config = {});
 
         // If `config` is already a node, just ensure it's in the node map and
@@ -367,6 +368,52 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
         }
 
         return removed;
+    },
+
+    /**
+    Performs a depth-first traversal of _node_, passing it and each of its
+    descendants to the specified _callback_, and returning the first node for
+    which the callback returns a truthy value.
+
+    Traversal will stop as soon as a truthy value is returned from the callback.
+
+    See `traverseNode()` for more details on how depth-first traversal works.
+
+    @method findNode
+    @param {Tree.Node} node Node to traverse.
+    @param {Object} [options] Options.
+        @param {Number} [options.depth] Depth limit. If specified, descendants
+            will only be traversed to this depth before backtracking and moving
+            on.
+    @param {Function} callback Callback function to call with the traversed
+        node and each of its descendants. If this function returns a truthy
+        value, traversal will be stopped and the current node will be returned.
+
+        @param {Tree.Node} callback.node Node being traversed.
+
+    @param {Object} [thisObj] `this` object to use when executing _callback_.
+    @return {Tree.Node|null} Returns the first node for which the _callback_
+        returns a truthy value, or `null` if the callback never returns a truthy
+        value.
+    **/
+    findNode: function (node, options, callback, thisObj) {
+        var match = null;
+
+        // Allow callback as second argument.
+        if (typeof options === 'function') {
+            thisObj  = callback;
+            callback = options;
+            options  = {};
+        }
+
+        this.traverseNode(node, options, function (descendant) {
+            if (callback.call(thisObj, descendant)) {
+                match = descendant;
+                return Tree.STOP_TRAVERSAL;
+            }
+        });
+
+        return match;
     },
 
     /**
@@ -539,6 +586,70 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
     **/
     toJSON: function () {
         return this.rootNode.toJSON();
+    },
+
+    /**
+    Performs a depth-first traversal of _node_, passing it and each of its
+    descendants to the specified _callback_.
+
+    If the callback function returns `Tree.STOP_TRAVERSAL`, traversal will be
+    stopped immediately. Otherwise, it will continue until the deepest
+    descendant of _node_ has been traversed, or until each branch has been
+    traversed to the optional maximum depth limit.
+
+    Since traversal is depth-first, that means nodes are traversed like this:
+
+                1
+              / | \
+             2  8  9
+            / \     \
+           3   7    10
+         / | \      / \
+        4  5  6    11 12
+
+    @method traverseNode
+    @param {Tree.Node} node Node to traverse.
+    @param {Object} [options] Options.
+        @param {Number} [options.depth] Depth limit. If specified, descendants
+            will only be traversed to this depth before backtracking and moving
+            on.
+    @param {Function} callback Callback function to call with the traversed
+        node and each of its descendants.
+
+        @param {Tree.Node} callback.node Node being traversed.
+
+    @param {Object} [thisObj] `this` object to use when executing _callback_.
+    @return {Mixed} Returns `Tree.STOP_TRAVERSAL` if traversal was stopped;
+        otherwise returns `undefined`.
+    **/
+    traverseNode: function (node, options, callback, thisObj) {
+        // Allow callback as second argument.
+        if (typeof options === 'function') {
+            thisObj  = callback;
+            callback = options;
+            options  = {};
+        }
+
+        options || (options = {});
+
+        var stop      = Tree.STOP_TRAVERSAL,
+            unlimited = typeof options.depth === 'undefined';
+
+        if (callback.call(thisObj, node) === stop) {
+            return stop;
+        }
+
+        var children = node.children;
+
+        if (unlimited || options.depth > 0) {
+            var childOptions = unlimited ? options : {depth: options.depth - 1};
+
+            for (var i = 0, len = children.length; i < len; i++) {
+                if (this.traverseNode(children[i], childOptions, callback, thisObj) === stop) {
+                    return stop;
+                }
+            }
+        }
     },
 
     // -- Protected Methods ----------------------------------------------------
@@ -732,6 +843,15 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
             this.children = this.rootNode.children;
         }
     }
+}, {
+    /**
+    Return this value from a `Tree#traverseNode()` or `Tree.Node#traverse()`
+    callback to immediately stop traversal.
+
+    @property STOP_TRAVERSAL
+    @static
+    **/
+    STOP_TRAVERSAL: {}
 });
 
 Y.Tree = Y.mix(Tree, Y.Tree);


### PR DESCRIPTION
…along with matching `traverse()` and `find()` wrapper methods on Tree.Node.

`traverseNode()` passes the specified node and each of its descendants to a callback function in depth-first order. Traversal can be stopped by returning `Tree.STOP_TRAVERSAL` from the callback.

`findNode()` passes the specified node and each of its descendants to a callback function and returns the first node for which the callback returns a truthy value.
