### PR TITLE
Fixed doc for return of method inRegion

### DIFF
--- a/src/node/js/node-region.js
+++ b/src/node/js/node-region.js
@@ -64,7 +64,7 @@ Y.Node.prototype.intersect = function(node2, altRegion) {
  * @param {Node|Object} node2 The node or region to compare with.
  * @param {Boolean} all Whether or not all of the node must be in the region.
  * @param {Object} altRegion An alternate region to use (rather than this node's).
- * @return {Object} An object representing the intersection of the regions.
+ * @return {Boolean} True if in region, false if not.
  */
 Y.Node.prototype.inRegion = function(node2, all, altRegion) {
     var node1 = Y.Node.getDOMNode(this);


### PR DESCRIPTION
The current API doc was copied from method intersect and not edited.
The value is the same as for DOM's method inRegion.
