### PR TITLE
Removing hard-coded wait() value to address flaky test

### DIFF
--- a/src/transition/tests/unit/transition.html
+++ b/src/transition/tests/unit/transition.html
@@ -921,7 +921,7 @@ YUI({
                     }
                 });
 
-                test.wait(1000);
+                test.wait();
             },
 
             'should hide using the named toggle': function() {


### PR DESCRIPTION
Removing hard-coded wait() value to address flaky test. CI VMs seem to sometimes take longer than 1000ms for test to execute.

Verified locally that test takes 518ms to execute. CI VMs are likely taking longer than 1000ms for test to execute. Removing hard-coded wait() value to address test flakiness.
