### PR TITLE
Fixed NPE on EventTarget.detach('cat | *')

### DIFF
--- a/src/event-custom/HISTORY.md
+++ b/src/event-custom/HISTORY.md
@@ -1,6 +1,12 @@
 Custom Event Infrastructure Change History
 ==========================================
 
+@VERSION@
+------
+
+* Fixed regression introduced in 3.10.0, where `EventTarget.detach('cat|*')` 
+  would throw an exception, when the EventTarget was configured with a prefix.
+
 3.11.0
 ------
 

--- a/src/event-custom/js/event-target.js
+++ b/src/event-custom/js/event-target.js
@@ -42,7 +42,7 @@ var L = Y.Lang,
      */
     _getType = function(type, pre) {
 
-        if (!pre || type.indexOf(PREFIX_DELIMITER) > -1) {
+        if (!pre || !type || type.indexOf(PREFIX_DELIMITER) > -1) {
             return type;
         }
 

--- a/src/event-custom/tests/unit/assets/event-custom-base-tests.js
+++ b/src/event-custom/tests/unit/assets/event-custom-base-tests.js
@@ -4336,6 +4336,28 @@ baseSuite.add(new Y.Test.Case({
         Y.Assert.areSame(1, count);
     },
 
+    "test target.after('cat|__', fn) + target.detach('cat|*'), with prefix": function () {
+        var count = 0,
+            target = new Y.EventTarget({prefix:"foo"});
+
+        function increment() {
+            count++;
+        }
+
+        target.after('cat|test', increment);
+
+        target.fire('test');
+
+        Y.Assert.areSame(1, count);
+
+        target.detach('cat|*');
+
+        target.fire('test');
+
+        Y.Assert.areSame(1, count);
+    },
+
+
     "test target.after({...}) + target.detach(type)": function () {
         var count = 0,
             target = new Y.EventTarget();


### PR DESCRIPTION
The exception was coming from the private `_getType(type, pre)` method.

We removed the `typeof type === 'string'` check in `getType`, for performance reasons in 3.10.0, since the calling code had it covered already and it sits on many critical paths.

However there's one path, for the `cat|*` use case, when a default prefix is configured, where a null `type` is passed to `_getType` and it was barfing on the `type.indexOf()` call as a result.

Re-added a simple truthy check (still avoiding the typeof string) before calling indexOf.

Debated (before settling on the above):
1. Leaving `_getType` as is, and just fixing the single place where it's called with null (in the interests of not impacting the other paths, performance wise), but since it's called by getEvent, which is public, leaves it open to more such edge case paths. Figured may as well just take the hit.
2. Re-adding the explicit typeof string check, but felt the above was a decent compromise, without re-introducing the check [ which from the extensive profiling done for 3.10.0, did have an impact ].

_[I've branched off of the v3.11.0 tag on dev-master for this currently, as opposed to dev-master HEAD. We can revisit that if required when we decide on the next release ]_
