### PR TITLE
Initial drop of CSSForm from the YUI 3 Gallery.

### DIFF
--- a/src/cssform/LICENSE.md
+++ b/src/cssform/LICENSE.md
@@ -1,0 +1,11 @@
+Normalize.css License
+=====================
+
+Copyright (c) Nicolas Gallagher and Jonathan Neal
+-------------------------------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/cssform/README.md
+++ b/src/cssform/README.md
@@ -1,0 +1,17 @@
+gallerycss-cssform
+===============
+
+Super simple CSS for HTML Form Elements. 
+
+
+What is it?
+-----------
+
+`cssform` is a YUI module that makes it easy to style HTML form elements by just adding class names. There are a variety of form styles that you can use by applying a class name to a `<form>` element. Check out the [documentation](http://tilomitra.github.com/cssforms/) for details.
+
+Dependencies
+------------
+
+* [cssbutton](http://yuilibrary.com/yui/docs/button/#usecssbutton) if you wish to adopt the default button styles.
+
+

--- a/src/cssform/build.json
+++ b/src/cssform/build.json
@@ -1,0 +1,12 @@
+{
+    "name": "cssform",
+    "builds": {
+        "cssform": {
+            "cssfiles": [
+                "forms-core.css",
+                "forms.css",
+                "forms-responsive.css"
+            ]
+        }
+    }
+}

--- a/src/cssform/css/forms-core.css
+++ b/src/cssform/css/forms-core.css
@@ -1,0 +1,155 @@
+/*! Copyright 2013 Yahoo! Inc. http://yuilibrary.com/license/ */
+/* This page lists core form styles adopted from Normalize.css. */
+/*! Copyright (c) Nicolas Gallagher and Jonathan Neal */ 
+
+/*! normalize.css v1.1.0 | MIT License | git.io/normalize */
+
+/* This page has Normalize.css form-specific style rules applied to a .yui3-form context */
+
+/* ==========
+   Forms Core
+   =========*/
+
+/*
+ * Corrects margin displayed oddly in IE 6/7.
+ */
+
+.yui3-form {
+    margin: 0;
+}
+
+/*
+ * Define consistent border, margin, and padding.
+ */
+
+.yui3-form fieldset {
+    border: 1px solid #c0c0c0;
+    margin: 0 2px;
+    padding: 0.35em 0.625em 0.75em;
+}
+
+/*
+ * 1. Corrects color not being inherited in IE 6/7/8/9.
+ * 2. Corrects text not wrapping in Firefox 3.
+ * 3. Corrects alignment displayed oddly in IE 6/7.
+ */
+
+.yui3-form legend {
+    border: 0; /* 1 */
+    padding: 0;
+    white-space: normal; /* 2 */
+    *margin-left: -7px; /* 3 */
+}
+
+/*
+ * 1. Corrects font size not being inherited in all browsers.
+ * 2. Addresses margins set differently in IE 6/7, Firefox 3+, Safari 5,
+ *    and Chrome.
+ * 3. Improves appearance and consistency in all browsers.
+ */
+
+.yui3-form button,
+.yui3-form input,
+.yui3-form select,
+.yui3-form textarea {
+    font-size: 100%; /* 1 */
+    margin: 0; /* 2 */
+    vertical-align: baseline; /* 3 */
+    *vertical-align: middle; /* 3 */
+}
+
+/*
+ * Addresses Firefox 3+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+.yui3-form button,
+.yui3-form input {
+    line-height: normal;
+}
+
+/*
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Corrects inability to style clickable `input` types in iOS.
+ * 3. Improves usability and consistency of cursor style between image-type
+ *    `input` and others.
+ * 4. Removes inner spacing in IE 7 without affecting normal text inputs.
+ *    Known issue: inner spacing remains in IE 6.
+ */
+
+.yui3-form button,
+.yui3-form input[type="button"], /* 1 */
+.yui3-form input[type="reset"],
+.yui3-form input[type="submit"] {
+    -webkit-appearance: button; /* 2 */
+    cursor: pointer; /* 3 */
+    *overflow: visible;  /* 4 */
+}
+
+/*
+ * Re-set default cursor for disabled elements.
+ */
+
+.yui3-form button[disabled],
+.yui3-form input[disabled] {
+    cursor: default;
+}
+
+/*
+ * 1. Addresses box sizing set to content-box in IE 8/9.
+ * 2. Removes excess padding in IE 8/9.
+ * 3. Removes excess padding in IE 7.
+ *    Known issue: excess padding remains in IE 6.
+ */
+
+.yui3-form input[type="checkbox"],
+.yui3-form input[type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+    *height: 13px; /* 3 */
+    *width: 13px; /* 3 */
+}
+
+/*
+ * 1. Addresses `appearance` set to `searchfield` in Safari 5 and Chrome.
+ * 2. Addresses `box-sizing` set to `border-box` in Safari 5 and Chrome
+ *    (include `-moz` to future-proof).
+ */
+
+.yui3-form input[type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    -moz-box-sizing: content-box;
+    -webkit-box-sizing: content-box; /* 2 */
+    box-sizing: content-box;
+}
+
+/*
+ * Removes inner padding and search cancel button in Safari 5 and Chrome
+ * on OS X.
+ */
+
+.yui3-form input[type="search"]::-webkit-search-cancel-button,
+.yui3-form input[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
+
+/*
+ * Removes inner padding and border in Firefox 3+.
+ */
+
+.yui3-form button::-moz-focus-inner,
+.yui3-form input::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+}
+
+/*
+ * 1. Removes default vertical scrollbar in IE 6/7/8/9.
+ * 2. Improves readability and alignment in all browsers.
+ */
+
+.yui3-form textarea {
+    overflow: auto; /* 1 */
+    vertical-align: top; /* 2 */
+}

--- a/src/cssform/css/forms-responsive.css
+++ b/src/cssform/css/forms-responsive.css
@@ -1,0 +1,31 @@
+@media only screen and (max-width : 480px) {
+	.yui3-form button[type='submit'] {
+		margin: 0.7em 0 0;
+	}
+
+	.yui3-form input[type='text'], .yui3-form button, .yui3-form label {
+		margin-bottom: 0.3em;
+		display: block;
+	}
+
+	.yui3-group input[type='text'] {
+		margin-bottom: 0;
+	}
+
+	.yui3-form-aligned .yui3-control-group label {
+		margin-bottom: 0.3em;
+		text-align: left;
+		display: block;
+		width: 100%;
+	}
+
+	.yui3-form-aligned .yui3-controls {
+		margin: 1.5em 0 0 0;
+	}
+
+	.yui3-form .yui3-help-inline {
+		display: block;
+		font-size: 80%;
+		padding: 0.2em 0 0.8em; /* increased bottom padding to make it group with its related input element */
+	}
+}

--- a/src/cssform/css/forms.css
+++ b/src/cssform/css/forms.css
@@ -1,0 +1,167 @@
+.yui3-form input,
+.yui3-form select {
+  padding: 0.5em 0.6em;
+  display: inline-block;
+  border: 1px solid #ccc;
+  font-size: 0.8em;
+  box-shadow: inset 0 1px 3px #ddd;
+  border-radius: 4px;
+  -webkit-transition: 0.3s linear border;
+  -moz-transition: 0.3s linear border;
+  -ms-transition: 0.3s linear border;
+  -o-transition: 0.3s linear border;
+  transition: 0.3s linear border;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+}
+
+.yui3-form input:focus,
+.yui3-form select:focus {
+  outline: 0;
+  outline: thin dotted \9; /* IE6-9 */
+  border-color: #129FEA;
+}
+.yui3-form .yui3-checkbox,
+.yui3-form .yui3-radio {
+  margin: 0.5em 0;
+  display: block;
+}
+.yui3-form input[disabled],
+.yui3-form select[disabled],
+.yui3-form textarea[disabled],
+.yui3-form input[readonly],
+.yui3-form select[readonly],
+.yui3-form textarea[readonly] {
+  cursor: not-allowed;
+  background-color: #eaeded;
+  color: #cad2d3;
+  border-color: transparent;
+}
+.yui3-form input:focus:invalid,
+.yui3-form textarea:focus:invalid,
+.yui3-form select:focus:invalid {
+  color: #b94a48;
+  border: 1px solid #ee5f5b;
+}
+.yui3-form input:focus:invalid:focus,
+.yui3-form textarea:focus:invalid:focus,
+.yui3-form select:focus:invalid:focus {
+  border-color: #e9322d;
+}
+.yui3-form select {
+  border: 1px solid #ccc;
+  background-color: white;
+}
+.yui3-form select[multiple] {
+  height: auto;
+}
+.yui3-form label {
+  margin: 0.5em 0 0.2em;
+  color: #999;
+  font-size:90%;
+}
+.yui3-form fieldset {
+  margin: 0;
+  padding: 0.35em 0 0.75em;
+  border: 0;
+}
+.yui3-form legend {
+  display: block;
+  width: 100%;
+  padding: 0.3em 0;
+  margin-bottom: 0.3em;
+  font-size: 125%;
+  color: #333;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.yui3-form.yui3-form-stacked input[type='text'], 
+.yui3-form.yui3-form-stacked select, 
+.yui3-form.yui3-form-stacked label {
+  display: block;
+}
+
+.yui3-form-aligned input,
+.yui3-form-aligned textarea,
+.yui3-form-aligned select,
+.yui3-form-aligned .yui3-help-inline {
+  display: inline-block;
+  *display: inline; /* IE7 inline-block hack */
+  *zoom: 1;
+  vertical-align: middle;
+}
+
+/* aligned Forms */
+.yui3-form-aligned .yui3-control-group {
+  margin-bottom: 0.5em;
+}
+.yui3-form-aligned .yui3-control-group label {
+  text-align: right;
+  display: inline-block;
+  vertical-align: middle;
+  width: 10em;
+  margin: 0 1em 0 0;
+}
+.yui3-form-aligned .yui3-controls {
+  margin: 1.5em 0 0 10em;
+}
+
+/* Rounded Inputs */
+.yui3-form .yui3-input-rounded {
+  border-radius: 20px;
+  padding-left:1em;
+}
+
+/* Grouped Inputs */
+.yui3-form .yui3-group fieldset {
+  margin-bottom: 10px;
+}
+.yui3-form .yui3-group input {
+  display: block;
+  padding: 10px;
+  margin: 0;
+  border-radius: 0;
+  position: relative;
+  top: -1px;
+}
+.yui3-form .yui3-group input:focus {
+  z-index: 2;
+}
+.yui3-form .yui3-group input:first-child {
+  top: 1px;
+  border-radius: 4px 4px 0 0;
+}
+.yui3-form .yui3-group input:last-child {
+  top: -2px;
+  border-radius: 0 0 4px 4px;
+}
+.yui3-form .yui3-group button {
+  margin: 0.35em 0;
+}
+
+.yui3-form .yui3-input-1 {
+  width: 100%;
+}
+.yui3-form .yui3-input-2-3 {
+  width: 66%;
+}
+.yui3-form .yui3-input-1-2 {
+  width: 50%;
+}
+.yui3-form .yui3-input-1-3 {
+  width: 33%;
+}
+.yui3-form .yui3-input-1-4 {
+  width: 25%;
+}
+
+/* Inline help for forms */
+.yui3-form .yui3-help-inline {
+  display: inline-block;
+  padding-left: 0.3em;
+  color: #666;
+  vertical-align: middle;
+  font-size: 90%;
+}

--- a/src/cssform/docs/component.json
+++ b/src/cssform/docs/component.json
@@ -1,0 +1,10 @@
+{
+    "name"       : "cssform",
+    "displayName": "CSS Forms",
+    "description": "Simple CSS for HTML Form Elements",
+    "author"     : "tilomitra",
+
+    "tags": [ "css", "beta" ],
+    "use": ["cssform"],
+    "hideAPILink": true
+}

--- a/src/cssform/docs/index.mustache
+++ b/src/cssform/docs/index.mustache
@@ -1,0 +1,9 @@
+<div class="intro">
+    <p>
+    	Simple CSS for HTML Form Elements.
+    </p>
+</div>
+
+<p>
+    Documentation for this module exists on <a href="http://tilomitra.github.com/cssforms/">Github Pages.</a>
+</p>

--- a/src/cssform/meta/cssform.json
+++ b/src/cssform/meta/cssform.json
@@ -1,0 +1,9 @@
+{
+    "cssform": {
+        "requires": [
+            "cssbutton"
+        ],
+        "type": "css"
+    }
+}
+

--- a/src/cssform/tests/manual/index.html
+++ b/src/cssform/tests/manual/index.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width = device-width">
+    <title>Forms CSS</title>
+    <link rel="stylesheet" type="text/css" href="../../../../../yui3/build/cssnormalize/cssnormalize.css">
+    <link rel="stylesheet" href="../../../../../yui3/build/cssbutton/cssbutton.css">
+    <link rel="stylesheet" type="text/css" href="../../../../../yui3/build/cssgrids-responsive/cssgrids-responsive-min.css">
+    <link rel="stylesheet" type="text/css" href="../../../../build/cssform/cssform.css">
+    
+<!--     <link rel="stylesheet" type="text/css" href="../../css/forms.css">
+    <link rel="stylesheet" type="text/css" href="../../css/forms-responsive.css"> -->
+    <style>
+        body {
+            color: #333;
+            font-size:1.2em;
+        }
+
+        .header {
+             background: black;
+             min-height: 80px;
+             margin: 0;
+             color:white;
+             padding: 30px 20px;
+         }
+             .header h2 {
+                 font-weight:300;
+                 color: #666;
+                 margin:0;
+             }
+
+        h1,h2,h3,h4,h5,h6 {
+            font-family: "HelveticaNeue-Light", "Helvetica Neue Light",
+                         "Helvetica Neue", sans-serif;
+            font-weight: 300;
+            margin:0;
+            padding:0;
+        }
+        .content {
+            padding:0 30px;
+        }
+
+        .content h2 {
+            color:#2B474F;
+            margin:50px 0 20px 0;
+            font-weight:bold;
+        }
+
+        .notice {
+            background-color: #61B842;
+            color: white;
+        }
+    </style>
+</head>
+<body class="yui3-skin-sam">
+
+    <div class="header y-u-1">
+
+        <h1 class="yui3-u-1">YUI3 Forms CSS</h1>
+        <h2 class="yui3-u">Simple styling for HTML Form elements.</h2>
+
+    </div>
+
+    <div class="content">
+
+     <p>
+      CSSForm is a YUI module that makes it easy to display good looking forms on your website. 
+     </p>
+
+
+    
+    <h2>Default Form</h2>
+
+    <form class="yui3-form">
+    <fieldset>
+     <legend>A default inline form.</legend>
+     <input type="text" placeholder="Email">
+     <input type="password" placeholder="Password">
+     <label>
+     <input type="checkbox"> Remember me
+     </label>
+     <button type="submit" class="yui3-button">Sign in</button>
+    </fieldset>
+    </form>
+
+     <h2>Multi-Column Form (with YUI Grids)</h2>
+
+     <p>
+      Multi-column forms such as the one below can be created by pulling down YUI Grids. 
+     </p>
+
+     <form class="yui3-form yui3-form-stacked">
+      <fieldset>
+      <legend>Legend</legend>
+
+      <div class='yui3-g-r'>
+       <div class='yui3-u-1-3'>
+        <label>First Name</label>
+        <input type="text">
+       </div>
+       <div class='yui3-u-1-3'>
+        <label>Last Name</label>
+        <input type="text">
+       </div>
+       <div class='yui3-u-1-3'>
+        <label>E-Mail</label>
+        <input type="email" required>
+       </div>
+       
+       <div class='yui3-u-1-3'>
+        <label>City</label>
+        <input type="text">
+       </div>
+
+       <div class='yui3-u-1-3'>
+        <label>State</label>
+        <select class='yui3-input-medium'>
+         <option>AL</option>
+         <option>CA</option>
+         <option>IL</option>
+         <option>MD</option>
+         <option>NY</option>
+        </select>
+       </div>
+      </div>
+      <label class="yui3-checkbox">
+       <input type="checkbox"> I've read the terms and conditions
+      </label>
+      <button type="submit" class='yui3-button'>Submit</button>
+      </fieldset>
+     </form>
+
+    
+    <h2>Stacked Form</h2>
+
+    <p>
+     Apply stacked label styling to any form by applying the <code>yui3-form-stacked</code> classname.
+    </p>
+    <form class="yui3-form yui3-form-stacked">
+     <fieldset>
+     <legend>Legend</legend>
+     <label>First Name</label>
+     <input type="text">
+     <label>Last Name</label>
+     <input type="text">
+     <label>E-Mail</label>
+     <input type="email" required>
+     <aside class='yui3-help-inline'>This is a required field.</aside>
+     <label>City</label>
+     <input type="text">
+     <label>State</label>
+     <select class='yui3-input-medium'>
+      <option>AL</option>
+      <option>CA</option>
+      <option>IL</option>
+      <option>MD</option>
+      <option>NY</option>
+     </select>
+     <label class="yui3-checkbox">
+      <input type="checkbox"> I've read the terms and conditions
+     </label>
+     <button type="submit" class='yui3-button notice'>Submit</button>
+     </fieldset>
+    </form>
+
+     <h2>Aligned Form</h2>
+
+     <p>Aligned forms are great for standard forms that look well-aligned. The labels are right-aligned against the form input controls.</p>
+
+     <form class="yui3-form yui3-form-aligned">
+      <fieldset>
+      <div class="yui3-control-group">
+       <label>Username</label>
+       <input type="text" placeholder="Username">
+      </div>
+
+      <div class="yui3-control-group">
+       <label>Password</label>
+       <input type="password" placeholder="Password">
+      </div>
+
+      <div class="yui3-control-group">
+       <label>Email Address</label>
+       <input type="text" placeholder="Email Address">
+      </div>
+
+      <div class="yui3-control-group">
+       <label>Supercalifragilistic Label</label>
+       <input type="text" placeholder="Enter something here...">
+      </div>
+
+      <div class="yui3-controls">
+       <label class="yui3-checkbox">
+        <input type="checkbox"> Check me out
+       </label>
+       <button type="submit" class="yui3-button">Submit</button>
+      </div>
+      </fieldset>
+     </form>
+
+     <h2>Grouped Inputs</h2>
+     
+     <p>Grouped inputs are great for grouping small sets of text-based input elements. They work well for sign-up forms, and look natural on mobile devices.</p>
+       
+     <form class="yui3-form">
+      <fieldset class='yui3-group'>
+       <input type="text" class="yui3-input-1-3" placeholder='Username'>
+       <input type="text" class="yui3-input-1-3" placeholder='Password'>
+       <input type="text" class="yui3-input-1-3" placeholder='Email'>
+      </fieldset>
+      <fieldset class='yui3-group'>
+       <input type="text" class="yui3-input-1-3" placeholder='Another Group'>
+       <input type="text" class="yui3-input-1-3" placeholder='More Stuff'>
+      </fieldset>
+      <button type="submit" class="yui3-button yui3-input-1-3">Sign in</button>
+     </form>
+
+
+
+
+     <h2>Input Sizing</h2>
+
+     <p>You can take advantage of YUI Grids and the <code>yui3-input-block</code> class to create fluid width inputs in practically any size that you want.</p>
+
+     <form class="yui3-form">
+       <input class="yui3-input-1" type="text" placeholder=".yui3-input-1"><br/>
+       <input class="yui3-input-2-3" type="text" placeholder=".yui3-input-2-3"><br/>
+       <input class="yui3-input-1-2" type="text" placeholder=".yui3-input-1-2"><br/>
+       <input class="yui3-input-1-3" type="text" placeholder=".yui3-input-1-3"><br/>
+       <input class="yui3-input-1-4" type="text" placeholder=".yui3-input-1-4"><br/>
+     </form>
+     
+     <div class="yui3-g sizing">
+       <form class="yui3-form">
+        <div class="yui3-u-1-4">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1-4">
+        </div>
+        <div class="yui3-u-3-4">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-3-4">
+        </div>
+
+
+        <div class="yui3-u-1-2">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1-2">
+        </div>
+        <div class="yui3-u-1-2">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1-2">
+        </div>
+
+
+        <div class="yui3-u-1-8">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1-8">
+        </div>
+        <div class="yui3-u-1-8">
+         <input class="v" type="text" placeholder=".yui3-u-1-8">
+        </div>
+        <div class="yui3-u-1-4">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1-4">
+        </div>
+        <div class="yui3-u-1-2">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1-2">
+        </div>
+
+
+        <div class="yui3-u-1-5">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1-5">
+        </div>
+        <div class="yui3-u-2-5">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-2-5">
+        </div>
+        <div class="yui3-u-2-5">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-2-5">
+        </div>
+
+        <div class="yui3-u-1">
+         <input class="yui3-input-1" type="text" placeholder=".yui3-u-1">
+        </div>
+       </form>
+     </div>
+
+     <h2>Invalid Inputs</h2>
+     <p>Add the required attribute to any form control.</p>
+     <form class="yui3-form">
+       <input type="email" placeholder="Requires an email" required>
+     </form>
+
+     <h2>Disabled Inputs</h2>
+     <p>Add the disabled attribute to any form control.</p>
+     <form class="yui3-form">
+       <input class="yui3-input-xlarge" id="disabledInput" type="text" placeholder="Disabled input here..." disabled>
+     </form>
+
+     <h2>Rounded Form</h2>
+     <p>Add the yui3-input-rounded classname to any form control.</p>
+
+     <form class="yui3-form">
+       <input type="text" class="yui3-input-rounded">
+       <button type="submit" class='yui3-button'>Search</button>
+     </form>
+
+
+     <h2>Selects</h2>
+     <form class="yui3-form">
+       <select class='yui3-input-medium'>
+        <option>Brazil</option>
+        <option>Canada</option>
+        <option>United States</option>
+        <option>United Kingdom</option>
+        <option>Venezuela</option>
+       </select>
+
+      
+     <select multiple="multiple" class="yui3-input-large">
+      <option>Brazil</option>
+      <option>Canada</option>
+      <option>United States</option>
+      <option>United Kingdom</option>
+      <option>Venezuela</option>
+     </select>
+     </form>
+
+     <h2>Checkboxes and Radios</h2>
+     <form class="yui3-form">
+       <label class="yui3-checkbox">
+        <input type="checkbox" value="">
+        Here's option one. 
+       </label>
+        
+       <label class="yui3-radio">
+        <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>
+        Here's a radio button. You can choose this one..
+       </label>
+       <label class="yui3-radio">
+        <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">
+        ..Or this one! 
+       </label>
+     </form>
+    </div>
+    <script type="text/javascript" src="//use.typekit.net/ajf8ggy.js"></script>
+    <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+</body>
+</html>


### PR DESCRIPTION
## About

This commit pulls in [CSSForm](https://github.com/tilomitra/cssforms/) from the YUI3 Gallery as of gallery-2013.03.27-22-06. The CSSForm repo can be found [here](https://github.com/tilomitra/cssforms/) with more granular commits.

This pull request introduces some small changes to CSSForm, mostly with the `meta/` and `build` file changes. The docs are empty right now, because they will probably live on YUI CSS. 

The CSS is up-to-date as of [f9c1d64d](https://github.com/tilomitra/cssforms/commit/f9c1d64da6794765f5929c06ee0b78bb84260a3c) which is CSSForm v0.2.1.

To get a sense of the CSS in this pull request, you should go to the [demo page](http://tilomitra.github.com/cssforms/).
## Reasons for pulling it into core

Forms, especially laying out forms, are a nuisance on the web. There are certain common styles which are used time-after-time and I think it makes sense to group them in one place such as this module. In addition, laying out forms comes with a fair share of cross-browser-compat issues. Luckily, Normalize takes care of these. CSSForms wraps up these rules (in `forms-core`) and makes it easy for people to create forms by adding class names. Since CSSNormalize is part of core, it makes sense for low level building blocks such as menus, forms and tables to be part of core too.

While working on YUI CSS, I tested this on IE7+, Latest FF, Chrome & Safari, iOS6. 

//cc @msweeney @jconniff @ericf 
