### PR TITLE
Tree: Massive speedup in Tree#emptyNode().

### DIFF
--- a/src/tree/HISTORY.md
+++ b/src/tree/HISTORY.md
@@ -4,7 +4,10 @@ Tree Change History
 @VERSION@
 ------
 
-* No changes.
+* `Tree#emptyNode()` now removes nodes without triggering a node map reindex for
+  each node, which makes it significantly faster when emptying a node with lots
+  of children. [Ryan Grove]
+
 
 3.10.3
 ------

--- a/src/tree/js/tree.js
+++ b/src/tree/js/tree.js
@@ -361,10 +361,11 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
     @return {Tree.Node[]} Array of removed child nodes.
     **/
     emptyNode: function (node, options) {
-        var removed = [];
+        var children = node.children,
+            removed  = [];
 
-        while (node.children.length) {
-            removed.push(this.removeNode(node.children[0], options));
+        for (var i = children.length - 1; i > -1; --i) {
+            removed[i] = this.removeNode(children[i], options);
         }
 
         return removed;
@@ -810,8 +811,15 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
             index = parent.indexOf(node);
 
             if (index > -1) {
-                parent.children.splice(index, 1);
-                parent._isIndexStale = true;
+                var children = parent.children;
+
+                if (index === children.length - 1) {
+                    children.pop();
+                } else {
+                    children.splice(index, 1);
+                    parent._isIndexStale = true;
+                }
+
                 node.parent = null;
             }
         }


### PR DESCRIPTION
Previously, `emptyNode()` triggered a node map reindex for each node that was removed. This commit modifies `emptyNode()` to remove nodes in last-first order and avoids the need to reindex.

Previously, emptying a node with 10,000 children took about 17 seconds in Chrome. After this change, it's nearly instantaneous.
