### PR TITLE
Fixed spelling error in ddm-base.js: 'Manger' should be 'Manager'

### DIFF
--- a/src/dd/js/ddm-base.js
+++ b/src/dd/js/ddm-base.js
@@ -1,11 +1,11 @@
 
     /**
-     * Provides the base Drag Drop Manger required for making a Node draggable.
+     * Provides the base Drag Drop Manager required for making a Node draggable.
      * @module dd
      * @submodule dd-ddm-base
      */
      /**
-     * Provides the base Drag Drop Manger required for making a Node draggable.
+     * Provides the base Drag Drop Manager required for making a Node draggable.
      * @class DDM
      * @extends Base
      * @constructor


### PR DESCRIPTION
There was a spelling error on this page: http://yuilibrary.com/yui/docs/api/classes/DD.DDM.html

"Provides the base Drag Drop Manger..."
  should be:
"Provides the base Drag Drop Manager..."
