### PR TITLE
Add test and HISTORY.md entry for patched `once('*:foo', fn)` #676

### DIFF
--- a/src/event-custom/HISTORY.md
+++ b/src/event-custom/HISTORY.md
@@ -5,6 +5,8 @@ Custom Event Infrastructure Change History
 ------
 
 * Fixed issue with facade carrying stale data for the "no subscriber" case.
+* Fixed regression where `once()` and `onceAfter()` subscriptions using the
+  `*` prefix threw a TypeError [#676]. `target.once('*:fooChange', callback)`
 
 3.10.0
 ------

--- a/src/event-custom/tests/unit/assets/event-custom-complex-tests.js
+++ b/src/event-custom/tests/unit/assets/event-custom-complex-tests.js
@@ -1329,6 +1329,17 @@ YUI.add("event-custom-complex-tests", function(Y) {
             Y.Assert.areEqual(2, heard);
 
             node.remove(true);
+        },
+
+        // Ticket #676 - this was throwing an error in 3.10.0
+        "test sibling once() subscriptions - once('*:type')": function () {
+            var target = new Y.EventTarget({ emitFacade: true });
+
+            target.once('*:foo', function (e) {
+                Y.Assert.isTrue(true);
+            });
+
+            target.fire('x:foo');
         }
 
     }));


### PR DESCRIPTION
Added a test for `once()`. I didn't bother adding one for `onceAfter()`.
