### PR TITLE
Remove unused _hasSubs and _hasAfters properties

### DIFF
--- a/src/event-custom/js/event-custom.js
+++ b/src/event-custom/js/event-custom.js
@@ -451,13 +451,11 @@ Y.CustomEvent.prototype = {
         if (when === AFTER) {
             if (!this._afters) {
                 this._afters = [];
-                this._hasAfters = true;
             }
             this._afters.push(s);
         } else {
             if (!this._subscribers) {
                 this._subscribers = [];
-                this._hasSubs = true;
             }
             this._subscribers.push(s);
         }
@@ -797,14 +795,6 @@ Y.CustomEvent.prototype = {
 
             if (s && subs[i] === s) {
                 subs.splice(i, 1);
-
-                if (subs.length === 0) {
-                    if (when === AFTER) {
-                        this._hasAfters = false;
-                    } else {
-                        this._hasSubs = false;
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
They are not referenced in the library code, nor did they have API docs.

@sdesai, if you know a reason for their existence, close this PR and I'll file a ticket to have them documented.
