### PR TITLE
Refix of  `Node#getHTML()`'s unit test

### DIFF
--- a/src/node/tests/unit/node.html
+++ b/src/node/tests/unit/node.html
@@ -1947,7 +1947,7 @@ YUI({
                 node = Y.one(Y.config.doc.createDocumentFragment());
 
             node.setHTML(html);
-            Assert.areEqual(html, node.getHTML().toLowerCase());
+            Assert.areEqual(html, node.getHTML().toLowerCase().replace(/\s+/g, ''));
 
             // make sure node's contents have not disappeared 
             Assert.areEqual(node.get("children").size(), 1);


### PR DESCRIPTION
Apparently, not only does IE 6-8 uppercase the result innerHTML, it also adds new lines in random places.

Discussion can be found here: https://github.com/yui/yui3/pull/978
