### PR TITLE
Changing test failure to be ignored in browsers with buggy innerHTML implementation

### DIFF
--- a/src/app/tests/unit/assets/app-content-test.js
+++ b/src/app/tests/unit/assets/app-content-test.js
@@ -11,6 +11,13 @@ var ArrayAssert  = Y.ArrayAssert,
     originalURL   = (win && win.location.toString()) || '',
     originalTitle = (doc && doc.title) || '',
 
+    hasInnerHTMLBug = (function(){
+        var responseHTML = "<html><head><title>Hello</title></head><body><div>Hello World!</div></body></html>",
+            node = Y.Node.create(responseHTML);
+
+        return node.get('children').size() <= 1;
+    })(),
+
     suite,
     appContentSuite;
 
@@ -291,10 +298,13 @@ appContentSuite.add(new Y.Test.Case({
 appContentSuite.add(new Y.Test.Case({
     name: 'Routes',
 
+    // Known bug in node.innerHTML implementation found in <IE9 and Android
+    // 2.3.x.  See PjaxContent documentation on appropriate server-side
+    // solutions for addressing this issue.
     _should: {
         ignore: {
             '`Y.App.Content.route` should set the document `title`': !doc,
-            '`Y.App.Content.route` should default the document `title` to `<title>`': Y.UA.ie && Y.UA.ie < 9
+            '`Y.App.Content.route` should default the document `title` to `<title>`': hasInnerHTMLBug
         }
     },
 
@@ -344,9 +354,10 @@ appContentSuite.add(new Y.Test.Case({
     },
 
     '`Y.App.Content.route` should default the document `title` to `<title>`': function () {
-        // There's a known issue that this won't work in IE < 9!
-        // Older IEs parse the HTML document and strip away the `<head>` and
-        // `<body>` elements.
+        // There's a known issue that this won't work in IE < 9 and old Android!
+        // These browsers parse the HTML document and strip away the `<head>`
+        // and `<body>` elements. See PjaxContent documentation for better
+        // server-side solutions for addressing this problem.
 
         var test = this,
             app  = this.app = new Y.App({contentSelector: '#content > *'});


### PR DESCRIPTION
As discussed in #962, I changed the test failure in App to use feature detection to determine if the browser has a buggy innerHTML implementation.  This will at least allow Android 2.3.x browsers and < IE9 to ignore the test, so the error doesn't come up again.

I'll start writing the documentation on how to better format the HTML response so that Pjax will work, even on those browsers.
