### PR TITLE
Fixes subcookie example code.

### DIFF
--- a/src/cookie/docs/partials/cookie-subcookie-example-source.mustache
+++ b/src/cookie/docs/partials/cookie-subcookie-example-source.mustache
@@ -7,19 +7,18 @@ YUI().use('cookie', 'node', function (Y) {
         log = function(str) {
             results.append(str + '<br>');
         };
-    
+
+    //set subcookie values
+    Y.Cookie.setSub("example", "name", "Yahoo!");
+    Y.Cookie.setSub("example", "today", (new Date()).toString());
+    Y.Cookie.setSub("example", "count", Math.round(Math.random() * 30));
+
     //get subcookie values
     var name = Y.Cookie.getSub("example", "name");
     var today = Y.Cookie.getSub("example", "today", function (value) {
         return new Date(value);
     });
     var count = Y.Cookie.getSub("example", "count", Number);
-
-    //set subcookie values
-    Y.Cookie.setSub("example", "name", "Yahoo!");
-    Y.Cookie.setSub("example", "today", (new Date()).toString());
-    Y.Cookie.setSub("example", "count", Math.round(Math.random() * 30));
-    
     
     log("The subcookie 'name' is '" + name + "' (" + (typeof name) + ")");
     log("The subcookie 'today' is '" + today + "' (" + (typeof today) + ")");


### PR DESCRIPTION
Switched the getSub and the setSub lines of code so that the example will work on the first page load, when the cookies have yet to be set. @tripp 
