### PR TITLE
fix an error in an example of the event simulate documentation

### DIFF
--- a/src/event/docs/simulate.mustache
+++ b/src/event/docs/simulate.mustache
@@ -404,8 +404,8 @@ YUI().use('node-event-simulate', function(Y) {
 
     //simulate a flick down 100 pixels over 50ms
     node.simulateGesture("flick", {
-        axis: y
-        distance: -100 
+        axis: "y",
+        distance: -100,
         duration: 50
     });
 


### PR DESCRIPTION
Hi YUI Team,

I found mistakes in the documentation, about DOM Events simulation : http://yuilibrary.com/yui/docs/event/simulate.html, on the part "Single Touch Gestures: Move and Flick" : commas was missing and axis value should be string.

Hope this helps,

Julien
