### PR TITLE
Tree.Sortable: Reindex children after sorting

### DIFF
--- a/src/tree/HISTORY.md
+++ b/src/tree/HISTORY.md
@@ -4,6 +4,14 @@ Tree Change History
 @VERSION@
 ------
 
+* Fixed: `Tree.Sortable` failed to reindex a node's children after sorting them,
+  which could result in `Tree#indexOf()` and `Tree.Node#index()` returning
+  incorrect indices. [Ryan Grove]
+
+
+3.11.0
+------
+
 * `Tree#emptyNode()` now removes nodes without triggering a node map reindex for
   each node, which makes it significantly faster when emptying a node with lots
   of children. [Ryan Grove]

--- a/src/tree/js/extensions/tree-sortable.js
+++ b/src/tree/js/extensions/tree-sortable.js
@@ -128,6 +128,7 @@ Sortable.prototype = {
         }
 
         node.children.sort(Y.rbind(this._sort, this, comparator, reverse));
+        node._isIndexStale = true;
 
         if (!options.silent) {
             this.fire(EVT_SORT, {

--- a/src/tree/tests/unit/assets/tree-sortable-test.js
+++ b/src/tree/tests/unit/assets/tree-sortable-test.js
@@ -278,6 +278,30 @@ suite.add(new Y.Test.Case({
         Assert.areSame(5, tree.children[1].foo, 'second node should be 5');
         Assert.areSame(2, tree.children[2].foo, 'third node should be 2');
         Assert.areSame(1, tree.children[3].foo, 'fourth node should be 1');
+    },
+
+    'node children should be re-indexed after being sorted': function () {
+        var tree = new Tree();
+
+        tree.insertNode(tree.rootNode, [
+            {foo: 'z'},
+            {foo: 'a'},
+            {foo: 'b'}
+        ]);
+
+        Assert.areSame(0, tree.children[0].index(), 'first node should have index 0 before sort');
+        Assert.areSame(1, tree.children[1].index(), 'second node should have index 1 before sort');
+        Assert.areSame(2, tree.children[2].index(), 'third node should have index 2 before sort');
+
+        tree.rootNode.sortComparator = function (node) {
+            return node.foo;
+        };
+
+        tree.sortNode(tree.rootNode);
+
+        Assert.areSame(0, tree.children[0].index(), 'first node should have index 0 after sort');
+        Assert.areSame(1, tree.children[1].index(), 'second node should have index 1 after sort');
+        Assert.areSame(2, tree.children[2].index(), 'third node should have index 2 after sort');
     }
 }));
 


### PR DESCRIPTION
This fixes a subtle bug that caused `Tree#indexOf()` and `Tree.Node#index()` to return incorrect indices if they had previously been used (thus creating a cached index) _and_ the parent node was then re-sorted in a way that changed child indices.
