### PR TITLE
Updated paths to Benchmark.js

### DIFF
--- a/src/app/tests/performance/app-benchmark.html
+++ b/src/app/tests/performance/app-benchmark.html
@@ -10,8 +10,8 @@
 
 <div id="log"></div>
 
-<applet code="nano" archive="http://pieisgood.org/misc/benchmark/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -44,8 +44,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -54,7 +54,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>

--- a/src/base/tests/benchmark/base-benchmark.html
+++ b/src/base/tests/benchmark/base-benchmark.html
@@ -10,8 +10,8 @@
 
 <div id="log"></div>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="https://raw.github.com/bestiejs/benchmark.js/v1.0.0/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <!--script src="http://yui.yahooapis.com/3.8.1/build/yui/yui.js"></script-->
 <script src="../../../../build/yui/yui.js"></script>

--- a/src/base/tests/benchmark/base-core-benchmark.html
+++ b/src/base/tests/benchmark/base-core-benchmark.html
@@ -10,8 +10,8 @@
 
 <div id="log"></div>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="https://raw.github.com/bestiejs/benchmark.js/v1.0.0/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <!--script src="http://yui.yahooapis.com/3.8.1/build/yui/yui.js"></script-->
 <script src="../../../../build/yui/yui.js"></script>

--- a/src/event-custom/tests/benchmark/event-custom-benchmark.html
+++ b/src/event-custom/tests/benchmark/event-custom-benchmark.html
@@ -10,8 +10,8 @@
 
 <div id="log"></div>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script type='text/javascript' src="https://raw.github.com/bestiejs/benchmark.js/v1.0.0/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <!--script src="http://yui.yahooapis.com/3.8.1/build/yui/yui.js"></script-->
 <script src="../../../../build/yui/yui.js"></script>

--- a/src/node/tests/perf/node-attrs.html
+++ b/src/node/tests/perf/node-attrs.html
@@ -29,8 +29,8 @@
     </select>
 </form>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -63,8 +63,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -73,7 +73,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>

--- a/src/node/tests/perf/node-core.html
+++ b/src/node/tests/perf/node-core.html
@@ -26,8 +26,8 @@
     </div>
 </div>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -60,8 +60,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -70,7 +70,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>

--- a/src/node/tests/perf/node-create.html
+++ b/src/node/tests/perf/node-create.html
@@ -13,8 +13,8 @@
 <div id="test-node"></div>
 <div id="test-append"></div>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -47,8 +47,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -57,7 +57,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>

--- a/src/node/tests/perf/node-data.html
+++ b/src/node/tests/perf/node-data.html
@@ -11,8 +11,8 @@
 <div id="log"></div>
 <div id="test-node"></div>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -45,8 +45,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -55,7 +55,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>

--- a/src/node/tests/perf/node-screen.html
+++ b/src/node/tests/perf/node-screen.html
@@ -11,8 +11,8 @@
 <div id="log"></div>
 <div id="test-node"></div>
 
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -45,8 +45,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -55,7 +55,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>

--- a/src/tabview/tests/perf/tabview.html
+++ b/src/tabview/tests/perf/tabview.html
@@ -9,8 +9,8 @@
 <p><button id="start">Start Benchmarks</button></p>
 
 <div id="log"></div>
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -43,8 +43,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -53,7 +53,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>

--- a/src/transition/tests/perf/transition.html
+++ b/src/transition/tests/perf/transition.html
@@ -18,8 +18,8 @@
 
 <div id="log"></div>
 <div id="demo"></div>
-<applet code="nano" archive="https://github.com/bestiejs/benchmark.js/raw/v1.0.0/nano.jar" style="display: none;"></applet>
-<script src="http://pieisgood.org/misc/benchmark/benchmark.js"></script>
+<applet code="nano" archive="../../../vendor/benchmarkjs/nano.jar" style="display: none;"></applet>
+<script src="../../../common/vendor/benchmarkjs/benchmark.js"></script>
 
 <script src="../../../../build/yui/yui.js"></script>
 <script>
@@ -52,8 +52,8 @@ var Y = YUI({
         Y.log('Starting benchmarks.');
     });
 
-    suite.on('cycle', function (bench) {
-        Y.log(String(bench));
+    suite.on('cycle', function (e) {
+        Y.log(String(e.target));
     });
 
     suite.on('complete', function () {
@@ -62,7 +62,7 @@ var Y = YUI({
     });
 
     start.on('click', function () {
-        suite.run(true);
+        suite.run({async:true});
     });
 });
 </script>


### PR DESCRIPTION
With the inclusion of Benchmark.js in the src tree, I updated the paths to include it for app, base, event-custom, node, tabview, and transition.  Also, due to some API changes, triggering an async run is different, along with logging the results per cycle.

Left out Charts and Graphics as @tripp is updating those tests himself.
