### PR TITLE
Add Tree.Node#depth()

### DIFF
--- a/src/tree/HISTORY.md
+++ b/src/tree/HISTORY.md
@@ -4,6 +4,9 @@ Tree Change History
 @VERSION@
 ------
 
+* Added `Tree.Node#depth()`, which returns the depth of the node, starting at 0
+  for the root node. [Ryan Grove]
+
 * The `Tree#createNode()`, `Tree#insertNode()`, and `Tree#traverseNode()`
   methods now throw or log informative error messages when given a destroyed
   node instead of failing cryptically (or succeeding when they shouldn't).

--- a/src/tree/js/tree-node.js
+++ b/src/tree/js/tree-node.js
@@ -193,6 +193,32 @@ TreeNode.prototype = {
     },
 
     /**
+    Returns this node's depth.
+
+    The root node of a tree always has a depth of 0. A child of the root has a
+    depth of 1, a child of that child will have a depth of 2, and so on.
+
+    @method depth
+    @return {Number} This node's depth.
+    @since @SINCE@
+    **/
+    depth: function () {
+        if (this.isRoot()) {
+            return 0;
+        }
+
+        var depth  = 0,
+            parent = this.parent;
+
+        while (parent) {
+            depth += 1;
+            parent = parent.parent;
+        }
+
+        return depth;
+    },
+
+    /**
     Removes all children from this node. The removed children will still be
     reusable unless the `destroy` option is truthy.
 

--- a/src/tree/tests/unit/assets/tree-test.js
+++ b/src/tree/tests/unit/assets/tree-test.js
@@ -1156,6 +1156,26 @@ nodeSuite.add(new Y.Test.Case({
         Mock.verify(mock);
     },
 
+    'depth() should return the depth of a node': function () {
+        var one   = this.tree.rootNode.append({}),
+            two   = one.append({}),
+            three = two.append({}),
+            four  = three.append({});
+
+        Assert.areSame(1, one.depth(), 'node one should have a depth of 1');
+        Assert.areSame(2, two.depth(), 'node two should have a depth of 2');
+        Assert.areSame(3, three.depth(), 'node three should have a depth of 3');
+        Assert.areSame(4, four.depth(), 'node four should have a depth of 4');
+    },
+
+    'depth() should return 0 for the root node': function () {
+        Assert.areSame(0, this.tree.rootNode.depth());
+    },
+
+    'depth() should return 0 for an unattached node': function () {
+        Assert.areSame(0, this.tree.createNode().depth());
+    },
+
     'empty() should wrap Tree#emptyNode()': function () {
         var mock    = Mock(),
             options = {};


### PR DESCRIPTION
Tiny last-minute feature!

`Tree.Node#depth()` returns the depth of a node in the tree. The root node is 0. A child of the root is 1. A child of a child is 2, and so on. Unattached nodes have a depth of 0.
