### PR TITLE
Fix renderBody in the docs and in table-message.

### DIFF
--- a/src/datatable/js/colwidths.js
+++ b/src/datatable/js/colwidths.js
@@ -98,7 +98,7 @@ To add a liner to all columns, either provide a custom `bodyView` to the
 DataTable constructor or update the default `bodyView`'s `CELL_TEMPLATE` like
 so:
 
-<pre><code>table.on('renderBody', function (e) {
+<pre><code>table.on('table:renderBody', function (e) {
     e.view.CELL_TEMPLATE = e.view.CELL_TEMPLATE.replace(/\{content\}/,
             '&lt;div class="yui3-datatable-liner">{content}&lt;/div>');
 });

--- a/src/datatable/js/message.js
+++ b/src/datatable/js/message.js
@@ -193,7 +193,7 @@ Y.mix(Message.prototype, {
         this._initMessageStrings();
 
         if (this.get('showMessages')) {
-            this.after('renderBody', Y.bind('_initMessageNode', this));
+            this.after('table:renderBody', Y.bind('_initMessageNode', this));
         }
 
         this.after(Y.bind('_bindMessageUI', this), this, 'bindUI');


### PR DESCRIPTION
Since 3.6.0 (as datatable HISTORY states) if you were subscribing to
renderHeader, renderBody, or renderFooter events, they now have to be prefixed
with 'table' (E.g. table.after('table:renderBody', fn).

This commit fixes the example for ColumnWidths class (datatable-column-widths)
and Message initializer (datatable-message), subscribing to table:renderBody.
