### PR TITLE
Fix glob option of .yeti.json

### DIFF
--- a/.yeti.json
+++ b/.yeti.json
@@ -1,4 +1,4 @@
 {
     "basedir": ".",
-    "glob": "**/tests/unit/*.html"
+    "glob": "src/*/tests/unit/*.html"
 }


### PR DESCRIPTION
It is now not use Globstar if you are also using the Globstar, because it would match up to file under `node_modules` directory.

```
[okuryu.local](yui3@dev-3.x)$ yeti
Found 297 files to test.
  Agent connected: Chrome (26.0.1410.65) / Mac OS from 127.0.0.1
✓ Testing started on Chrome (26.0.1410.65) / Mac OS
✗ Script error: Uncaught ReferenceError: YUI is not defined
  URL: node_modules/yogi/defaults/tests/unit/index.html
  Line: 1
  User-Agent: Chrome (26.0.1410.65) / Mac OS
✗ Script error: Uncaught ReferenceError: YUI is not defined
  URL: node_modules/yogi/defaults/tests/unit/index.html
  Line: 13
  User-Agent: Chrome (26.0.1410.65) / Mac OS
```

So I would like to push this against `dev-master` branch because this doesn't affect the source code and test code.

/cc @reid
