### PR TITLE
Fix 890. Update `getPage` method in the modified `modelList` to return a valid slice call in IE <= 9.

### DIFF
--- a/src/datatable/js/paginator.js
+++ b/src/datatable/js/paginator.js
@@ -98,6 +98,7 @@ View = Y.Base.create('dt-pg-view', Y.View, [], {
             });
 
         this.get('container').append(content);
+        this.attachEvents();
 
         this._rendered = true;
 
@@ -122,10 +123,20 @@ View = Y.Base.create('dt-pg-view', Y.View, [], {
 
         this._attachedViewEvents.push(
             container.delegate('click', this._controlClick, '.' + this.classNames.control, this),
-            container.after('change', this._controlChange, this, 'select'),
-            container.after('submit', this._controlSubmit, this, 'form'),
             this.get('model').after('change', this._modelChange, this)
         );
+
+        container.all('form').each(Y.bind(function (frm) {
+            this._attachedViewEvents.push(
+                frm.after('submit', this._controlSubmit, this)
+            );
+        }, this));
+
+        container.all('select').each(Y.bind(function (sel) {
+            this._attachedViewEvents.push(
+                sel.after('change', this._controlChange, this)
+            );
+        }, this));
 
     },
 
@@ -312,17 +323,12 @@ View = Y.Base.create('dt-pg-view', Y.View, [], {
      @protected
      @method _controlChange
      @param {EventFacade} e
-     @param {String} selector
      @SINCE@
      */
-    _controlChange: function (e, selector) {
+    _controlChange: function (e) {
 
-        var control = e.target;
         // register change events from the perPage select
-        if (
-            control.hasClass(CLASS_DISABLED) ||
-            ( selector && !(control.test(selector)) )
-        ) {
+        if ( e.target.hasClass(CLASS_DISABLED) ) {
             return;
         }
 
@@ -335,15 +341,10 @@ View = Y.Base.create('dt-pg-view', Y.View, [], {
      @protected
      @method _controlSubmit
      @param {EventFacade} e
-     @param {String} selector
      @SINCE@
      */
-    _controlSubmit: function (e, selector) {
-        var control = e.target;
-        if (
-            control.hasClass(CLASS_DISABLED) ||
-            ( selector && !(control.test(selector)) )
-        ) {
+    _controlSubmit: function (e) {
+        if ( e.target.hasClass(CLASS_DISABLED) ) {
             return;
         }
 

--- a/src/datatable/tests/unit/assets/datatable-paginator-tests.js
+++ b/src/datatable/tests/unit/assets/datatable-paginator-tests.js
@@ -288,41 +288,43 @@ suite.add(new Y.Test.Case({
         nextBtn.simulate('click');
 
         // test cell data
-        Y.Assert.areSame(data[10].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'));
+        Y.Assert.areSame(data[10].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'), 'a');
 
         // click prev
         prevBtn.simulate('click');
 
         // test cell data
-        Y.Assert.areSame(data[0].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'));
+        Y.Assert.areSame(data[0].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'), 'b');
 
         // click last
         lastBtn.simulate('click');
 
         // test cell data
-        Y.Assert.areSame(data[90].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'));
+        Y.Assert.areSame(data[90].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'), 'c');
 
         // click first
         firstBtn.simulate('click');
 
         // test cell data
-        Y.Assert.areSame(data[0].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'));
+        Y.Assert.areSame(data[0].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'), 'd');
 
         // change input number and submit
         submitBtn.previous('input').set('value', 4);
-        submitBtn.simulate('click');
+        submitBtn.ancestor('form').simulate('submit');
 
         // test cell data
-        Y.Assert.areSame(data[30].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'));
+        Y.Assert.areSame(data[30].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'), 'e');
 
         // change rows per page
+        selectNode.focus();
         selectNode.set('selectedIndex', 1);
         selectNode.simulate('change');
+        selectNode.blur();
 
         // test number of rows per page
-        Y.Assert.areSame(50, dt.body.tbodyNode.all('tr').size());
+        Y.Assert.areSame(50, dt.body.tbodyNode.all('tr').size(), 'f');
         // test cell data
-        Y.Assert.areSame(data[0].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'));
+        Y.Assert.areSame(data[0].name.toString(), dt.body.tbodyNode.all('td').item(1).get('text'), 'g');
 
 
         dt.destroy();


### PR DESCRIPTION
Fix 890. Update `getPage` method in the modified `modelList` to return a valid slice call in IE <= 9.
