### PR TITLE
Attempt to clean up lang xframe tests, to avoid intermittent Yeti + IE issues

### DIFF
--- a/src/yui/tests/coverage/index-automated.html
+++ b/src/yui/tests/coverage/index-automated.html
@@ -15,13 +15,10 @@
 
 <span id="test"></span>
 
-<iframe name="xframe" id="xframe" src="assets/xframe.html" style="visibility: hidden;"></iframe>
-
-
 <script>
 var YUI = {};
 </script>
-<!-- This is the main test file, notice it's using the `yui-base` seed file 
+<!-- This is the main test file, notice it's using the `yui-base` seed file
 without Loader on the page, so Loader is fetched before tests are executed. -->
 <script type="text/javascript" src="../../../build/yui-core/yui-core-coverage.js"></script>
 <script type="text/javascript" src="../../../build/get/get.js"></script>
@@ -63,7 +60,7 @@ var YUI_config = {
 
 YUI({
     allowRollup: false,
-    logExclude: {Dom: true, Selector: true, Node: true, attribute: true, base: true, event: true, widget: true },    
+    logExclude: {Dom: true, Selector: true, Node: true, attribute: true, base: true, event: true, widget: true },
     filter: YUI_config.gfilter,
     modules: {
         'array-test': {
@@ -77,7 +74,18 @@ YUI({
         'lang-test': {
             fullpath: 'lang-test.js',
             requires: ['test']
-        },        
+        },
+        'lang-xframe-test' : {
+            fullpath: './assets/lang-xframe-test.js',
+            condition: {
+                name : 'lang-xframe-test',
+                trigger : 'lang-test',
+                test : function(Y) {
+                    return !(Y.UA.nodejs);
+                }
+            },
+            requires: ['test']
+        },
         'seed-tests': {
             fullpath: './seed-tests.js',
             requires: [ 'test']
@@ -112,7 +120,7 @@ YUI({
             fullpath: './ua-tests.js',
             requires: [ 'ua-data', 'ua-yui-data', 'test' ]
         }
-        
+
     }
 }).use('ua-tests', 'seed-tests', 'core-tests', 'config-test', 'later-test', 'namespace-test', 'array-test', 'object-test', 'lang-test', 'test-console', 'test', function(Y) {
     new Y.Test.Console().render('#log');

--- a/src/yui/tests/unit/assets/lang-test.js
+++ b/src/yui/tests/unit/assets/lang-test.js
@@ -9,12 +9,10 @@ var Assert = Y.Assert,
 
 suite.add(new Y.Test.Case({
     name: 'Lang tests',
+
     _should: {
         ignore: {
-            test_is_array_dom: (Y.UA.nodejs),
-            test_is_function_dom: (Y.UA.nodejs),
-            test_is_object_dom: (Y.UA.nodejs),
-            test_is_date_dom: (Y.UA.nodejs)
+            test_is_array_dom: (Y.UA.nodejs)
         }
     },
     '_isNative() should return true for native functions': function () {
@@ -44,22 +42,20 @@ suite.add(new Y.Test.Case({
         a["one"] = "two";
         Assert.isTrue(Lang.isArray(a), "'Associative' arrays are arrays");
     },
+
     test_is_array_dom: function() {
+
+        // TODO: Does this really all need to be excluded for nodejs?
+
+        // Seems like only the dom stuff needs to be excluded.
+        // The other stuff is basic array stuff.
+
         Assert.isFalse(Lang.isArray(document.getElementsByTagName("body")),
                 "Element collections are array-like, but not arrays");
 
         Assert.isFalse(Lang.isArray(null), "null is not an array");
         Assert.isFalse(Lang.isArray(''), "'' is not an array");
         Assert.isFalse(Lang.isArray(undefined), "undefined is not an array");
-
-        Assert.isTrue(Lang.isArray(xframe.arr), "Cross frame array failure");
-        Assert.isFalse(Lang.isArray(xframe.far), "Cross frame fake array failure");
-        Assert.isFalse(Lang.isArray(xframe.obj), "Cross frame object failure");
-        Assert.isFalse(Lang.isArray(xframe.fun), "Cross frame function failure");
-        Assert.isFalse(Lang.isArray(xframe.boo), "Cross frame boolean failure");
-        Assert.isFalse(Lang.isArray(xframe.str), "Cross frame string failure");
-        Assert.isFalse(Lang.isArray(xframe.nul), "Cross frame null failure");
-        Assert.isFalse(Lang.isArray(xframe.und), "Cross frame undefined failure");
 
         if (Array.isArray) {
             Assert.areSame(Array.isArray, Lang.isArray, 'Lang.isArray() should use native Array.isArray() when available');
@@ -75,15 +71,6 @@ suite.add(new Y.Test.Case({
     test_is_function: function() {
         Assert.isTrue(Lang.isFunction(function(){}), "a function is a function");
         Assert.isFalse(Lang.isFunction({foo: "bar"}), "an object is not a function");
-    },
-    test_is_function_dom: function() {
-        Assert.isTrue(Lang.isFunction(xframe.fun), "Cross frame function failure");
-        Assert.isFalse(Lang.isFunction(xframe.arr), "Cross frame array failure");
-        Assert.isFalse(Lang.isFunction(xframe.obj), "Cross frame object failure");
-        Assert.isFalse(Lang.isFunction(xframe.boo), "Cross frame boolean failure");
-        Assert.isFalse(Lang.isFunction(xframe.str), "Cross frame string failure");
-        Assert.isFalse(Lang.isFunction(xframe.nul), "Cross frame null failure");
-        Assert.isFalse(Lang.isFunction(xframe.und), "Cross frame undefined failure");
     },
 
     test_is_null: function() {
@@ -107,15 +94,6 @@ suite.add(new Y.Test.Case({
         Assert.isFalse(Lang.isObject(true), "boolean values are not objects");
         Assert.isFalse(Lang.isObject("{}"), "strings are not objects");
         Assert.isFalse(Lang.isObject(null), "null should return false even though it technically is an object");
-    },
-    test_is_object_dom: function() {
-        Assert.isTrue(Lang.isObject(xframe.obj), "Cross frame object failure");
-        Assert.isTrue(Lang.isObject(xframe.fun), "Cross frame function failure");
-        Assert.isTrue(Lang.isObject(xframe.arr), "Cross frame array failure");
-        Assert.isFalse(Lang.isObject(xframe.boo), "Cross frame boolean failure");
-        Assert.isFalse(Lang.isObject(xframe.str), "Cross frame string failure");
-        Assert.isFalse(Lang.isObject(xframe.nul), "Cross frame null failure");
-        Assert.isFalse(Lang.isObject(xframe.und), "Cross frame undefined failure");
     },
 
     test_is_string: function() {
@@ -174,10 +152,6 @@ suite.add(new Y.Test.Case({
 
         var badDateObj = new Date('junk');
         Assert.isFalse(Lang.isDate(badDateObj), "A date object containing and invalid date should be false.");
-    },
-    test_is_date_dom: function() {
-        Assert.isFalse(Lang.isDate(xframe.fun), "Cross frame function should be false");
-        Assert.isTrue(Lang.isDate(xframe.dat), "Cross frame date should be true");
     },
 
     test_now: function () {

--- a/src/yui/tests/unit/assets/lang-xframe-test.js
+++ b/src/yui/tests/unit/assets/lang-xframe-test.js
@@ -1,0 +1,63 @@
+YUI.add('lang-xframe-test', function (Y) {
+
+var Assert = Y.Assert,
+    Lang   = Y.Lang,
+
+    suite = new Y.Test.Suite('YUI: Lang - CrossFrame');
+
+suite.add(new Y.Test.Case({
+
+    name: 'Lang Cross Frame Tests',
+
+    "async:init": function() {
+
+        var startTests = this.callback();
+
+        YUI.Env._StartFrameTests = function() {
+            startTests();
+        };
+
+        Y.one('body').append('<iframe name="xframe" id="xframe" src="assets/xframe.html" style="visibility: hidden;"></iframe>');
+    },
+
+    test_is_array_xframe: function() {
+        Assert.isTrue(Lang.isArray(xframe.arr), "Cross frame array failure");
+        Assert.isFalse(Lang.isArray(xframe.far), "Cross frame fake array failure");
+        Assert.isFalse(Lang.isArray(xframe.obj), "Cross frame object failure");
+        Assert.isFalse(Lang.isArray(xframe.fun), "Cross frame function failure");
+        Assert.isFalse(Lang.isArray(xframe.boo), "Cross frame boolean failure");
+        Assert.isFalse(Lang.isArray(xframe.str), "Cross frame string failure");
+        Assert.isFalse(Lang.isArray(xframe.nul), "Cross frame null failure");
+        Assert.isFalse(Lang.isArray(xframe.und), "Cross frame undefined failure");
+
+    },
+
+    test_is_function_xframe: function() {
+        Assert.isTrue(Lang.isFunction(xframe.fun), "Cross frame function failure");
+        Assert.isFalse(Lang.isFunction(xframe.arr), "Cross frame array failure");
+        Assert.isFalse(Lang.isFunction(xframe.obj), "Cross frame object failure");
+        Assert.isFalse(Lang.isFunction(xframe.boo), "Cross frame boolean failure");
+        Assert.isFalse(Lang.isFunction(xframe.str), "Cross frame string failure");
+        Assert.isFalse(Lang.isFunction(xframe.nul), "Cross frame null failure");
+        Assert.isFalse(Lang.isFunction(xframe.und), "Cross frame undefined failure");
+    },
+
+    test_is_object_xframe: function() {
+        Assert.isTrue(Lang.isObject(xframe.obj), "Cross frame object failure");
+        Assert.isTrue(Lang.isObject(xframe.fun), "Cross frame function failure");
+        Assert.isTrue(Lang.isObject(xframe.arr), "Cross frame array failure");
+        Assert.isFalse(Lang.isObject(xframe.boo), "Cross frame boolean failure");
+        Assert.isFalse(Lang.isObject(xframe.str), "Cross frame string failure");
+        Assert.isFalse(Lang.isObject(xframe.nul), "Cross frame null failure");
+        Assert.isFalse(Lang.isObject(xframe.und), "Cross frame undefined failure");
+    },
+
+    test_is_date_xframe: function() {
+        Assert.isFalse(Lang.isDate(xframe.fun), "Cross frame function should be false");
+        Assert.isTrue(Lang.isDate(xframe.dat), "Cross frame date should be true");
+    }
+}));
+
+Y.Test.Runner.add(suite);
+
+}, '@VERSION@', {requires: ['test']});

--- a/src/yui/tests/unit/assets/xframe.html
+++ b/src/yui/tests/unit/assets/xframe.html
@@ -3,12 +3,13 @@
 <head>
 <title>xframe tester</title>
 <script type="text/javascript">
+
     function FakeArray() {
         // ok, if we put the index in the prototype we could fool
         // YAHOO.lang.isArray as long as the index is never
         // updated.  This isn't likely to happen unless someone
         // is trying very hard to break it.
-        this.index=0; 
+        this.index=0;
     }
 
     FakeArray.prototype.splice = function() {
@@ -26,12 +27,25 @@
         nul = null,
         el  = document.createElement('div'),
         und;
-        window.onload = function() {
-            window._xframeLoaded = true;
-        };
 </script>
 </head>
 <body>
 <h1></h1>
+
+<script type="text/javascript">
+window.onload = function() {
+
+    // Try and avoid intermittent failures in IE, when running through
+    // YETI, under load, by having the child iframe tell the parent when it's
+    // ready, as opposed to having the parent check the child.
+
+    // In past lives, I've seen IE think an iframe is ready onload, when it's
+    // not, and accessing stuff from the parent through contentWindow fails.
+
+    setTimeout(function() {
+        window.parent.YUI.Env._StartFrameTests();
+    }, 500);
+};
+</script>
 </body>
 </html>

--- a/src/yui/tests/unit/coverage.html
+++ b/src/yui/tests/unit/coverage.html
@@ -14,14 +14,10 @@
 </div>
 
 <span id="test"></span>
-
-<iframe name="xframe" id="xframe" src="assets/xframe.html" style="visibility: hidden;"></iframe>
-
-
 <script>
 var YUI = {};
 </script>
-<!-- This is the main test file, notice it's using the `yui-base` seed file 
+<!-- This is the main test file, notice it's using the `yui-base` seed file
 without Loader on the page, so Loader is fetched before tests are executed. -->
 <script type="text/javascript" src="../../../../build/yui-core/yui-core-coverage.js"></script>
 <script type="text/javascript" src="../../../../build/get/get.js"></script>
@@ -64,7 +60,7 @@ var YUI_config = {
 YUI({
     coverage: [ 'yui' ],
     allowRollup: false,
-    logExclude: {Dom: true, Selector: true, Node: true, attribute: true, base: true, event: true, widget: true },    
+    logExclude: {Dom: true, Selector: true, Node: true, attribute: true, base: true, event: true, widget: true },
     filter: YUI_config.gfilter,
     modules: {
         'array-test': {
@@ -78,7 +74,18 @@ YUI({
         'lang-test': {
             fullpath: './assets/lang-test.js',
             requires: ['test']
-        },        
+        },
+        'lang-xframe-test' : {
+            fullpath: './assets/lang-xframe-test.js',
+            condition: {
+                name : 'lang-xframe-test',
+                trigger : 'lang-test',
+                test : function(Y) {
+                    return !(Y.UA.nodejs);
+                }
+            },
+            requires: ['test']
+        },
         'seed-tests': {
             fullpath: './assets/seed-tests.js',
             requires: [ 'test']
@@ -113,29 +120,14 @@ YUI({
             fullpath: './assets/ua-tests.js',
             requires: [ 'ua-data', 'ua-yui-data', 'test' ]
         }
-        
+
     }
 }).use('ua-tests', 'seed-tests', 'core-tests', 'config-test', 'later-test', 'namespace-test', 'array-test', 'object-test', 'lang-test', 'test-console', 'test', function(Y) {
     new Y.Test.Console().render('#log');
 
     //This is a YUITest hack to rename this test for reporting
     Y.Test.Runner.setName('YUI: Coverage');
-    if (window && window.$yetify) {
-        var timer,
-            check = function() {
-                var f = document.getElementById('xframe');
-                if (f && f.contentWindow && f.contentWindow._xframeLoaded) {
-                    clearInterval(timer);
-                    Y.Test.Runner.run();
-                    return true;
-                }
-                return false;
-            };
-
-        timer = setInterval(check, 100);
-    } else {
-        Y.Test.Runner.run();
-    }
+    Y.Test.Runner.run();
 });
 
 </script>

--- a/src/yui/tests/unit/index-static.html
+++ b/src/yui/tests/unit/index-static.html
@@ -15,13 +15,10 @@
 
 <span id="test"></span>
 
-<iframe name="xframe" id="xframe" src="assets/xframe.html" style="visibility: hidden;"></iframe>
-
-
 <script>
 var YUI = {};
 </script>
-<!-- This is the main test file, notice it's using the `yui-base` seed file 
+<!-- This is the main test file, notice it's using the `yui-base` seed file
 without Loader on the page, so Loader is fetched before tests are executed. -->
 <script type="text/javascript" src="../../../../build/yui-core/yui-core.js"></script>
 <script type="text/javascript" src="../../../../build/get/get.js"></script>
@@ -62,7 +59,7 @@ var TestName = 'YUI: All';
 
 YUI({
     allowRollup: false,
-    logExclude: {Dom: true, Selector: true, Node: true, attribute: true, base: true, event: true, widget: true },    
+    logExclude: {Dom: true, Selector: true, Node: true, attribute: true, base: true, event: true, widget: true },
     filter: YUI_config.gfilter,
     modules: {
         'array-test': {
@@ -76,7 +73,18 @@ YUI({
         'lang-test': {
             fullpath: './assets/lang-test.js',
             requires: ['test']
-        },        
+        },
+        'lang-xframe-test' : {
+            fullpath: './assets/lang-xframe-test.js',
+            condition: {
+                name : 'lang-xframe-test',
+                trigger : 'lang-test',
+                test : function(Y) {
+                    return !(Y.UA.nodejs);
+                }
+            },
+            requires: ['test']
+        },
         'seed-tests': {
             fullpath: './assets/seed-tests.js',
             requires: [ 'test']
@@ -111,28 +119,12 @@ YUI({
             fullpath: './assets/ua-tests.js',
             requires: [ 'ua-data', 'ua-yui-data', 'test' ]
         }
-        
+
     }
 }).use('ua-tests', 'seed-tests', 'core-tests', 'config-test', 'later-test', 'namespace-test', 'array-test', 'object-test', 'lang-test', 'test-console', 'test', function(Y) {
     new Y.Test.Console().render('#log');
-    
     Y.Test.Runner.setName(TestName);
-    if (window && window.$yetify) {
-        var timer,
-            check = function() {
-                var f = document.getElementById('xframe');
-                if (f && f.contentWindow && f.contentWindow._xframeLoaded) {
-                    clearInterval(timer);
-                    Y.Test.Runner.run();
-                    return true;
-                }
-                return false;
-            };
-
-        timer = setInterval(check, 100);
-    } else {
-        Y.Test.Runner.run();
-    }
+    Y.Test.Runner.run();
 });
 
 </script>

--- a/src/yui/tests/unit/lang.html
+++ b/src/yui/tests/unit/lang.html
@@ -7,7 +7,6 @@
 <body class="yui3-skin-sam">
 
 <div id="log"></div>
-<iframe name="xframe" id="xframe" src="assets/xframe.html" style="visibility: hidden;"></iframe>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -18,30 +17,24 @@ var Y = YUI({
         'lang-test': {
             fullpath: './assets/lang-test.js',
             requires: ['test']
+        },
+        'lang-xframe-test' : {
+            fullpath: './assets/lang-xframe-test.js',
+            condition: {
+                name : 'lang-xframe-test',
+                trigger : 'lang-test',
+                test : function(Y) {
+                    return !(Y.UA.nodejs);
+                }
+            },
+            requires: ['test']
         }
     }
 }).use('lang-test', 'test-console', function (Y) {
+
     new Y.Test.Console().render('#log');
-
-    if (window && window.$yetify) {
-        var timer,
-            check = function() {
-                var f = document.getElementById('xframe');
-                if (f && f.contentWindow && f.contentWindow._xframeLoaded) {
-                    clearInterval(timer);
-                    Y.Test.Runner.run();
-                    return true;
-                }
-                return false;
-            };
-
-        timer = setInterval(check, 100);
-    } else {
-        Y.Test.Runner.run();
-    }
-
+    Y.Test.Runner.run();
 });
 </script>
-
 </body>
 </html>


### PR DESCRIPTION
BACKGROUND

When running the cross frame lang tests on IE, under Yeti, that too,
only in a CI context (more server load, at the end of running all tests?) we 
intermittently see failures for these cross-frame tests.

I haven't been able to repro them either running them manually,
or through Yeti locally.

My gut feel is that we're trying to do stuff with the iframe when it's not
fully ready. In my old life, I remember hitting scenarios where even
though the frame's onload fired in the iframe, and the parent could get to
contentWindow, it wouldn't be completely robust when accesing contentWindow
properties (specifically for IE).

FIX

The fix aims to reverse responsibilities. Have the frame call the parent
when ready, as opposed to the parent check something on the frame.

In addition to the attempted fix the commit also does some cleanup:

1). It breaks out the xframe tests into a separate suite, which is not
loaded at all in nodejs (instead of ignoring the whole set of tests
individually)

2). It uses YUITest's async:init support to set up the iframe, so that
everything is encapsulated in the lang-xframe-test.js file, and we
don't need to repeat stuff across the various html file flavors.

NOTE: I didn't find any docs for the async:init stuff in the landing guide,
so had to look through the code - but it seems to be consciously/formally
supported.

So, regardless of whether or not it fixes the intermittent issue, it seems like it's a cleaner test setup in general.

**NOTE**

This is not ready to commit yet (see testing), and **doesn't need to be merged for 3.10.0** [ this commit is just trying to clean up test flakiness tech debt in general - the issue has been around forever ].

I wanted to get this out there, for an initial look, and I needed @davglass to see if the changes to the other various flavored files [ index-full.html, index.html, index-static.html, coverage.html etc. ] are valid/required.

TESTING

I've tested `src/yui/tests/unit/lang.html` through yeti, in FF, Chrome, Safari, IE6, IE7, IE8, IE9, iOS and it all looks good.

However when running all the tests in `src/yui/tests/unit/` through Yeti, IE9 seems to be hitting exceptions in Yeti code (inject.js) [ yeti 0.2.21 ]. Now that I type this out, that may be the flakiness (??). It happens in dev-3.x also, so seems to be unrelated to these changes.

Running them manually, everything passes in IE9

<!---
@huboard:{"order":2.3984375}
-->
