### PR TITLE
fix #2533227 - Datatable sort descending is actually ascending

### DIFF
--- a/src/datatable/js/sort.js
+++ b/src/datatable/js/sort.js
@@ -813,7 +813,7 @@ Y.mix(Sortable.prototype, {
         for (i = 0, len = columns.length; i < len; ++i) {
             col  = columns[i];
             node = this._theadNode.one('#' + col.id);
-            desc = col.sortDir === -1;
+            desc = col.sortDir === 1;
 
             if (node) {
                 liner = node.one('.' + linerClass);


### PR DESCRIPTION
Sorry for the pull request to the wrong branch. I accidentally before the base-branch had a chance to update >.<

<!---
@huboard:{"order":710.125}
-->
