### PR TITLE
Fixed intermittently failing dom, node and widget-parent tests in IE6

### DIFF
--- a/src/dom/tests/unit/dom-base.html
+++ b/src/dom/tests/unit/dom-base.html
@@ -7,16 +7,6 @@
 <script type="text/javascript" src="./assets/dom-core-test.js"></script>
 <script type="text/javascript" src="./assets/dom-class-test.js"></script>
 <script type="text/javascript" src="./assets/dom-size-test.js"></script>
-<script type="text/javascript">
-YUI({
-    coverage: ['dom-core', 'dom-class', 'dom-size'],
-    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
-}).use('test-console', 'test', 'dom-core-test', 'dom-class-test', 'dom-size-test', function (Y) {
-    new Y.Test.Console().render();
-    Y.Test.Runner.masterSuite.name = 'Dom: Base';
-    Y.Test.Runner.run();
-});
-</script>
 <style>
 
 h1, h2, h3, h4, h5, h6, p, ul, ol, li {
@@ -157,5 +147,15 @@ form {
     <strong>baz</strong>
 </div>
 </div>
+<script type="text/javascript">
+YUI({
+    coverage: ['dom-core', 'dom-class', 'dom-size'],
+    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
+}).use('test-console', 'test', 'dom-core-test', 'dom-class-test', 'dom-size-test', function (Y) {
+    new Y.Test.Console().render();
+    Y.Test.Runner.masterSuite.name = 'Dom: Base';
+    Y.Test.Runner.run();
+});
+</script>
 </body>
 </html>

--- a/src/dom/tests/unit/dom-screen.html
+++ b/src/dom/tests/unit/dom-screen.html
@@ -5,20 +5,6 @@
 
 <script type="text/javascript" src="../../../../build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/dom-region-test.js"></script>
-<script type="text/javascript">
-YUI({
-    coverage: ['dom-screen'],
-    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
-}).use('console', 'test', 'dom-region-test', function (Y) {
-    //create the logger
-
-    var logger = new Y.Console({
-        height: '800px'
-    }).render();
-    
-    Y.Test.Runner.run();
-});
-</script>
 <style>
 #ft {
     opacity: 0.75;
@@ -52,5 +38,19 @@ YUI({
 
 </head>
 <body class="yui3-skin-sam">
+<script type="text/javascript">
+YUI({
+    coverage: ['dom-screen'],
+    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
+}).use('console', 'test', 'dom-region-test', function (Y) {
+    //create the logger
+
+    var logger = new Y.Console({
+        height: '800px'
+    }).render();
+
+    Y.Test.Runner.run();
+});
+</script>
 </body>
 </html>

--- a/src/dom/tests/unit/dom-xy.html
+++ b/src/dom/tests/unit/dom-xy.html
@@ -4,29 +4,18 @@
 <title>YUI: GetXY</title>
 <script type="text/javascript" src="../../../../build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/dom-xy-test.js"></script>
-<script type="text/javascript">
-YUI({
-    coverage: ['dom-screen'],
-    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
-}).use('test-console', 'dom-xy-test', function (Y) {
-        Y.DOM._testXY();
-        new Y.Test.Console().render();
-        Y.Test.Runner.setName('Dom: XY');
-        Y.Test.Runner.run();
-});
-</script>
 <style type="text/css" media="screen">
     .yui3-console {
         position: absolute;
         right: 0;
         top: 0;
     }
-    
+
     html {
         border: 10px solid #000;
         Xmargin: 20px; /* manual test: false negative */
     }
-    
+
     body {
         /*background-image: url( grid.png );*/
         background-position: -12.5px -12.5px;
@@ -152,8 +141,8 @@ YUI({
         <div id="static3" class="node">S3</div>
         <div id="abs3" class="node">A3</div>
         <div id="rel3" class="node">R3</div>
-        Lorem ipsum dolor sit amet, <span id="p2-is" class="node st">P2 Static Inline</span> consectetuer adipiscing elit. Morbi sed mauris in magna tincidunt sodales. Etiam dolor. Aenean non justo. Sed nec diam sed lacus pretium luctus. Vivamus felis tortor, cursus vitae, malesuada in, pharetra vel, arcu. Aliquam erat volutpat. Suspendisse potenti. Maecenas in ipsum ac nisl congue congue. Cras a nibh. Praesent non est. 
-        Morbi non dolor. <span  id="p2-ir" class="node rel">P2 Rel Inline</span> Donec ut est <span id="p2-ia" class="node abs">P2 Abs Inline</span> vitae quam hendrerit tincidunt. Cras non tellus at lectus luctus ultricies. Nullam bibendum leo quis purus. Curabitur cursus tempus elit. Donec fringilla pede in leo. Morbi dapibus vestibulum enim. Phasellus non mi vel nunc luctus lacinia. Phasellus quis urna. Pellentesque dolor risus, fermentum et, molestie tempus, cursus eget, nisl. 
+        Lorem ipsum dolor sit amet, <span id="p2-is" class="node st">P2 Static Inline</span> consectetuer adipiscing elit. Morbi sed mauris in magna tincidunt sodales. Etiam dolor. Aenean non justo. Sed nec diam sed lacus pretium luctus. Vivamus felis tortor, cursus vitae, malesuada in, pharetra vel, arcu. Aliquam erat volutpat. Suspendisse potenti. Maecenas in ipsum ac nisl congue congue. Cras a nibh. Praesent non est.
+        Morbi non dolor. <span  id="p2-ir" class="node rel">P2 Rel Inline</span> Donec ut est <span id="p2-ia" class="node abs">P2 Abs Inline</span> vitae quam hendrerit tincidunt. Cras non tellus at lectus luctus ultricies. Nullam bibendum leo quis purus. Curabitur cursus tempus elit. Donec fringilla pede in leo. Morbi dapibus vestibulum enim. Phasellus non mi vel nunc luctus lacinia. Phasellus quis urna. Pellentesque dolor risus, fermentum et, molestie tempus, cursus eget, nisl.
     </div>
 </div>
 
@@ -168,8 +157,8 @@ YUI({
         <div id="static5" class="node">S5</div>
         <div id="abs4" class="node">A4</div>
         <div id="rel4" class="node">R4</div>
-        Lorem ipsum dolor sit amet, <span id="p4-is" class="node st">P4 Static Inline</span> consectetuer adipiscing elit. Morbi sed mauris in magna tincidunt sodales. Etiam dolor. Aenean non justo. Sed nec diam sed lacus pretium luctus. Vivamus felis tortor, cursus vitae, malesuada in, pharetra vel, arcu. Aliquam erat volutpat. Suspendisse potenti. Maecenas in ipsum ac nisl congue congue. Cras a nibh. Praesent non est. 
-        Morbi non dolor. <span id="p4-ir" class="node rel">P4 Rel Inline</span> Donec ut est <span id="p4-ia" class="node abs">P4 Abs Inline</span> vitae quam hendrerit tincidunt. Cras non tellus at lectus luctus ultricies. Nullam bibendum leo quis purus. Curabitur cursus tempus elit. Donec fringilla pede in leo. Morbi dapibus vestibulum enim. Phasellus non mi vel nunc luctus lacinia. Phasellus quis urna. Pellentesque dolor risus, fermentum et, molestie tempus, cursus eget, nisl. 
+        Lorem ipsum dolor sit amet, <span id="p4-is" class="node st">P4 Static Inline</span> consectetuer adipiscing elit. Morbi sed mauris in magna tincidunt sodales. Etiam dolor. Aenean non justo. Sed nec diam sed lacus pretium luctus. Vivamus felis tortor, cursus vitae, malesuada in, pharetra vel, arcu. Aliquam erat volutpat. Suspendisse potenti. Maecenas in ipsum ac nisl congue congue. Cras a nibh. Praesent non est.
+        Morbi non dolor. <span id="p4-ir" class="node rel">P4 Rel Inline</span> Donec ut est <span id="p4-ia" class="node abs">P4 Abs Inline</span> vitae quam hendrerit tincidunt. Cras non tellus at lectus luctus ultricies. Nullam bibendum leo quis purus. Curabitur cursus tempus elit. Donec fringilla pede in leo. Morbi dapibus vestibulum enim. Phasellus non mi vel nunc luctus lacinia. Phasellus quis urna. Pellentesque dolor risus, fermentum et, molestie tempus, cursus eget, nisl.
     </div>
 </div>
 
@@ -203,5 +192,16 @@ YUI({
         </tr>
     </tbody>
 </table>
+<script type="text/javascript">
+YUI({
+    coverage: ['dom-screen'],
+    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
+}).use('test-console', 'dom-xy-test', function (Y) {
+        Y.DOM._testXY();
+        new Y.Test.Console().render();
+        Y.Test.Runner.setName('Dom: XY');
+        Y.Test.Runner.run();
+});
+</script>
 </body>
 </html>

--- a/src/dom/tests/unit/dom.html
+++ b/src/dom/tests/unit/dom.html
@@ -4,6 +4,122 @@
 <title>DOM Test Suite</title>
 
 <script type="text/javascript" src="../../../../build/yui/yui.js"></script>
+<style>
+h1, h2, h3, h4, h5, h6, p, ul, ol, li {
+    Xmargin:0;
+    Xpadding:0;
+}
+
+form {
+    width: 30em;
+}
+
+#doc {
+    border:5px solid #000;
+    margin:10px;
+    padding:10px;
+}
+
+#hd {
+    background:#ccc;
+}
+
+#foo {
+    float:left; /* required for getStyle test */
+}
+
+#ft {
+    height:200px;
+    opacity: 0.75;
+}
+.yui3-skin-sam .yui-console-entry-pass .yui-console-entry-cat {
+    background: #070;
+    color: #fff;
+}
+.yui3-skin-sam .yui-console-entry-fail .yui-console-entry-cat {
+    background: #700;
+    color: #fff;
+}
+</style>
+</head>
+<body class="yui3-skin-sam">
+    <div id="doc">
+        <div id="hd"><h1>Page Header</h1></div>
+        <div id="bd">
+            <div id="main" class="main">
+                <h2 id="foo">Section Header</h2>
+                <select id="test-select"><option>choose</option></select>
+                <em class="lorem ipsum ipsum" id="lorem-ipsum">lorem ipsum</em>
+                <div class="mod" id="mod1">
+                    <div class="hd">
+                        <h3>Module Header</h3>
+                    </div>
+                    <div class="bd">
+                        <p>Fusce feugiat diam. Vestibulum elementum dui in augue. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris pulvinar.</p>
+                    </div>
+                    <div class="ft"><a href="#">more</a></div>
+                </div>
+                <div class="mod" id="mod2">
+                    <div class="hd">
+                        <h3>Module Header</h3>
+                    </div>
+                    <div class="bd">
+                        <form action="#" method="get" id="search">
+                            <fieldset id="search-fields">
+                                <legend>Search</legend>
+                                <label for="search-p" id="search-p-label">Query</label>
+                                <input type="text" name="p" id="search-p">
+                                <input name="id">
+                                <input type="submit" value="search">
+                            </fieldset>
+                        </form>
+                    </div>
+                    <div class="ft"><a href="http://www.developer.yahoo.com">more</a></div>
+                </div>
+            </div>
+            <form id="test-form" class="test-class" action="#">
+                <input id="test-text-value" value="text value">
+                <input id="test-text-novalue" name=>
+                <input id="test-text-emptyvalue">
+
+
+                <textarea id="test-textarea-value" value="textarea value"></textarea>
+                <textarea id="test-textarea-novalue"></textarea>
+                <textarea id="test-textarea-textvalue">textarea text</textarea>
+
+                <button id="test-button-value" value="button value">button</button>
+                <button id="test-button-novalue"></button>
+                <button id="test-button-textvalue">button text</button>
+
+                <select id="test-select-value">
+                    <option id="test-option-value" value="option value">option text</option>
+                    <option id="test-option-textvalue">option text</option>
+                    <option id="test-option-emptyvalue" value="">empty value</option>
+                    <option id="test-option-emptyvalue-notext" value=""></option>
+                    <option id="test-option-novalue"></option>
+                </select>
+
+                <select id="test-select-textvalue">
+                    <option>option text</option>
+                </select>
+
+                <select id="test-select-emptyvalue">
+                    <option value="">option text</option>
+                </select>
+                <select id="test-select-emptyvalue-notext">
+                    <option value=""></option>
+                </select>
+            </form>
+            <form id="test-names">
+                <input id="test-name-id1" name="test-name-id2" >
+                <input id="test-name-id2" name="test-name-id1">
+            </form>
+            <div id="test-add">test</div>
+        </div>
+        <div id="ft">
+            <p>In hac habitasse platea dictumst. Sed sit amet ligula vitae justo consequat facilisis. Integer tortor. Integer erat. In hac habitasse platea dictumst. Phasellus convallis quam vitae turpis aliquam lobortis. Aliquam scelerisque condimentum lectus. Proin semper adipiscing leo. Nulla facilisi.</p>
+        </div>
+    </div>
 
 <script type="text/javascript">
     YUI({
@@ -93,7 +209,7 @@
 
                 Assert.areEqual('static',
                         Y.DOM.getStyle(doc, 'position'), 'doc, position');
-            },            
+            },
 
             test_setStyle: function() {
                 Y.DOM.setStyle(ft, 'opacity', 0.5);
@@ -667,15 +783,15 @@
 
                 rgb = "rgb(97, 56, 11)" ;
                 hex = Y.Color.toHex(rgb);
-                Assert.areSame(hex, "#61380B", " shoudl be #61380B"); 
+                Assert.areSame(hex, "#61380B", " shoudl be #61380B");
 
                 rgb = "rgb(11, 97, 11)" ; // 0B610B
                 hex = Y.Color.toHex(rgb);
-                Assert.areSame(hex, "#0B610B", " shoudl be #0B610B"); 
+                Assert.areSame(hex, "#0B610B", " shoudl be #0B610B");
 
                 rgb = "rgb(56, 11, 97)" ; //380B61
                 hex = Y.Color.toHex(rgb);
-                Assert.areSame(hex, "#380B61", " shoudl be #380B61"); 
+                Assert.areSame(hex, "#380B61", " shoudl be #380B61");
 
                 rgb = "rgb(97, 11, 56)" ; //610B38
                 hex = Y.Color.toHex(rgb);
@@ -720,11 +836,11 @@
                 var width = Y.DOM.getScrollbarWidth();
 
                 Assert.isNumber(width);
-                
+
                 Assert.areSame(width, Y.DOM.getScrollbarWidth());
             }
 
-        })); 
+        }));
         Y.Test.Runner.add(suite);
 
         if (parent && parent != window && Y.Test.Manager) {
@@ -735,126 +851,5 @@
 
 });
 </script>
-<style>
-
-h1, h2, h3, h4, h5, h6, p, ul, ol, li {
-    Xmargin:0;
-    Xpadding:0;
-}
-
-form {
-    width: 30em;
-}
-
-#doc {
-    border:5px solid #000;
-    margin:10px;
-    padding:10px;
-}
-
-#hd {
-    background:#ccc;
-}
-
-#foo {
-    float:left; /* required for getStyle test */
-}
-
-#ft {
-    height:200px;
-    opacity: 0.75;
-}
-.yui3-skin-sam .yui-console-entry-pass .yui-console-entry-cat {
-    background: #070;
-    color: #fff;
-}
-.yui3-skin-sam .yui-console-entry-fail .yui-console-entry-cat {
-    background: #700;
-    color: #fff;
-}
-</style>
-
-<style type="text/css">
-
-</style>
-</head>
-<body class="yui3-skin-sam">
-    <div id="doc">
-        <div id="hd"><h1>Page Header</h1></div>
-        <div id="bd">
-            <div id="main" class="main">
-                <h2 id="foo">Section Header</h2>
-                <select id="test-select"><option>choose</option></select>
-                <em class="lorem ipsum ipsum" id="lorem-ipsum">lorem ipsum</em>
-                <div class="mod" id="mod1">
-                    <div class="hd">
-                        <h3>Module Header</h3>
-                    </div>
-                    <div class="bd">
-                        <p>Fusce feugiat diam. Vestibulum elementum dui in augue. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris pulvinar.</p>
-                    </div>
-                    <div class="ft"><a href="#">more</a></div>
-                </div>
-                <div class="mod" id="mod2">
-                    <div class="hd">
-                        <h3>Module Header</h3>
-                    </div>
-                    <div class="bd">
-                        <form action="#" method="get" id="search">
-                            <fieldset id="search-fields">
-                                <legend>Search</legend>
-                                <label for="search-p" id="search-p-label">Query</label>
-                                <input type="text" name="p" id="search-p">
-                                <input name="id">
-                                <input type="submit" value="search">
-                            </fieldset>
-                        </form>
-                    </div>
-                    <div class="ft"><a href="http://www.developer.yahoo.com">more</a></div>
-                </div>
-            </div>
-            <form id="test-form" class="test-class" action="#">
-                <input id="test-text-value" value="text value">
-                <input id="test-text-novalue" name=>
-                <input id="test-text-emptyvalue">
-
-
-                <textarea id="test-textarea-value" value="textarea value"></textarea>
-                <textarea id="test-textarea-novalue"></textarea>
-                <textarea id="test-textarea-textvalue">textarea text</textarea>
-
-                <button id="test-button-value" value="button value">button</button>
-                <button id="test-button-novalue"></button>
-                <button id="test-button-textvalue">button text</button>
-
-                <select id="test-select-value">
-                    <option id="test-option-value" value="option value">option text</option>
-                    <option id="test-option-textvalue">option text</option>
-                    <option id="test-option-emptyvalue" value="">empty value</option>
-                    <option id="test-option-emptyvalue-notext" value=""></option>
-                    <option id="test-option-novalue"></option>
-                </select>
-
-                <select id="test-select-textvalue">
-                    <option>option text</option>
-                </select>
-
-                <select id="test-select-emptyvalue">
-                    <option value="">option text</option>
-                </select>
-                <select id="test-select-emptyvalue-notext">
-                    <option value=""></option>
-                </select>
-            </form>
-            <form id="test-names">
-                <input id="test-name-id1" name="test-name-id2" >
-                <input id="test-name-id2" name="test-name-id1">
-            </form>
-            <div id="test-add">test</div>
-        </div>
-        <div id="ft">
-            <p>In hac habitasse platea dictumst. Sed sit amet ligula vitae justo consequat facilisis. Integer tortor. Integer erat. In hac habitasse platea dictumst. Phasellus convallis quam vitae turpis aliquam lobortis. Aliquam scelerisque condimentum lectus. Proin semper adipiscing leo. Nulla facilisi.</p>
-        </div>
-    </div>
 </body>
 </html>

--- a/src/node/tests/unit/node-data.html
+++ b/src/node/tests/unit/node-data.html
@@ -5,6 +5,8 @@
 
 <script type="text/javascript" src="../../../../build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/node-data-test.js"></script>
+</head>
+<body class="yui3-skin-sam">
 <script>
 YUI({
     coverage: ['node-base'],
@@ -14,7 +16,5 @@ YUI({
     Y.Test.Runner.run();
 });
 </script>
-</head>
-<body class="yui3-skin-sam">
 </body>
 </html>

--- a/src/node/tests/unit/node.html
+++ b/src/node/tests/unit/node.html
@@ -113,7 +113,7 @@ button {
             <label for="test-text-value"><em>label</em></label>
             <input name="test-text-value" id="test-text-value" readonly="read" value="text value">
             <input name="test-text-novalue">
-    
+
             <textarea name="test-textarea-value" value="textarea value"></textarea>
             <textarea name="test-textarea-novalue"></textarea>
             <textarea name="test-textarea-textvalue">textarea text</textarea>
@@ -335,7 +335,7 @@ YUI({
 
             node.set('foo', 'foo');
             Assert.isUndefined(node.get('foo'), 'node.get("foo")');
-            
+
             node.set('title', 'my title');
             Assert.areEqual('my title', Y.Node.getDOMNode(node).title, 'node.title)');
             Assert.areEqual('my title', node.get('title'), 'node.set("title")');
@@ -352,8 +352,8 @@ YUI({
             };
             node.setAttrs(attrMap);
             var getAttrs = node.getAttrs(['className', 'title']);
-            Assert.areEqual(attrMap.className, getAttrs.className, 'node.setAttrs(attrMap) (get className)'); 
-            Assert.areEqual(attrMap.title, getAttrs.title, 'node.setAttrs(attrMap) (get title)'); 
+            Assert.areEqual(attrMap.className, getAttrs.className, 'node.setAttrs(attrMap) (get className)');
+            Assert.areEqual(attrMap.title, getAttrs.title, 'node.setAttrs(attrMap) (get title)');
 
             Y.one('#test-select').set('selectedIndex', 2);
             Assert.areEqual(2, Y.one('#test-select')._node.selectedIndex,
@@ -385,7 +385,7 @@ YUI({
             Assert.isFalse(xmlNode.hasMethod('onreadystatechange')," xmlNode.hasMethod('onreadystatechange')");
 
             //Assert.isTrue(element === Y.one(node), 'element === Y.one(node)');
-            Assert.areEqual(element.getElementsByTagName('em')[0].nodeName, node.getElementsByTagName('em').item(0).get('nodeName'), 'getElementsByTagName'); 
+            Assert.areEqual(element.getElementsByTagName('em')[0].nodeName, node.getElementsByTagName('em').item(0).get('nodeName'), 'getElementsByTagName');
             var insertNode = document.createElement('div');
             Y.stamp(insertNode);
             insertNode.innerHTML = 'inserted node';
@@ -433,7 +433,7 @@ YUI({
             Assert.isTrue(node.contains(byId('test-contains')), 'contains()');
             Assert.isTrue(node.contains(node), 'contains() self');
             Assert.isTrue(node.contains(element), 'contains() self');
-        
+
             Assert.isFalse(node.contains(document.getElementsByTagName('div')), 'contains() false positive for collection');
 
             Assert.areEqual('doc', node.ancestor(function(el) {
@@ -465,7 +465,7 @@ YUI({
             Assert.areEqual(node.getAttribute('tabIndex'), node.get('tabIndex'),
                 "node.getAttribute('tabIndex') === node.get('tabIndex')");
                 */
-            
+
             Assert.isFalse(Y.one('body').hasAttribute('title'), 'body.hasAttribute("title")');
             Assert.areEqual('0', Y.one('select[name=test-select] option:nth-child(1)').getAttribute('value'), 'option1.getAttribute("value") (from innerText)');
             Assert.areEqual('1', Y.one('select[name=test-select] option:nth-child(2)').getAttribute('value'), 'option2.getAttribute("value") (from innerText)');
@@ -585,10 +585,10 @@ YUI({
 
             node.setStyle('float', 'left');
             Assert.areEqual('left', node.getStyle('float'), "setStyle('float', 'left')");
-            
+
             nodes.setStyle('marginTop', '1em');
             Assert.areEqual('1em', nodes.getStyle('marginTop')[2], "setStyle('marginTop', '1em'");
-        },            
+        },
 
         test_getStyle: function() {
             var node = Y.one('#get-style');
@@ -1045,7 +1045,7 @@ YUI({
             //window.scrollTo(0,0);
             mask.style.height = doc.get('docHeight') + 'px';
             mask.style.width = doc.get('docWidth') + 'px';
-            Y.DOM.setStyle(mask, 'opacity', 0.4); 
+            Y.DOM.setStyle(mask, 'opacity', 0.4);
             Assert.areEqual('DIV', Y.one('#test-prop').get('nodeName'), 'one("test-prop")');
 
             Assert.areEqual('test-xy', doc.one('#test-xy').get('id'), 'doc.one("#test-xy")');
@@ -1090,15 +1090,15 @@ YUI({
                 "Y.one(Y.DOM.byId('_funky:id{$400}')).all(h2)");
 
             node = Y.one('body');
-            ArrayAssert.itemsAreEqual([node._node], Y.all(node)._nodes, 
+            ArrayAssert.itemsAreEqual([node._node], Y.all(node)._nodes,
                 "Y.all(Y.one('body'))");
 
             node = Y.one('win');
-            ArrayAssert.itemsAreEqual([node._node], Y.all(node)._nodes, 
+            ArrayAssert.itemsAreEqual([node._node], Y.all(node)._nodes,
                 "Y.all(Y.one('win'))");
 
 /* comparision fails in webkit, so using alert test below
-            Assert.areEqual(window, Y.all(window)._nodes[0], 
+            Assert.areEqual(window, Y.all(window)._nodes[0],
                 "Y.all(window)");
 */
 
@@ -1739,7 +1739,7 @@ YUI({
             var node = Y.Node.create('<div>foo</div><div>bar</div>');
             Assert.isUndefined(Y.Node._instances[node._yuid]);
         }
-    })); 
+    }));
 
     suite.add( new Y.Test.Case({
         name: 'generateID',
@@ -1750,7 +1750,7 @@ YUI({
             Assert.isTrue(node.get('id') !== '');
             Assert.areEqual(node.get('id'), id);
         },
-        
+
         'should return exising ID': function() {
             var node = Y.Node.create('<div id="foo"/>'),
                 id = node.generateID();
@@ -1758,8 +1758,8 @@ YUI({
             Assert.areEqual('foo', node.get('id'));
             Assert.areEqual('foo', id);
         }
-        
-    })); 
+
+    }));
 
     suite.add( new Y.Test.Case({
         name: 'new Y.Node()',
@@ -1771,7 +1771,7 @@ YUI({
         'compareTo should pass': function() {
             Assert.isTrue(Y.one('body').compareTo(Y.Node('body')));
         }
-    })); 
+    }));
 
     suite.add( new Y.Test.Case({
         name: 'NodeList API',
@@ -1812,7 +1812,7 @@ YUI({
         'should create empty NodeList from empty string via Y.all': function() {
             ArrayAssert.itemsAreEqual([], Y.all('')._nodes);
         }
-    })); 
+    }));
 
     Y.Test.Runner.add(new Y.Test.Case({
         name: 'Y.Node.insert',

--- a/src/widget-parent/tests/unit/parent-child.html
+++ b/src/widget-parent/tests/unit/parent-child.html
@@ -34,7 +34,7 @@
     </style>
 </head>
 <body class="yui3-skin-sam">
-
+    <p><input type="button" value="Run Tests" id="btnRun" disabled=true></p>
     <script type="text/javascript">
 
         YUI({
@@ -222,7 +222,7 @@
                     widget.add({type: Y.ChildWidget, label: "Child Two", id: "child-2" }, 1);
                     widget.add({type: Y.ChildWidget, label: "Child One", id: "child-1" }, 0);
                     widget.add({type: Y.ChildWidget, label: "Child Three", id: "child-3" }, 2);
-                    
+
                     widget.render();
 
                     var children = widget.get("children");
@@ -239,18 +239,18 @@
 
                     widget.destroy();
                 },
-                
+
                 testAddOutOfOrderPostRender : function() {
                     var widget = new Y.ParentWidget({
                         id:"widget-1"
                     });
-                    
+
                     widget.render();
 
                     widget.add({type: Y.ChildWidget, label: "Child Two", id: "child-2" }, 1);
                     widget.add({type: Y.ChildWidget, label: "Child One", id: "child-1" }, 0);
                     widget.add({type: Y.ChildWidget, label: "Child Three", id: "child-3" }, 2);
-                    
+
                     Y.Assert.areEqual(widget.item(0).get("id"), "child-1", "child-1 is out of order");
                     Y.Assert.areEqual(widget.item(1).get("id"), "child-2", "child-2 is out of order");
                     Y.Assert.areEqual(widget.item(2).get("id"), "child-3", "child-3 is out of order");
@@ -321,7 +321,7 @@
                     widget.selectChild(1);
 
                     Y.Assert.areSame(widget.item(1), widget.get("selection"));
-                    
+
                     Y.Assert.areEqual(widget.remove(1).get("id"), "child-2", "The parent's \"remove\" method should return a reference to the child removed.");
                     Y.Assert.areEqual(parentBB.one("#child-2"), null, "child-2's bounding box should have been removed");
                     Y.Assert.areEqual(parentBB.all(childSelector).size(), 3, "The widget should now have three children bounding boxes.");
@@ -355,7 +355,7 @@
 
                     Y.Assert.areSame(widget.item(1), widget.get("activeDescendant"));
 
-                    var removedChild = widget.remove(1); 
+                    var removedChild = widget.remove(1);
 
                     Y.Assert.isFalse(removedChild.get("focused"));
                     Y.Assert.areEqual(removedChild.get("id"), "child-2", "The parent's \"remove\" method should return a reference to the child removed.");
@@ -467,7 +467,7 @@
                     Y.Assert.areEqual(tree.get("selection").get("id"), "subtree", "The root's \"selection\" attribute should return the subtree.");
                     Y.Assert.areEqual(tree.item(2).get("selection").get("id"), "subtree-leaf-3", "The subtree's \"selection\" attribute should return its third child.");
 
-                    // Confirm that we can't do a multiple selection 
+                    // Confirm that we can't do a multiple selection
                     var evts = [];
 
                     tree.on("selectedChange", function() {
@@ -482,13 +482,13 @@
 
                     Y.ArrayAssert.itemsAreEqual(["root:onSelectedChange"], evts);
                     Y.Assert.areEqual(2, tree.get("selected"));
-                    
+
                     evts = [];
 
                     tree.item(2).on("selectedChange", function() {
                         evts.push("subTree:onSelectedChange");
                     });
-                    
+
                     tree.item(2).after("selectedChange", function() {
                         evts.push("subTree:afterSelectedChange");
                     });
@@ -635,7 +635,7 @@
                     Y.Assert.areEqual(widget.item(0).ancestor(-1).get("id"), "widget-1", "The ancestor of \"child-1\" at depth -1 should be \"widget-1\"");    // parent depth
 
                     root.destroy();
-                    
+
                     // So tests can be rerun
                     Y.ParentWidget.prototype.ROOT_TYPE = null;
                     Y.ChildWidget.prototype.ROOT_TYPE = null;
@@ -722,9 +722,9 @@
                     // seem to be working (subtree is missing). Otherwise we would use tree.on("*:destroy");
 
                     tree.each(function(child) {
-                        
+
                         var id = child.get("id");
-                        
+
                         child.after("destroy", function(e) {
                             destroyed.push(id);
                             Y.Assert.isNull(Y.Node.one("#" + id), "Child bounding box still in DOM");
@@ -732,8 +732,8 @@
 
                         if (child.hasImpl(Y.WidgetParent)) {
                             child.each(function(subtreechild) {
-                        
-                                var id = subtreechild.get("id");        
+
+                                var id = subtreechild.get("id");
 
                                 subtreechild.after("destroy", function(e) {
                                     destroyed.push(id);
@@ -742,16 +742,16 @@
                             });
                         }
                     });
-                    
+
                     var rootId = tree.get("id");
-                    
+
                     tree.after("destroy", function(e) {
                         destroyed.push(rootId);
                         Y.Assert.isNull(Y.Node.one("#" + rootId), "Root Bounding box still in DOM");
                     });
 
                     tree.destroy();
-                    
+
                     Y.ArrayAssert.itemsAreEqual(expected, destroyed, "Unexpected destroy events");
                 },
 
@@ -779,15 +779,15 @@
                     tree.item(1).destroy();
 
                     Y.Assert.areEqual(2, tree.size(), "Item 1 doesn't seem to have been removed. Tree size is the same");
-                    Y.Assert.areEqual("subtree", tree.item(1).get("id"), "Item 1 doesn't seem to have been removed");  
+                    Y.Assert.areEqual("subtree", tree.item(1).get("id"), "Item 1 doesn't seem to have been removed");
 
-                    subree = tree.item(1); 
+                    subree = tree.item(1);
 
                     subtree.item(0).destroy();
 
                     Y.Assert.areEqual(1, subtree.size(), "Subtree item 0 doesn't seem to have been removed. subtree size is the same");
                     Y.Assert.areEqual("subtree-leaf-2", subtree.item(0).get("id"), "Subtree item 0 doesn't seem to have been removed");
-                    Y.Assert.areEqual(subtree.item(1), null, "Subtree item 1 should have moved up to item 0");  
+                    Y.Assert.areEqual(subtree.item(1), null, "Subtree item 1 should have moved up to item 0");
 
                     tree.destroy();
                 },
@@ -801,7 +801,7 @@
                         actualEvents = [],
 
                         expectedChildEvents = [
-                            "childwidget:click", 
+                            "childwidget:click",
                             "childwidget:click"
                         ],
                         actualChildEvents = [];
@@ -836,12 +836,12 @@
 
                     widget.destroy();
                 },
-                
+
                 testCustomAsyncRender : function() {
 
                     // NOTE: This is not a unit test for "out-of-the-box" code per-se.
 
-                    // It's testing an additional check for "rendered", added to _uiAddChild, specifically 
+                    // It's testing an additional check for "rendered", added to _uiAddChild, specifically
                     // for a customization which modified child.render() to be async.
 
                     // See http://yuilibrary.com/projects/yui3/ticket/2529863 for more details.
@@ -866,7 +866,7 @@
                         render: function() {
                             var w = this,
                                 args = arguments;
-        
+
                             this.get("parent").renderQ.add(function() {
                                 AsyncRenderChild.superclass.render.apply(w, args);
                             });
@@ -881,17 +881,17 @@
 
                     widget.after("asyncAddComplete", function(e) {
                         test.resume(function() {
-    
+
                             Y.Assert.areEqual(widget.item(0).get("id"), "child-1", "child-1 is out of order");
                             Y.Assert.areEqual(widget.item(1).get("id"), "child-2", "child-2 is out of order");
                             Y.Assert.areEqual(widget.item(2).get("id"), "child-3", "child-3 is out of order");
-        
+
                             var renderedChildren = widget.get("contentBox").get("children");
-        
+
                             Y.Assert.areEqual(renderedChildren.item(0).get("id"), "child-1", "child-1 is out of order");
                             Y.Assert.areEqual(renderedChildren.item(1).get("id"), "child-2", "child-2 is out of order");
                             Y.Assert.areEqual(renderedChildren.item(2).get("id"), "child-3", "child-3 is out of order");
-    
+
                             widget.destroy();
                         });
                     });
@@ -902,7 +902,7 @@
                         {type: AsyncRenderChild, label: "Child Three", id: "child-3"}
                     ]);
 
-                    test.wait();                    
+                    test.wait();
                 }
 
             }));
@@ -929,12 +929,11 @@
                     '</pre>'
                 }).render();
             }
-    
+
             Y.Test.Runner.enableLogging();
             Y.Test.Runner.run();
         });
     });
     </script>
-    <p><input type="button" value="Run Tests" id="btnRun" disabled=true></p>
 </body>
 </html>


### PR DESCRIPTION
Dom/Node tests would fail with a `Node.one() is null` error on load with
a clean cache, and on refresh would sometimes render the console and tests
would pass, and would sometimes not render the console at all.

Issue was that we were creating the YUI instance for test execution in HEAD,
so based on the browser, we could sometimes start executing before the DOM was
fully ready.

Widget-Parent tests would do the same looking for the run button.

**Fixed both by moving the script execution to the end of body.**

All tests run reliably now in IE6, both manually and through Yeti except for
the Dom's "should find 2 FORMs via form query: Values should be equal"

Ran all tests through Chrome as a sanity test, to make sure there
weren't regressions in non-IE browsers.
