### PR TITLE
[#656] fix failing loader test on android 2.3.4

### DIFF
--- a/src/loader/tests/unit/assets/loader-tests.js
+++ b/src/loader/tests/unit/assets/loader-tests.js
@@ -1188,17 +1188,9 @@ YUI.add('loader-tests', function(Y) {
                         Assert.isFalse(node2.async, '#1 Async flag on node2 was set incorrectly');
                         Assert.isTrue(node3.async, '#1 Async flag on node3 was set incorrectly');
                     } else {
-                        //The async attribute is still
-                        if (Y.UA.ie && Y.UA.ie > 8 || Y.UA.opera) {
-                            Assert.isTrue(node3.async, '#2 Async flag on node3 was set incorrectly');
-                            Assert.isUndefined(node1.async, '#2 Async flag on node1 was set incorrectly');
-                            Assert.isUndefined(node2.async, '#2 Async flag on node2 was set incorrectly');
-                        } else {
-                            Assert.isNull(node1.getAttribute('async'), '#3 Async flag on node1 was set incorrectly');
-                            Assert.isNull(node2.getAttribute('async'), '#3 Async flag on node2 was set incorrectly');
-                            Assert.isNotNull(node3.getAttribute('async'), '#3 Async flag on node3 was set incorrectly');
-
-                        }
+                        Assert.isTrue(node3.async, '#2 Async flag on node3 was set incorrectly');
+                        Assert.isUndefined(node1.async, '#2 Async flag on node1 was set incorrectly');
+                        Assert.isUndefined(node2.async, '#2 Async flag on node2 was set incorrectly');
                     }
                 });
             });


### PR DESCRIPTION
Removed an unnecessary if-else fork when checking to see whether the `async`
configuration propagated to the DOM as expected.

Results of the investigation that support this change:
https://gist.github.com/ekashida/5762890
