### PR TITLE
Fixing event-custom-base YArray.indexOf('subs ~ null'...) case.

### DIFF
--- a/src/event-custom/js/event-custom.js
+++ b/src/event-custom/js/event-custom.js
@@ -790,10 +790,11 @@ Y.CustomEvent.prototype = {
 
         if (!subs) {
             subs = (when === AFTER) ? this._afters : this._subscribers;
-            i = YArray.indexOf(subs, s, 0);
         }
 
         if (subs) {
+            i = YArray.indexOf(subs, s, 0);
+
             if (s && subs[i] === s) {
                 subs.splice(i, 1);
 


### PR DESCRIPTION
After upgrading to YUI 3.10.0 I found that 'subs' in the code could be null and therefore the YArray.indexOf fails in some cases.

This seems logical as the _afters and _subscribers arrays are no longer initialized.
