### PR TITLE
Minimal flux fix for CandleStickSeries regression from Attribute perf changes

### DIFF
--- a/src/attribute/js/AttributeCore.js
+++ b/src/attribute/js/AttributeCore.js
@@ -258,6 +258,8 @@
 
             var host = this, // help compression
                 state = host._state,
+                data = state.data,
+                storedCfg = data[name],
                 value,
                 added,
                 hasValue;
@@ -271,10 +273,26 @@
             added = state.get(name, ADDED);
 
             if (lazy && !added) {
-                state.data[name] = {
-                    lazy : config,
-                    added : true
-                };
+
+                // LAST MINUTE PRE 3.10.0 RELEASE WORKAROUND.
+
+                // Revisit for 3.11.0 with the planned change to add all attributes
+                // at once, instead of filtering for each class which is the root
+                // of the issue.
+
+                // This is to account for the case when an attribute value gets set,
+                // before it's actual config is added formally. We end up blowing away
+                // the previously set value in that case, with the config. Prior to
+                // the performance fixes, we just used to merge, so we didn't see the
+                // issue.
+
+                if (!storedCfg) {
+                    storedCfg = data[name] = {};
+                }
+
+                storedCfg.lazy = config;
+                storedCfg.added = true;
+
             } else {
 
                 if (added && !config.isLazyAdd) { Y.log('Attribute: ' + name + ' already exists. Cannot add it again without removing it first', 'warn', 'attribute'); }
@@ -296,12 +314,17 @@
 
                         value = config.value;
                         config.value = undefined;
+                    } else {
+                        // LAST MINUTE PRE 3.10.0 RELEASE WORKAROUND.
+                        if (storedCfg && (VALUE in storedCfg)) {
+                            config.value = storedCfg.value;
+                        }
                     }
 
                     config.added = true;
                     config.initializing = true;
 
-                    state.data[name] = config;
+                    data[name] = config;
 
                     if (hasValue) {
                         // Go through set, so that raw values get normalized/validated
@@ -371,6 +394,7 @@
             lazyCfg = lazyCfg || state.get(name, LAZY);
 
             if (lazyCfg) {
+
                 // PERF TODO: For App's id override, otherwise wouldn't be
                 // needed. It expects to find it in the cfg for it's
                 // addAttr override. Would like to remove, once App override is
@@ -378,6 +402,7 @@
                 state.data[name].lazy = undefined;
 
                 lazyCfg.isLazyAdd = true;
+
                 this.addAttr(name, lazyCfg);
             }
         },

--- a/src/attribute/tests/unit/assets/attribute-tests.js
+++ b/src/attribute/tests/unit/assets/attribute-tests.js
@@ -1418,6 +1418,52 @@ YUI.add('attribute-tests', function(Y) {
             var o = new MyClass();
 
             Y.Assert.areEqual("bar", o.get("testValueFn"));
+        },
+
+        testSuperClassToSubClassSetterWithLazyAddFalse : function() {
+
+            // CandleStickSeries use case, where graphic === a, upcandle = b
+
+            function MySubClass() {
+                MySubClass.superclass.constructor.apply(this, arguments);
+            }
+
+            function MySuperClass() {
+                MySuperClass.superclass.constructor.apply(this, arguments);
+            }
+
+            Y.extend(MySuperClass, Y.Base, null, {
+                NAME : "mySuperClass",
+                ATTRS : {
+                    a : {
+                        lazyAdd : false,
+                        setter : function(val) {
+                            return val;
+                        }
+                    }
+                }
+            });
+
+            Y.extend(MySubClass, MySuperClass, null, {
+                NAME : "mySubClass",
+                ATTRS : {
+                    a : {
+                        lazyAdd : false,
+                        setter : function(val) {
+                            this.set("b", 10);
+                            return val;
+                        }
+                    },
+                    b : {}
+                }
+            });
+
+            var o = new MySubClass({
+                a:20
+            });
+
+            Y.Assert.areEqual(20, o.get("a"));
+            Y.Assert.areEqual(10, o.get("b"));
         }
     };
 


### PR DESCRIPTION
This is a pull request to fix a last minute regression found with the attribute performance changes. 

I still need to measure performance impact. It should just be an extra "in" in cases where attribute configs don't have a default value - so we should still maintain benefits for the 80% case. I'll update with numbers.

BACKGROUND

Prior to the Attribute perf changes, we used `state.addAll()` to set up
the initial config for an attribute while adding it. For performance
reasons this was replaced by simply setting `state.data` directly, to
consciously avoid iteration and mix costs for the initial add.

However there are use cases, such as CandleStickSeries' relationship
between it's `graphic` and `upcandle` attributes where this causes
a regression.

`graphic` is defined by a superclass, but it's setter is overridden by
CandleStickSeries. The overridden setter sets the `upcandle` attribute,
which only exists on CandleStickSeries, not on the superclass.

As a result, the value of `upcandle` is set while the `graphic` setter
is executed, before the `upcandle` attribute is formally added.

In older versions, we'd add the `upcandle` attribute later, when
processing CandleStickSeries attributes, and since we just merged,
we'd maintain the original set value. In the new version, since we
set `state.data` directly, the original value gets blown away.

FIX

The localized fix, aims to re-introduce the 'merge' behavior, if
a value already exists, while still trying to keep the optimized
performance.

The longer term fix, which is targetted for the next release is
to remove the class-by-class attribute setup and just added all
attributes in one shot, which not only avoids the issue, but will also likely result in more performance benefits.

TESTING

All library tests pass through yogi --no-cli. A unit test was added
to attribute for this use case.

Total]: Passed: 10843 Failed: 0 Total: 10936 (ignored 93)
