### PR TITLE
Fix #583. Allow upper and lowercase `to` values for `convert()`. Also re...

### DIFF
--- a/src/color/js/color-base.js
+++ b/src/color/js/color-base.js
@@ -112,20 +112,26 @@ Y.Color = {
     CONVERTS: CONVERTS,
 
     /**
-    @public
-    @method convert
-    @param {String} str
-    @param {String} to
-    @return {String}
-    @since 3.8.0
-    **/
-    convert: function (str, to) {
-        // check for a toXXX conversion method first
-        // if it doesn't exist, use the toXxx conversion method
-        var convert = Y.Color.CONVERTS[to],
-            clr = Y.Color[convert](str);
+     Converts the provided string to the provided type.
+     You can use the `Y.Color.TYPES` to get a valid `to` type.
+     If the color cannot be converted, the original color will be returned.
 
-        return clr.toLowerCase();
+     @public
+     @method convert
+     @param {String} str
+     @param {String} to
+     @return {String}
+     @since 3.8.0
+     **/
+    convert: function (str, to) {
+        var convert = Y.Color.CONVERTS[to.toLowerCase()],
+            clr = str;
+
+        if (convert && Y.Color[convert]) {
+            clr = Y.Color[convert](str).toLowerCase();
+        }
+
+        return clr;
     },
 
     /**

--- a/src/color/tests/unit/assets/color-base-tests.js
+++ b/src/color/tests/unit/assets/color-base-tests.js
@@ -29,6 +29,15 @@ YUI.add('color-tests', function(Y) {
                 Assert.areEqual('rgba(0, 255, 0, 1)', Y.Color.convert('lime', Types.RGBA), 'Keyword to RGBa');
             },
 
+            'test conversion with various strings': function () {
+                Assert.areEqual('#ffffff', Y.Color.convert('fff', 'hex'));
+                Assert.areEqual('#ffffff', Y.Color.convert('fff', 'HEX'));
+
+                // invalid conversion types
+                Assert.areEqual('fff', Y.Color.convert('fff', 'foo'));
+                Assert.areEqual('FFF', Y.Color.convert('FFF', 'foo'));
+            },
+
             'test original Y.DOM color conversons': function() {
                 var rgb = 'rgb(97, 11, 11)', // #610b0b
                     rgba = 'rgba(97, 11, 11, 1)',


### PR DESCRIPTION
Allow upper and lowercase `to` values for `convert()`. Also return original value if an invalid `to` value is provided.

Fixes https://github.com/yui/yui3/issues/583

Ping @ericf
