### PR TITLE
Adding CONTRIBUTING.md Fixes #857

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Create a free account on
 [YUILibrary.com](http://yuilibrary.com/forum/ucp.php?mode=register) account so
 you can:
 
-  * [Create bugs](http://yuilibrary.com/projects/yui3/newticket/) and
+  * [Create bugs](https://github.com/yui/yui3/issues/new) and
   enhancement requests.
   * Post on the [support forum](http://yuilibrary.com/forum/).
   * Contribute modules to the [Gallery](http://yuilibrary.com/gallery/).


### PR DESCRIPTION
Moving the content finally from the wiki into the repo under CONTRIBUTING.md
I know this is "documentation"  but since it's a new file doing this as a pull request to do due diligence.
This is verbatim from the wiki file that I've been soliciting and incorporating feedback on for several months from the yui-contrib mailing list. ( https://github.com/yui/yui3/wiki/Contributing.md ) 
