### PR TITLE
Fixed issues due to Y.DOM being undefined when event-base was attached in rare use cases

### DIFF
--- a/src/event/js/event-dom.js
+++ b/src/event/js/event-dom.js
@@ -20,8 +20,7 @@
 Y.Env.evt.dom_wrappers = {};
 Y.Env.evt.dom_map = {};
 
-var YDOM = Y.DOM,
-    _eventenv = Y.Env.evt,
+var _eventenv = Y.Env.evt,
     config = Y.config,
     win = config.win,
     add = YUI.Env.add,
@@ -44,7 +43,7 @@ var YDOM = Y.DOM,
     shouldIterate = function(o) {
         try {
             // TODO: See if there's a more performant way to return true early on this, for the common case
-            return (o && typeof o !== "string" && Y.Lang.isNumber(o.length) && !o.tagName && !YDOM.isWindow(o));
+            return (o && typeof o !== "string" && Y.Lang.isNumber(o.length) && !o.tagName && !Y.DOM.isWindow(o));
         } catch(ex) {
             Y.log("collection check failure", "warn", "event");
             return false;
@@ -414,7 +413,7 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
                 // oEl = (compat) ? Y.DOM.byId(el) : Y.Selector.query(el);
 
                 if (compat) {
-                    oEl = YDOM.byId(el);
+                    oEl = Y.DOM.byId(el);
                 } else {
 
                     oEl = Y.Selector.query(el);
@@ -531,7 +530,7 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
 
                 // el = (compat) ? Y.DOM.byId(el) : Y.all(el);
                 if (compat) {
-                    el = YDOM.byId(el);
+                    el = Y.DOM.byId(el);
                 } else {
                     el = Y.Selector.query(el);
                     l = el.length;
@@ -605,7 +604,7 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
          * @static
          */
         generateId: function(el) {
-            return YDOM.generateID(el);
+            return Y.DOM.generateID(el);
         },
 
         /**
@@ -715,7 +714,7 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
                 if (item && !item.checkReady) {
 
                     // el = (item.compat) ? Y.DOM.byId(item.id) : Y.one(item.id);
-                    el = (item.compat) ? YDOM.byId(item.id) : Y.Selector.query(item.id, null, true);
+                    el = (item.compat) ? Y.DOM.byId(item.id) : Y.Selector.query(item.id, null, true);
 
                     if (el) {
                         // Y.log('avail: ' + el);
@@ -734,7 +733,7 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
                 if (item && item.checkReady) {
 
                     // el = (item.compat) ? Y.DOM.byId(item.id) : Y.one(item.id);
-                    el = (item.compat) ? YDOM.byId(item.id) : Y.Selector.query(item.id, null, true);
+                    el = (item.compat) ? Y.DOM.byId(item.id) : Y.Selector.query(item.id, null, true);
 
                     if (el) {
                         // The element is available, but not necessarily ready

--- a/src/event/tests/unit/assets/testA.js
+++ b/src/event/tests/unit/assets/testA.js
@@ -1,0 +1,2 @@
+YUI.add('testA', function(Y) {
+}, '0.0.1', {requires: ['testB']});

--- a/src/event/tests/unit/assets/testB.js
+++ b/src/event/tests/unit/assets/testB.js
@@ -1,0 +1,2 @@
+YUI.add('testB', function(Y) {
+}, '0.0.1', {requires: ['node-base']});

--- a/src/event/tests/unit/dom.html
+++ b/src/event/tests/unit/dom.html
@@ -620,7 +620,7 @@
                     Y.on("load", function() {
                         var thisWin = this;
 
-                        // setTimeout to make sure we don't hit resume w/o wait, because we don't have absolute control over whether this 
+                        // setTimeout to make sure we don't hit resume w/o wait, because we don't have absolute control over whether this
                         // fires async or sync - based on whether or not the window.load event has fired already.
 
                         setTimeout(function() {
@@ -656,10 +656,60 @@
                             });
                         }
                     }, null, true);
-    
+
                     Y.later(25, {}, function () {
                         Y.one('#clickcontainer')
                             .append('<p id="infinite-poll">THIS SHOULD NOT BE LEFT OVER</p>');
+                    });
+
+                    test.wait();
+                },
+
+                test_nodelist_on_with_custom_deps: function() {
+
+                    // See: http://yuilibrary.com/projects/yui3/ticket/2533242
+
+                    // NOTE: To reproduce the bug, you need to avoid having
+                    // 'requires' in the loader meta-data for testA, testB
+                    // below [which is not a good idea, but still a bug]
+
+                    var config = {
+                        groups: {
+                            'local-modules': {
+                                base: './',
+                                modules: {
+                                    'testA': {
+                                        path: 'assets/testA.js'
+                                    },
+                                    'testB': {
+                                        path: 'assets/testB.js'
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    test = this,
+                    actualClicked = [],
+
+                    assertResults = function() {
+                        Y.ArrayAssert.itemsAreEqual(["clicker1", "clicker2"], actualClicked);
+                    }
+
+                    // Create a YUI instance
+                    YUI(config).use('node-base', 'testA', function(Y2) {
+
+                        function onClick(e) {
+                            actualClicked.push(e.target.get("id"));
+                        }
+
+                        var nodelist = Y2.all(".clickers");
+                        nodelist.on("click", onClick);
+
+                        Y.Event.simulate(document.getElementById('clicker1'), 'click');
+                        Y.Event.simulate(document.getElementById('clicker2'), 'click');
+
+                        test.resume(assertResults);
+
                     });
 
                     test.wait();


### PR DESCRIPTION
Fixes #2533242

The `YDOM = Y.DOM` alias we added in 3.7.3 would end up being undefined
in certain custom module dependency use cases, which would result in
`nodelist.on()` failing to attach listners.

In order to bring out the issue, all the following need to apply:
1. Custom modules with deeper node-base dependency.
2. node-base repeated in `use` statement.
3. Module dependencies for custom modules not provided to YUI() instance config (that is, not available to loader).

This is not the root fix. The root fix is probably in loader somewhere, but given the catch-22 complexity between node-base and event-base attach order, and the rarity of the use case, this seemed like the better, less fragile way to go.

Confirmed that the unit test added passes with this commit, and fails starting with 3.7.3, when this issue was introduced.

<!---
@huboard:{"order":0.599609375}
-->
