### PR TITLE
Stop unconditionally setting the z-index on sync

### DIFF
--- a/src/widget-modality/js/Widget-Modality.js
+++ b/src/widget-modality/js/Widget-Modality.js
@@ -262,7 +262,6 @@ var WIDGET       = 'widget',
             //var host = this.get(HOST);
 
             this._uiSetHostVisibleModal(this.get(VISIBLE));
-            this._uiSetHostZIndexModal(this.get(Z_INDEX));
 
         },
 

--- a/src/widget-modality/tests/unit/assets/widget-modality-test.js
+++ b/src/widget-modality/tests/unit/assets/widget-modality-test.js
@@ -70,6 +70,36 @@ suite.add(new Y.Test.Case({
 
         modal1.destroy();
         modal2.destroy();
+    },
+
+    'WidgetModality should not set mask node zindex to its own when hidden': function () {
+        var modal1, modal2, StackedTestWidget;
+
+        StackedTestWidget = Y.Base.create('stackedTestWidget', Y.Widget, [Y.WidgetModality], {}, {
+                ATTRS: {
+                    zIndex: {value : 0}
+                }});
+
+        modal1 = new StackedTestWidget({
+            bodyContent: 'Content',
+            zIndex : 7,
+            modal : true,
+            visible : true,
+            render: '#test'
+        });
+
+        // A hidden modal instantiated after a visible modal shouldn't reset the mask z-index. It once did.
+        modal2 = new StackedTestWidget({
+            zIndex : 8,
+            modal: true,
+            visible : false,
+            render: '#test'
+        });
+
+        Assert.areSame('7', modal1.get('maskNode').getStyle('zIndex'), 'widget mask got wrong zIndex.');
+
+        modal1.destroy();
+        modal2.destroy();
     }
 }));
 


### PR DESCRIPTION
This causes a bug where hidden widgets set the z-index of the mask
to their own z-index. The mask z-index is anyway correctly set
previously in _uiSetHostVisibleModal.

You can test this bug manually with this code:

``` html
<div id="panel1">
</div>
<div id="panel2">
</div>

<script type="text/javascript">
YUI().use('panel', function (Y) {

        panel1 = new Y.Panel({
            bodyContent: 'This panel opens first, sets the mask zindex correctly, but gets hidden by the second panel rednering',
            width      : 400,
            zIndex     : 6,
            modal      : true,
            visible    : true,
            render     : '#panel1'
        });
        panel2 = new Y.Panel({
            bodyContent: 'This panel, even though it is hidden, sets the mask index, covering panel1',
            zIndex     : 7,
            modal      : true,
            visible    : false,
            render     : '#panel2'
        });

});

</script>
```
