### PR TITLE
Need to expose methods that calculate widget alignment coordinates

### DIFF
--- a/src/widget-position-align/HISTORY.md
+++ b/src/widget-position-align/HISTORY.md
@@ -4,7 +4,7 @@ Widget Position Align Change History
 @VERSION@
 ------
 
-* No changes.
+Exposed method that calculate widget alignment coordinates (_getAlignToXY).
 
 3.15.0
 ------

--- a/src/widget-position-align/js/Widget-PositionAlign.js
+++ b/src/widget-position-align/js/Widget-PositionAlign.js
@@ -328,52 +328,28 @@ PositionAlign.prototype = {
     // -- Protected Methods ----------------------------------------------------
 
     /**
-    Default setter for `center` Attribute changes. Sets up the appropriate
-    value, and passes it through the to the align attribute.
+    Returns coordinates realative to the `Node` alignment.
 
-    @method _setAlignCenter
-    @param {Boolean|Node} val The Attribute value being set.
-    @return {Boolean|Node} the value passed in.
-    @protected
-    **/
-    _setAlignCenter: function (val) {
-        if (val) {
-            this.set(ALIGN, {
-                node  : val === true ? null : val,
-                points: [PositionAlign.CC, PositionAlign.CC]
-            });
-        }
-
-        return val;
-    },
-
-    /**
-    Updates the UI to reflect the `align` value passed in.
-
-    **Note:** See the `align` Attribute documentation, for the Object structure
-    expected.
-
-    @method _uiSetAlign
+    @method _getNodePointXY
     @param {Node|String|null} [node] The node to align to, or null to indicate
       the viewport.
     @param {Array} points The alignment points.
+    @return {Array} the coordinates.
     @protected
     **/
-    _uiSetAlign: function (node, points) {
+    _getNodePointXY: function (node, points) {
         if ( ! Lang.isArray(points) || points.length !== 2) {
             Y.error('align: Invalid Points Arguments');
             return;
         }
 
-        var nodeRegion = this._getRegion(node),
-            widgetPoint, nodePoint, xy;
+        var nodeRegion = this._getRegion(node), nodePoint, xy;
 
         if ( ! nodeRegion) {
             // No-op, nothing to align to.
             return;
         }
 
-        widgetPoint = points[0];
         nodePoint   = points[1];
 
         // TODO: Optimize KWeight - Would lookup table help?
@@ -430,14 +406,50 @@ PositionAlign.prototype = {
             break;
 
         default:
-            Y.log('align: Invalid Points Arguments', 'info',
-                'widget-position-align');
             break;
 
         }
 
+        return xy;
+    },
+
+    /**
+    Default setter for `center` Attribute changes. Sets up the appropriate
+    value, and passes it through the to the align attribute.
+
+    @method _setAlignCenter
+    @param {Boolean|Node} val The Attribute value being set.
+    @return {Boolean|Node} the value passed in.
+    @protected
+    **/
+    _setAlignCenter: function (val) {
+        if (val) {
+            this.set(ALIGN, {
+                node  : val === true ? null : val,
+                points: [PositionAlign.CC, PositionAlign.CC]
+            });
+        }
+
+        return val;
+    },
+
+    /**
+    Updates the UI to reflect the `align` value passed in.
+
+    **Note:** See the `align` Attribute documentation, for the Object structure
+    expected.
+
+    @method _uiSetAlign
+    @param {Node|String|null} [node] The node to align to, or null to indicate
+      the viewport.
+    @param {Array} points The alignment points.
+    @protected
+    **/
+    _uiSetAlign: function (node, points) {
+        var xy = this._getNodePointXY(node, points);
+
         if (xy) {
-            this._doAlign(widgetPoint, xy[0], xy[1]);
+            this._doAlign(points[0], xy[0], xy[1]);
         }
     },
 
@@ -503,17 +515,16 @@ PositionAlign.prototype = {
     // -- Private Methods ------------------------------------------------------
 
     /**
-    Helper method, used to align the given point on the widget, with the XY page
-    coordinates provided.
+    Returns coordinates realative to the `Widget` alignment.
 
-    @method _doAlign
-    @param {String} widgetPoint Supported point constant
-      (e.g. WidgetPositionAlign.TL)
-    @param {Number} x X page coordinate to align to.
-    @param {Number} y Y page coordinate to align to.
+    @method _getWidgetPointXY
+    @param {Array} [widgetPoint] The widget alignment points.
+    @param {Number} 'Node' x coordinate.
+    @param {Number} 'Node' y coordinate.
+    @return {Array} the coordinates.
     @private
     **/
-    _doAlign: function (widgetPoint, x, y) {
+    _getWidgetPointXY: function (widgetPoint, x, y) {
         var widgetNode = this._posNode,
             xy;
 
@@ -579,11 +590,26 @@ PositionAlign.prototype = {
             break;
 
         default:
-            Y.log('align: Invalid Points Argument', 'info',
-                'widget-position-align');
             break;
 
         }
+
+        return xy;
+    },
+
+    /**
+    Helper method, used to align the given point on the widget, with the XY page
+    coordinates provided.
+
+    @method _doAlign
+    @param {String} widgetPoint Supported point constant
+      (e.g. WidgetPositionAlign.TL)
+    @param {Number} x X page coordinate to align to.
+    @param {Number} y Y page coordinate to align to.
+    @private
+    **/
+    _doAlign: function(widgetPoint, x, y) {
+        var xy = this._getWidgetPointXY(widgetPoint, x, y);
 
         if (xy) {
             this.move(xy);

--- a/src/widget-position-align/tests/unit/assets/widget-position-align-test.js
+++ b/src/widget-position-align/tests/unit/assets/widget-position-align-test.js
@@ -36,7 +36,7 @@ suite.add(new Y.Test.Case({
                 node  : 'body',
                 points: [Y.WidgetPositionAlign.CC, Y.WidgetPositionAlign.CC]
             };
-        
+
         widget.align();
         Assert.isNull(widget.get('align'));
 
@@ -78,6 +78,22 @@ suite.add(new Y.Test.Case({
         widget.align(null, [null, null]);
         widget.align(null, []);
         widget.align(null);
+    },
+
+    'Value returned from _getAlignedXY() before alignment should be the same of get(\'xy\') after alignment': function () {
+        var widget = new this.TestWidget( { render: true } ),
+            align  = {
+                node  : 'body',
+                points: [Y.WidgetPositionAlign.CC, Y.WidgetPositionAlign.CC]
+            };
+
+        var beforeAlignment = widget._getAlignedXY(align.node, align.points);
+
+        widget.align(align.node, align.points);
+
+        var afterAlignment = widget.get('xy');
+
+        Y.Test.ArrayAssert.itemsAreEqual(beforeAlignment, afterAlignment);
     },
 
     'align() should be chainable': function () {


### PR DESCRIPTION
@sdesai 

@eduardolundgren

In the context of WidgetPositionAlign, there are some cases where we need to know the coordinates where the widget will be after alignment but before actually touching the DOM. This way we can extend the alignment behavior more easily, just like we do in 

WidgetPositionContrain.getConstrainedXY()

Which is a method that calculates the constrainment coordinates, but doesn't actually set it.

-----

As for the pull request, there are no logical changes, just moving methods.