### PR TITLE
Fixed a bug in widget-stdmod

### DIFF
--- a/src/widget-stdmod/js/Widget-StdMod.js
+++ b/src/widget-stdmod/js/Widget-StdMod.js
@@ -431,7 +431,7 @@
             if (this.get(FILL_HEIGHT)) {
                 var height = this.get(HEIGHT);
                 if (height != EMPTY && height != AUTO) {
-                    this.fillHeight(this._currFillNode);
+                    this.fillHeight(this.getStdModNode(this.get(FILL_HEIGHT)));
                 }
             }
         },

--- a/src/widget-stdmod/tests/unit/assets/widget-stdmod-test.js
+++ b/src/widget-stdmod/tests/unit/assets/widget-stdmod-test.js
@@ -140,6 +140,18 @@ suite.add(new Y.Test.Case({
         Assert.areSame('150px', body.getStyle('height'), 'body is not 150px in height after fill.');
     },
 
+    'fillHeight() should fill up the widget even if section content is set after render()': function () {
+        this.widget = new TestWidget({
+            headerContent:    'header',
+            // no body content, so no section node will be created
+            render:            '#test',
+            height:            100
+        });
+
+        this.widget.set('bodyContent', '<div style="height: 200px;">body</div>');
+        Assert.isTrue(this.widget.getStdModNode('body').get('offsetHeight') < 100);
+    },
+
     'HTML_PARSER rules should return the proper inner HTML contents from markup': function () {
         var src, headerMarkup, footerMarkup, bodyMarkup;
         


### PR DESCRIPTION
_fillHeight depends on this._currFillNode being set by _uiSetFillHeight
However, if the fillHeight node's content is set after render(),
_uiSetFillHeight doesn't set this._currFillNode, because the fill node doesn't exist (yet).

When the content is set, _fillHeight is called after('contentUpdate'), but since
this._currFillNode isn't set, it calls fillHeight with undefined.

The fix is to have _fillHeight getStdModNode() instead of relying on this._currFillNode
