### PR TITLE
fix flaky test

### DIFF
--- a/src/yui/tests/unit/assets/core-tests.js
+++ b/src/yui/tests/unit/assets/core-tests.js
@@ -678,19 +678,17 @@ YUI.add('core-tests', function(Y) {
 
             test.wait();
         },
+        // This test does not require a `wait()` and `resume()` because it is
+        // completely synchronous (i.e., `load` has already fired and `node`
+        // has already loaded).
         'test: window.onload delay': function() {
-            var test = this,
-            Assert = Y.Assert;
+            var Assert = Y.Assert;
 
             YUI({
                 delayUntil: 'load'
-            }).use('dd-drag', function(Y, status) {
-                test.resume(function() {
-                    Assert.areSame('load', status.delayUntil, 'load did not trigger this callback');
-                });
+            }).use('node', function(Y, status) {
+                Assert.areSame('load', status.delayUntil, 'load did not trigger this callback');
             });
-
-            test.wait();
         },
         'test: available delay': function() {
             var test = this,
@@ -709,8 +707,8 @@ YUI.add('core-tests', function(Y) {
                     event: 'available',
                     args: '#foobar'
                 }
-            }).use('dd-drop', function(Y, status) {
-              test.resume(function() {
+            }).use('node', function(Y, status) {
+                test.resume(function() {
                     Assert.isNotNull(Y.one('#foobar'), 'Failed to find trigger #foobar');
                     Assert.areSame('available', status.delayUntil, 'available did not trigger this callback');
                 });
@@ -735,8 +733,8 @@ YUI.add('core-tests', function(Y) {
                     event: 'contentready',
                     args: '#foobar2'
                 }
-            }).use('dd-drop', function(Y, status) {
-              test.resume(function() {
+            }).use('node', function(Y, status) {
+                test.resume(function() {
                     Assert.isNotNull(Y.one('#foobar2'), 'Failed to find trigger #foobar2');
                     Assert.areSame('contentready', status.delayUntil, 'contentready did not trigger this callback');
                 });

--- a/src/yui/tests/unit/coverage.html
+++ b/src/yui/tests/unit/coverage.html
@@ -85,7 +85,7 @@ YUI({
         },
         'core-tests': {
             fullpath: './assets/core-tests.js',
-            requires: [ 'classnamemanager']
+            requires: ['classnamemanager', 'node']
         },
 
         'config-test': {

--- a/src/yui/tests/unit/index-full.html
+++ b/src/yui/tests/unit/index-full.html
@@ -43,7 +43,7 @@ YUI({
         },
         'core-tests': {
             fullpath: './assets/core-tests.js',
-            requires: [ 'classnamemanager']
+            requires: ['classnamemanager', 'node']
         },
 
         'config-test': {

--- a/src/yui/tests/unit/index-loader.html
+++ b/src/yui/tests/unit/index-loader.html
@@ -43,7 +43,7 @@ YUI({
         },
         'core-tests': {
             fullpath: './assets/core-tests.js',
-            requires: [ 'classnamemanager']
+            requires: ['classnamemanager', 'node']
         },
 
         'config-test': {

--- a/src/yui/tests/unit/index-static.html
+++ b/src/yui/tests/unit/index-static.html
@@ -83,7 +83,7 @@ YUI({
         },
         'core-tests': {
             fullpath: './assets/core-tests.js',
-            requires: [ 'classnamemanager']
+            requires: ['classnamemanager', 'node']
         },
 
         'config-test': {

--- a/src/yui/tests/unit/index.html
+++ b/src/yui/tests/unit/index.html
@@ -54,7 +54,7 @@ YUI({
         },
         'core-tests': {
             fullpath: './assets/core-tests.js',
-            requires: [ 'classnamemanager']
+            requires: ['classnamemanager', 'node']
         },
 
         'config-test': {


### PR DESCRIPTION
Fix flaky tests that timeout by removing dynamic module dependencies in
favor of cached module dependencies.
