### PR TITLE
Tree: Fix inconsistencies when inserting nodes already in the tree

### DIFF
--- a/src/tree/HISTORY.md
+++ b/src/tree/HISTORY.md
@@ -14,6 +14,19 @@ Tree Change History
   each node, which makes it significantly faster when emptying a node with lots
   of children. [Ryan Grove]
 
+* When inserting a node that already exists in the same parent (which results in
+  that node being removed and then re-inserted), `Tree#insertNode()` now
+  adjusts the insertion index to ensure that the node is re-inserted at the
+  correct position after being removed, even if that position has shifted as a
+  result of the removal. [Ryan Grove]
+
+* The `remove` event is now fired when a node is removed and re-inserted as the
+  result of a `Tree#appendNode()`, `Tree#insertNode()`, or `Tree#prependNode()`
+  call. Previously, the node was removed silently with no event.
+
+  The `src` property of the `remove` event facade in this case will be set to
+  "add". Filter on this source if you want to ignore these events. [Ryan Grove]
+
 * The `Tree#createNode()`, `Tree#insertNode()`, and `Tree#traverseNode()`
   methods now throw or log informative error messages when given a destroyed
   node instead of failing cryptically (or succeeding when they shouldn't).

--- a/src/tree/js/tree.js
+++ b/src/tree/js/tree.js
@@ -779,6 +779,7 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
     _fireTreeEvent: function (name, facade, options) {
         if (options && options.silent) {
             if (options.defaultFn) {
+                facade.silent = true; // intentionally modifying the facade
                 options.defaultFn.call(this, facade);
             }
         } else {
@@ -844,17 +845,38 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
 
     // -- Default Event Handlers -----------------------------------------------
     _defAddFn: function (e) {
-        var node   = e.node,
-            parent = e.parent;
+        var index  = e.index,
+            node   = e.node,
+            parent = e.parent,
+            oldIndex;
 
         // Remove the node from its existing parent if it has one.
         if (node.parent) {
-            this._removeNodeFromParent(node);
+            // If the node's existing parent is the same parent it's being
+            // inserted into, adjust the index to avoid an off-by-one error.
+            if (node.parent === parent) {
+                oldIndex = parent.indexOf(node);
+
+                if (oldIndex === index) {
+                    // Old index is the same as the new index, so just don't do
+                    // anything.
+                    return;
+                } else if (oldIndex < index) {
+                    // Removing the node from its old index will affect the new
+                    // index, so decrement the new index by one.
+                    index -= 1;
+                }
+            }
+
+            this.removeNode(node, {
+                silent: e.silent,
+                src   : 'add'
+            });
         }
 
         // Add the node to its new parent at the desired index.
         node.parent = parent;
-        parent.children.splice(e.index, 0, node);
+        parent.children.splice(index, 0, node);
 
         parent.canHaveChildren = true;
         parent._isIndexStale   = true;

--- a/src/tree/tests/unit/assets/tree-test.js
+++ b/src/tree/tests/unit/assets/tree-test.js
@@ -504,6 +504,22 @@ treeSuite.add(new Y.Test.Case({
         Assert.areSame(-1, this.tree.rootNode.indexOf(node), 'node should no longer be a child of the root node');
     },
 
+    'insertNode() should reinsert at the correct position relative to other nodes even when the inserted node already exists in the same parent': function () {
+
+        var one   = this.tree.children[0],
+            two   = this.tree.children[1],
+            three = this.tree.children[2];
+
+        this.tree.insertNode(this.tree.rootNode, one, {index: 2});
+
+        Assert.areSame(0, two.index(), 'node two should now be at index 0');
+        Assert.areSame(1, one.index(), 'node one should now be at index 1');
+        Assert.areSame(2, three.index(), 'node three should still be at index 2');
+        Assert.areSame(two, this.tree.children[0], 'node two should now be first');
+        Assert.areSame(one, this.tree.children[1], 'node one should now be second');
+        Assert.areSame(three, this.tree.children[2], 'node three should still be third');
+    },
+
     'insertNode() should return `null` if a destroyed node is inserted and an errorFn handles the error': function () {
         Y.config.errorFn = function () {
             return true;
@@ -923,6 +939,27 @@ treeSuite.add(new Y.Test.Case({
         });
 
         this.tree.insertNode(this.tree.rootNode, {id: 'inserted'}, {silent: true});
+    },
+
+    'insertNode() should fire a `remove` event if the inserted node is removed from another parent': function () {
+        var fired;
+
+        this.tree.once('remove', function (e) {
+            fired = true;
+            Assert.areSame('add', e.src, 'src should be "add"');
+        });
+
+        this.tree.insertNode(this.tree.rootNode, this.tree.children[0]);
+
+        Assert.isTrue(fired, 'remove event should fire');
+    },
+
+    'insertNode() should not fire a `remove` event when the inserted node is removed from another parent if options.silent is truthy': function () {
+        this.tree.once('remove', function (e) {
+            Assert.fail('remove event should not fire');
+        });
+
+        this.tree.insertNode(this.tree.rootNode, this.tree.children[0], {silent: true});
     },
 
     'removeNode() should fire a `remove` event': function () {


### PR DESCRIPTION
This fixes two issues when inserting a node that already exists in the tree:
- Previously, the node was removed from its original parent silently before being reparented. Now we fire a `remove` event with {src: 'add'}.
- Inserting a node into the same parent with a new index could result in an off-by-one error. Now the desired insert position is maintained.
