### PR TITLE
Don't break the back/forward cache. Fixes #959

### DIFF
--- a/src/event/js/event-dom.js
+++ b/src/event/js/event-dom.js
@@ -930,13 +930,18 @@ if (config.injected || YUI.Env.windowLoaded) {
 // Process onAvailable/onContentReady items when when the DOM is ready in IE
 if (Y.UA.ie) {
     Y.on(EVENT_READY, Event._poll);
-}
 
-try {
-    add(win, "unload", onUnload);
-} catch(e) {
-    /*jshint maxlen:300*/
-    Y.log("Registering unload listener failed. This is known to happen in Chrome Packaged Apps and Extensions, which don't support unload, and don't provide a way to test for support", "warn", "event-base");
+    // In IE6 and below, detach event handlers when the page is unloaded in
+    // order to try and prevent cross-page memory leaks. This isn't done in
+    // other browsers because a) it's not necessary, and b) it breaks the
+    // back/forward cache.
+    if (Y.UA.ie < 7) {
+        try {
+            add(win, "unload", onUnload);
+        } catch(e) {
+            Y.log("Registering unload listener failed.", "warn", "event-base");
+        }
+    }
 }
 
 Event.Custom = Y.CustomEvent;


### PR DESCRIPTION
Attaching an unload listener breaks the back/forward cache in modern browsers, and is only necessary in old versions of IE that can leak memory across pageviews if events aren't detached.

This change limits the unload listener to IE6 and below. I'm not aware of any need for it in newer IEs, but if anyone knows differently, please speak up.

All unit tests pass, but this PR probably needs manual testing on some real-world use cases to make sure unbreaking the back/forward cache doesn't violate assumptions YUI developers have been making. I'll test it at SmugMug and report back with insight. If others could test as well, that'd be much appreciated.
