### PR TITLE
Replacing @SINCE@ with currect version

### DIFF
--- a/src/base/js/Base.js
+++ b/src/base/js/Base.js
@@ -149,7 +149,7 @@
     @param {Object} configs The collection of `ATTRS` configs to mix with the
         existing attribute configurations.
     @static
-    @since @SINCE@
+    @since 3.10.0
     **/
     Base.modifyAttrs = BaseCore.modifyAttrs;
 

--- a/src/base/js/BaseCore.js
+++ b/src/base/js/BaseCore.js
@@ -186,7 +186,7 @@
     @param {Object} configs The collection of `ATTRS` configs to mix with the
         existing attribute configurations.
     @static
-    @since @SINCE@
+    @since 3.10.0
     **/
     BaseCore.modifyAttrs = function (ctor, configs) {
         // When called without a constructor, assume `this` is the constructor.


### PR DESCRIPTION
Replaces instances of "@since @SINCE@" with "@since 3.10.0" 
