### PR TITLE
ModelSync.REST: Add entityLocator

### DIFF
--- a/src/app/js/model-extensions/model-sync-rest.js
+++ b/src/app/js/model-extensions/model-sync-rest.js
@@ -290,11 +290,21 @@ RESTSync.prototype = {
     url: '',
 
     /**
-    @property resourcePrefix
+    indicate where the model data is located within the json returned by the
+    server and sent to the server.
+
+    Example:
+    {
+      "user": { "username": "hojberg", name: "Simon Hojberg" }
+    }
+
+    In the above example the `entityLocator` would be `'user'`
+
+    @property entityLocator
     @type {Null|String}
     @default null
     **/
-    resourcePrefix: null,
+    entityLocator: null,
 
     // -- Lifecycle Methods ----------------------------------------------------
 
@@ -510,8 +520,8 @@ RESTSync.prototype = {
     _serialize: function (action) {
         var serialized = this.serialize(action);
 
-        if (typeof this.resourcePrefix === 'string') {
-            serialized = this._addResourcePrefix(serialized);
+        if (typeof this.entityLocator === 'string') {
+            serialized = this._addEntityLocator(serialized);
         }
 
         return serialized;
@@ -577,8 +587,8 @@ RESTSync.prototype = {
             response = this.parseIOResponse(response);
         }
 
-        if (typeof this.resourcePrefix === 'string') {
-            response = this._removeResourcePrefix(response);
+        if (typeof this.entityLocator === 'string') {
+            response = this._removeEntityLocator(response);
         }
 
         return this.parse(response);
@@ -586,22 +596,22 @@ RESTSync.prototype = {
 
     /**
     parse the response using Y.Model's parse method.
-    If a resourcePrefix is defined and in the response,
+    If an entityLocator is defined and in the response,
     return the nested object.
 
-    @method _removeResourcePrefix
+    @method _removeEntityLocator
     @param {Any} response Server response.
     @return {Object} Attribute hash.
     **/
-    _removeResourcePrefix: function (response) {
-        var prefix = this.resourcePrefix,
+    _removeEntityLocator: function (response) {
+        var locator = this.entityLocator,
             result;
 
-        // Get the nested object inside the prefix if it exists
+        // Get the nested object inside the entity locator if it exists
         if (response) {
             result = Y.Model.prototype.parse.call(this, response);
-            if (prefix && (prefix in result)) {
-                return result[prefix];
+            if (locator && (locator in result)) {
+                return result[locator];
             }
         }
 
@@ -609,17 +619,17 @@ RESTSync.prototype = {
     },
 
     /**
-    Add the resourcePrefix to the serialized string
+    Add the entityLocator to the serialized string
 
-    @method _addResourcePrefix
+    @method _addEntityLocator
     @param {String} serialized the serialized object
-    @return {String} serialized object nested with a resourcePrefix
+    @return {String} serialized object nested with a entityLocator
     **/
-    _addResourcePrefix: function (serialized) {
-        var prefix = this.resourcePrefix;
+    _addEntityLocator: function (serialized) {
+        var locator = this.entityLocator;
 
-        if (typeof prefix === 'string') {
-            serialized = '{"' + prefix + '":'+ serialized + '}';
+        if (typeof locator === 'string') {
+            serialized = '{"' + locator + '":'+ serialized + '}';
         }
 
         return serialized;

--- a/src/app/tests/unit/assets/model-sync-rest-test.js
+++ b/src/app/tests/unit/assets/model-sync-rest-test.js
@@ -72,12 +72,12 @@ modelSyncRESTSuite.add(new Y.Test.Case({
         Assert.areSame('', modelList.root);
     },
 
-    '`resourcePrefix` property should be an null by default': function () {
+    '`entityLocator` property should be an null by default': function () {
         var model     = new Y.TestModel(),
             modelList = new Y.TestModelList();
 
-        Assert.areSame(null, model.resourcePrefix);
-        Assert.areSame(null, modelList.resourcePrefix);
+        Assert.areSame(null, model.entityLocator);
+        Assert.areSame(null, modelList.entityLocator);
     },
 
     '`url` property should be an empty string by default': function () {
@@ -317,12 +317,12 @@ modelSyncRESTSuite.add(new Y.Test.Case({
         Assert.areSame(1, calls);
     },
 
-    'parse() should receive the response without the resourcePrefix when defined': function () {
+    'parse() should receive the response without the entityLocator when defined': function () {
         var model = new Y.TestModel(),
             responseText = '{"pie": {"id":1, "name":"Simon"}}',
             result;
 
-        model.resourcePrefix = 'pie';
+        model.entityLocator = 'pie';
         model.parse = function (res) {
             result = res;
         };
@@ -342,12 +342,12 @@ modelSyncRESTSuite.add(new Y.Test.Case({
         Assert.isFalse(Y.Object.owns('pie'));
     },
 
-    'parse() should receive the response when no resourcePrefix is defined': function () {
+    'parse() should receive the response when no entityLocator is defined': function () {
         var model = new Y.TestModel(),
             responseText = '{"pie": {"id":1, "name":"Simon"}}',
             result;
 
-        model.resourcePrefix = 'pie';
+        model.entityLocator = 'pie';
         model.parse = function (res) {
             result = res;
         };
@@ -564,11 +564,11 @@ modelSyncRESTSuite.add(new Y.Test.Case({
         model.save();
     },
 
-    "save() should include the resourcePrefix in it's entity": function () {
+    "save() should include the entityLocator in it's entity": function () {
         var model = new Y.TestModel({name: 'Simon'});
 
-        // setup the resourcePrefix
-        model.resourcePrefix = 'pie';
+        // setup the entityLocator
+        model.entityLocator = 'pie';
 
         // Overrides because `Y.io()` is too hard to test!
         model._sendSyncIORequest = function (config) {


### PR DESCRIPTION
Web frameworks like Rails, add a resource prefix be default to JSON returned.

This adds an option to ModelSync.REST to provide a `entityLocator` that will
automatically be added on `save()` and removed on `load()`

A prefixed response looks something like this:

```
GET /user/1.json

{
  "user": {
    "name": "Simon"
  }
}
```

@ericf There are several ways to achieve this, I went down a few paths and ended up on this, because it has no impact on current consumption of ModelSync.REST. 
I don't particularly like my `_addEntityLocator` method - Would love suggestions.
