### PR TITLE
Move Widget's `_preAddAttrs` method override into `widget-htmlparser`.

### DIFF
--- a/src/widget/js/Widget.js
+++ b/src/widget/js/Widget.js
@@ -565,44 +565,6 @@ Y.extend(Widget, Y.Base, {
     },
 
     /**
-     * Implement the BaseCore _preAddAttrs method hook, to add
-     * the srcNode and related attributes, so that HTML_PARSER
-     * (which relies on `this.get("srcNode")`) can merge in it's
-     * results before the rest of the attributes are added.
-     *
-     * @method _preAddAttrs
-     * @protected
-     *
-     * @param attrs {Object} The full hash of statically defined ATTRS
-     * attributes being added for this instance
-     *
-     * @param userVals {Object} The hash of user values passed to
-     * the constructor
-     *
-     * @param lazy {boolean} Whether or not to add the attributes lazily
-     */
-    _preAddAttrs : function(attrs, userVals, lazy) {
-
-        var preAttrs = {
-            id : attrs.id,
-            boundingBox : attrs.boundingBox,
-            contentBox : attrs.contentBox,
-            srcNode : attrs.srcNode
-        };
-
-        this.addAttrs(preAttrs, userVals, lazy);
-
-        delete attrs.boundingBox;
-        delete attrs.contentBox;
-        delete attrs.srcNode;
-        delete attrs.id;
-
-        if (this._applyParser) {
-            this._applyParser(userVals);
-        }
-    },
-
-    /**
      * Default render handler
      *
      * @method _defRenderFn

--- a/src/widget/js/WidgetHTMLParser.js
+++ b/src/widget/js/WidgetHTMLParser.js
@@ -81,6 +81,44 @@ Y.mix(Widget.prototype, {
     },
 
     /**
+     * Implement the BaseCore _preAddAttrs method hook, to add
+     * the srcNode and related attributes, so that HTML_PARSER
+     * (which relies on `this.get("srcNode")`) can merge in it's
+     * results before the rest of the attributes are added.
+     *
+     * @method _preAddAttrs
+     * @protected
+     *
+     * @param attrs {Object} The full hash of statically defined ATTRS
+     * attributes being added for this instance
+     *
+     * @param userVals {Object} The hash of user values passed to
+     * the constructor
+     *
+     * @param lazy {boolean} Whether or not to add the attributes lazily
+     */
+    _preAddAttrs : function(attrs, userVals, lazy) {
+
+        var preAttrs = {
+            id : attrs.id,
+            boundingBox : attrs.boundingBox,
+            contentBox : attrs.contentBox,
+            srcNode : attrs.srcNode
+        };
+
+        this.addAttrs(preAttrs, userVals, lazy);
+
+        delete attrs.boundingBox;
+        delete attrs.contentBox;
+        delete attrs.srcNode;
+        delete attrs.id;
+
+        if (this._applyParser) {
+            this._applyParser(userVals);
+        }
+    },
+
+    /**
      * @method _applyParsedConfig
      * @protected
      * @return {Object} The merged configuration literal

--- a/src/widget/tests/unit/widget-base.html
+++ b/src/widget/tests/unit/widget-base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>WidgetBase Smoke Test</title>
+</head>
+<body>
+    <script src="../../../../build/yui/yui.js"></script>
+    <script>
+        YUI({
+            coverage: ['widget-base'],
+            filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
+        }).use("test", "widget-base", function (Y) {
+            // Don't use console, since it includes widget-htmlparser
+            // which we want to exclude from this test.
+
+            var suite = new Y.Test.Suite("WidgetBase");
+
+            suite.add(new Y.Test.Case({
+                name: "Basic Smoke Test",
+                "should instantiate without widget-htmlparser present": function () {
+                    var instance = new Y.Widget();
+                    Y.Assert.isObject(instance);
+                }
+            }));
+
+            Y.Test.Runner.add(suite);
+            Y.Test.Runner.run();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Because `widget-base` no longer includes the ATTRS definition for `srcNode`, any attempt to instantiate `Y.Widget` when only requiring `widget-base` will fail spectacularly. Anyone using the `widget` rollup won't notice a difference.

This is related to https://github.com/yui/yui3/pull/917, and is extremely important to get in before 3.11.0 GA. http://jsfiddle.net/evocateur/EzJeQ/ demonstrates the current problem, and the test file I added verifies that the issue is fixed.
