### PR TITLE
Fixed a 3.10.2 regression, where attr change listeners subscribing with additional args, would see their args shifted if the attribute was set with options

### DIFF
--- a/src/attribute/HISTORY.md
+++ b/src/attribute/HISTORY.md
@@ -1,6 +1,17 @@
 Attribute Change History
 ========================
 
+@VERSION@
+------
+
+* Fixed regression introduced with the solution for setter opts, added in
+  3.10.2, for cases where user subscribed to attribute change events, with
+  additional arguments to be passed to the subscriber, for example: 
+
+    host.after("myattrChange", fn(e, custArg){}, context, custArgValue);
+    ...
+    host.set("myattr", 10, {src:"foo"});
+
 3.10.3
 ------
 

--- a/src/attribute/js/AttributeObservable.js
+++ b/src/attribute/js/AttributeObservable.js
@@ -134,7 +134,6 @@
             var host = this,
                 eventName = this._getFullType(attrName + CHANGE),
                 state = host._state,
-                hasOpts = false,
                 facade,
                 broadcast,
                 e;
@@ -163,7 +162,7 @@
 
             if (opts) {
                 facade = Y.merge(opts);
-                hasOpts = true;
+                facade._attrOpts = opts;
             } else {
                 facade = host._ATTR_E_FACADE;
             }
@@ -176,11 +175,7 @@
             facade.prevVal = currVal;
             facade.newVal = newVal;
 
-            if (hasOpts) {
-                host.fire(eventName, facade, opts);
-            } else {
-                host.fire(eventName, facade);
-            }
+            host.fire(eventName, facade);
         },
 
         /**
@@ -192,7 +187,12 @@
          */
         _defAttrChangeFn : function(e) {
 
-            if (!this._setAttrVal(e.attrName, e.subAttrName, e.prevVal, e.newVal, e.details[1])) {
+            var opts = e._attrOpts;
+            if (opts) {
+                delete e._attrOpts;
+            }
+
+            if (!this._setAttrVal(e.attrName, e.subAttrName, e.prevVal, e.newVal, opts)) {
                 // Prevent "after" listeners from being invoked since nothing changed.
                 e.stopImmediatePropagation();
 

--- a/src/attribute/tests/unit/assets/attribute-tests.js
+++ b/src/attribute/tests/unit/assets/attribute-tests.js
@@ -2103,6 +2103,43 @@ YUI.add('attribute-tests', function(Y) {
             Y.ObjectAssert.areEqual({bar:30}, actualOpts[3]);
             Y.Assert.areEqual(30, actualFacades[3].bar);
             Y.Assert.isFalse("foo" in actualFacades[3]);
+        },
+
+        testOptsWithSubscriberArgs : function() {
+
+            var h = this.createHost(),
+                onArgs,
+                afterArgs,
+                subscriberArgs = [];
+
+            h.addAttr("setterWithOpts", {
+                value: "X"
+            });
+
+            h.on("setterWithOptsChange", function() {
+                subscriberArgs.push(Y.Array(arguments));
+            }, {context:"on"}, {argsA:10}, {argsB:20});
+
+            h.after("setterWithOptsChange", function() {
+                subscriberArgs.push(Y.Array(arguments));
+            }, {context:"after"}, {argsA:30}, {argsB:40});
+
+            h.set("setterWithOpts", "A", {myopts:50});
+
+            onArgs = subscriberArgs[0];
+            afterArgs = subscriberArgs[1];
+
+            Y.Assert.areEqual(3, onArgs.length, "Expected 3 args to the on subscriber");
+            Y.Assert.isTrue(onArgs[0] instanceof Y.EventFacade, "on subscriber didn't get opts");
+            Y.Assert.areEqual(50, onArgs[0].myopts, "on subscriber didn't get opts");
+            Y.ObjectAssert.areEqual({argsA:10}, onArgs[1], "on subscriber didn't get first subscriber arg");
+            Y.ObjectAssert.areEqual({argsB:20}, onArgs[2], "on subscriber didn't get second subscriber arg");
+
+            Y.Assert.areEqual(3, afterArgs.length, "Expected 3 args to the after subscriber");
+            Y.Assert.isTrue(afterArgs[0] instanceof Y.EventFacade, "after subscriber didn't get opts");
+            Y.Assert.areEqual(50, afterArgs[0].myopts, "after subscriber didn't get opts");
+            Y.ObjectAssert.areEqual({argsA:30}, afterArgs[1], "after subscriber didn't get first subscriber arg");
+            Y.ObjectAssert.areEqual({argsB:40}, afterArgs[2], "after subscriber didn't get second subscriber arg");
         }
     };
 


### PR DESCRIPTION
For example, for the following use case (only):

```
foo.after("myAttrChange", function myListener(e, myCustomArg) {
   ...
}, context, myCustomArgValue);

foo.set("someAttribute", 20, myCustomOpts);
```

`myListener` would see `[e, myCustomOpts, myCustomArg]` instead of
`[e, myCustomArg]` for it's `arguments` list.

See: https://github.com/yui/yui3/issues/846
## Testing

Added new tests for the scenario.

_All_ library tests pass:
✔ [Total]: Passed: 10988 Failed: 0 Total: 11078 (ignored 90)

Also manually tested the node-menunav examples. These passed functional
tests, even with the older broken code.
