### PR TITLE
Fix issue with Router trying to URL-decode `undefined` path segments

### DIFF
--- a/src/app/HISTORY.md
+++ b/src/app/HISTORY.md
@@ -4,12 +4,17 @@ App Framework Change History
 @VERSION@
 ------
 
-* No changes.
+### Router
+
+* Fixed issue with trying to URL-decode matching path segments that are
+  `undefined`.
+
 
 3.10.3
 ------
 
 * No changes.
+
 
 3.10.2
 ------

--- a/src/app/js/router.js
+++ b/src/app/js/router.js
@@ -669,7 +669,9 @@ Y.Router = Y.extend(Router, Y.Base, {
 
                 // Decode each of the path matches so that the any URL-encoded
                 // path segments are decoded in the `req.params` object.
-                matches = YArray.map(route.regex.exec(path) || [], decode);
+                matches = YArray.map(route.regex.exec(path) || [], function (match) {
+                    return match && decode(match);
+                });
 
                 // Use named keys for parameter names if the route path contains
                 // named keys. Otherwise, use numerical match indices.


### PR DESCRIPTION
When Router is dispatching to a route's callbacks, it URL-decodes the matching path segments so that placeholders like `req.foo` don't have encoded values. Since Router supports registering a route as a Regex, when Router executes that regex it may return an array with some undefined matches. This fixes the issue where Router assumed all items in the array returned from `exec()` are strings.
