### PR TITLE
querystring-parse-simple module docs reference Y.QueryString.stringify

### DIFF
--- a/src/querystring/js/querystring-parse-simple.js
+++ b/src/querystring/js/querystring-parse-simple.js
@@ -5,7 +5,7 @@
 
 /*global Y */
 /**
- * <p>Provides Y.QueryString.parse method for converting objects to Query Strings.
+ * <p>Provides Y.QueryString.parse method for converting Query Strings to an object.
  * This is a simpler implementation than the full querystring-parse.</p>
  * <p>Because some things may require basic query string escaping functionality,
  * this module provides the bare minimum functionality (decoding a hash of simple values),


### PR DESCRIPTION
The querystring-parse-simple module _probably_ doesn't actually define `Y.QueryString.stringify`, & looking at the code proves that assumption to be true. So I've fixed the docs to match reality.
