### PR TITLE
Adding missing HISTORY entry for JSON utility.

### DIFF
--- a/src/json/HISTORY.md
+++ b/src/json/HISTORY.md
@@ -4,9 +4,11 @@ JSON Utility Change History
 3.10.2
 ------
 
-* YUICompressor was unable to minify the json-parse code because it contained `eval`. 
-  It had inserted a placeholder `EVAL_TOKEN` which to allow minification, then used a post-minify script to replace `EVAL_TOKEN` with `eval`. 
-  This appears not to be necessary any more, and caused a problem with the 3.10.0 CDN deployed files and was removed.  [lsmith]
+* YUICompressor was unable to minify the json-parse code because it contained `eval`.
+  It had inserted a placeholder `EVAL_TOKEN` which to allow minification,
+  then used a post-minify script to replace `EVAL_TOKEN` with `eval`.
+  This appears not to be necessary any more, and caused a problem with the
+  3.10.0 CDN deployed files and was removed.  [lsmith]
 
 3.10.1
 ------


### PR DESCRIPTION
There was a code change in JSON that should have had a HISTORY.md entry. 
@ericf @lsmith - here's the update.
