### PR TITLE
#960 problem with checkbox

### DIFF
--- a/src/datatable/docs/datatable-chkboxselect.mustache
+++ b/src/datatable/docs/datatable-chkboxselect.mustache
@@ -90,10 +90,7 @@ var table = new Y.DataTable({
         {   key:        'select',
             allowHTML:  true, // to avoid HTML escaping
             label:      '<input type="checkbox" class="protocol-select-all" title="Toggle ALL records"/>',
-            formatter:   function(o) {
-                    var checked = o.record.get('select') ? 'checked' : '';
-                    return '<input type="checkbox"'+ checked +'/>';
-            },
+            formatter: '<input type="checkbox" checked/>',
             emptyCellValue: '<input type="checkbox"/>'
         },
         {   key: 'port',   label: 'Port No.' },
@@ -131,7 +128,10 @@ var table = new Y.DataTable({
 table.delegate("click", function(e){
     // undefined to trigger the emptyCellValue
     var checked = e.target.get('checked') || undefined;
-
+    
+    /*If `{silent:true}` is not set, every non-master checkbox selection will cause to fire the 'change' event
+    which will eventually re-render the datatable always which is bad at performance and also as the formatter is of static string type,
+    when user checks/selects a  checkbox it will cause other checkboxes also to be checked/selected, which is the actual reported issue.*/
     this.getRecord(e.target).set('select', checked, { silent: true });
 
     // Uncheck the header checkbox

--- a/src/datatable/docs/partials/datatable-chkboxselect-source.mustache
+++ b/src/datatable/docs/partials/datatable-chkboxselect-source.mustache
@@ -32,10 +32,7 @@ YUI({ filter: 'raw' }).use( "datatable-sort", "datatable-scroll", "cssbutton", f
             {   key:        'select',
                 allowHTML:  true, // to avoid HTML escaping
                 label:      '<input type="checkbox" class="protocol-select-all" title="Toggle ALL records"/>',
-                formatter:   function(o) {
-                    var checked = o.record.get('select') ? 'checked' : '';
-                    return '<input type="checkbox"'+ checked +'/>';
-                },
+                formatter: '<input type="checkbox" checked/>',
                 emptyCellValue: '<input type="checkbox"/>'
             },
             {   key: 'port',   label: 'Port No.' },
@@ -63,7 +60,10 @@ YUI({ filter: 'raw' }).use( "datatable-sort", "datatable-scroll", "cssbutton", f
     table.delegate("click", function(e){
         // undefined to trigger the emptyCellValue
         var checked = e.target.get('checked') || undefined;
-
+        
+        /*If `{silent:true}` is not set, every non-master checkbox selection will cause to fire the 'change' event
+        which will eventually re-render the datatable always which is bad at performance and also as the formatter is of static string type,
+        when user checks/selects a  checkbox it will cause other checkboxes also to be checked/selected, which is the actual reported issue.*/
         this.getRecord(e.target).set('select', checked, { silent: true });
 
         // Uncheck the header checkbox


### PR DESCRIPTION
Fix for #960 issue.
- Modified `formatter` config to set the checkbox `checked` attribute correctly pulling it from the model.
- Making the non-master checkboxes `select` attribute change `silent` to prevent from the datatable re-rendering every time user toggles non-master checkbox selection. Just the silent model update would `suffice` as already UI is updated by browser.
