### PR TITLE
Add ability to filter log messages by threshold

### DIFF
--- a/src/yui/js/yui-log.js
+++ b/src/yui/js/yui-log.js
@@ -11,9 +11,9 @@ var INSTANCE = Y,
     LOGEVENT = 'yui:log',
     UNDEFINED = 'undefined',
     LEVELS = { debug: 1,
-               info: 1,
-               warn: 1,
-               error: 1 };
+               info: 2,
+               warn: 4,
+               error: 8 };
 
 /**
  * If the 'debug' config is true, a 'yui:log' event will be
@@ -35,7 +35,7 @@ var INSTANCE = Y,
  * @return {YUI}      YUI instance.
  */
 INSTANCE.log = function(msg, cat, src, silent) {
-    var bail, excl, incl, m, f,
+    var bail, excl, incl, m, f, minlevel,
         Y = INSTANCE,
         c = Y.config,
         publisher = (Y.fire) ? Y : YUI.Env.globalEvents;
@@ -53,6 +53,15 @@ INSTANCE.log = function(msg, cat, src, silent) {
                 bail = !incl[src];
             } else if (excl && (src in excl)) {
                 bail = excl[src];
+            }
+
+            // Determine the current minlevel as defined in configuration
+            Y.config.logLevel = Y.config.logLevel || 'debug';
+            minlevel = LEVELS[Y.config.logLevel.toLowerCase()];
+
+            if (cat in LEVELS && LEVELS[cat] < minlevel) {
+                // Skip this message if the we don't meet the defined minlevel
+                bail = 1;
             }
         }
         if (!bail) {

--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -1975,6 +1975,22 @@ supported native console. This function is executed with the YUI instance as its
 **/
 
 /**
+The minimum log level to log messages for. Log levels are defined
+incrementally. Messages greater than or equal to the level specified will
+be shown. All others will be discarded. The order of log levels in
+increasing priority is:
+
+    debug
+    info
+    warn
+    error
+
+@property {String} logLevel
+@default 'debug'
+@since 3.10.0
+**/
+
+/**
 Callback to execute when `Y.error()` is called. It receives the error message
 and a JavaScript error object if one was provided.
 

--- a/src/yui/tests/unit/assets/core-tests.js
+++ b/src/yui/tests/unit/assets/core-tests.js
@@ -272,7 +272,9 @@ YUI.add('core-tests', function(Y) {
                 Assert = Y.Assert,
                 last;
 
-            console.info = function(str) {
+            // Override all of the console functions so that we can check
+            // their return values.
+            console.error = console.log = console.warn = console.debug = console.info = function(str) {
                 last = str.split(':')[0];
             };
 
@@ -316,6 +318,123 @@ YUI.add('core-tests', function(Y) {
                 Assert.isUndefined(last, 'Failed to exclude log param with empty string');
                 Y.log('This should NOT be ignored', 'info', 'davglass');
                 Assert.areEqual(last, 'davglass', 'Failed to include log param');
+
+                // Default logLevel is debug
+                Y.applyConfig({
+                    logInclude: {
+                        'logleveltest': true
+                    }
+                });
+                last = undefined;
+                Y.log('This should be logged', 'debug', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'info', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'warn', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'error', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+
+                // Debug should also take effect when actively specified
+                Y.applyConfig({
+                    logLevel: 'debug'
+                });
+                last = undefined;
+                Y.log('This should be logged', 'debug', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'info', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'warn', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'error', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+
+                // An invalid log level has the same effect as 'debug'
+                Y.applyConfig({
+                    logLevel: 'invalidloglevel'
+                });
+                last = undefined;
+                Y.log('This should be logged', 'debug', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'info', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'warn', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'error', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+
+                Y.applyConfig({
+                    logLevel: 'info'
+                });
+                last = undefined;
+                Y.log('This should NOT be logged', 'debug', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold');
+                last = undefined;
+                Y.log('This should be logged', 'info', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'warn', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'error', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+
+                Y.applyConfig({
+                    logLevel: 'warn'
+                });
+                last = undefined;
+                Y.log('This should NOT be logged', 'debug', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold');
+                last = undefined;
+                Y.log('This should NOT be logged', 'info', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold');
+                last = undefined;
+                Y.log('This should be logged', 'warn', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+                last = undefined;
+                Y.log('This should be logged', 'error', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+
+                Y.applyConfig({
+                    logLevel: 'error'
+                });
+                last = undefined;
+                Y.log('This should NOT be logged', 'debug', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold');
+                last = undefined;
+                Y.log('This should NOT be logged', 'info', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold');
+                last = undefined;
+                Y.log('This should NOT be ignored', 'warn', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold');
+                last = undefined;
+                Y.log('This should NOT be ignored', 'error', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
+
+                Y.applyConfig({
+                    logLevel: 'ERROR'
+                });
+                last = undefined;
+                Y.log('This should NOT be logged', 'debug', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold - case insensitivty possibly ignored');
+                last = undefined;
+                Y.log('This should NOT be logged', 'info', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold - case insensitivty possibly ignored');
+                last = undefined;
+                Y.log('This should NOT be ignored', 'warn', 'logleveltest');
+                Assert.isUndefined(last, 'Failed to exclude log level below threshold - case insensitivty possibly ignored');
+                last = undefined;
+                Y.log('This should NOT be ignored', 'error', 'logleveltest');
+                Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
             });
             console.info = l;
         },


### PR DESCRIPTION
This allows configuration of a minimum log level. Log messages greater than
or equal to the specific log level will be included in the log output,
others will be discarded.
