### PR TITLE
yui: Fix duplicated YUIDoc tag

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -2075,8 +2075,8 @@ relying on ES5 functionality, even when ES5 functionality is available.
 
 /**
 Delay the `use` callback until a specific event has passed (`load`, `domready`, `contentready` or `available`)
-@property delayUntil
-@type String|Object
+
+@property {Object|String} delayUntil
 @since 3.6.0
 @example
 
@@ -2100,6 +2100,4 @@ Or you can delay until a node is available (with `available` or `contentready`):
         // available in the DOM.
     });
 
-@property {Object|String} delayUntil
-@since 3.6.0
 **/


### PR DESCRIPTION
The YUIDoc tag for `delayUntil` seems to duplicate. I guess that output HTML is incorrect because of this.

See: http://yuilibrary.com/yui/docs/api/classes/config.html
