### PR TITLE
Removing extraguard condition on touchEnd

### DIFF
--- a/build/event-tap/event-tap.js
+++ b/build/event-tap/event-tap.js
@@ -237,18 +237,14 @@ Y.Event.define(EVT_TAP, {
 
         detachHelper(subscription, [ HANDLES.MOVE, HANDLES.END, HANDLES.CANCEL ], true, context);
 
-        // make sure mouse didn't move
-        if (Math.abs(endXY[0] - startXY[0]) === 0 && Math.abs(endXY[1] - startXY[1]) === 0) {
+        event.type = EVT_TAP;
+        event.pageX = endXY[0];
+        event.pageY = endXY[1];
+        event.clientX = clientXY[0];
+        event.clientY = clientXY[1];
+        event.currentTarget = context.node;
 
-            event.type = EVT_TAP;
-            event.pageX = endXY[0];
-            event.pageY = endXY[1];
-            event.clientX = clientXY[0];
-            event.clientY = clientXY[1];
-            event.currentTarget = context.node;
-
-            notifier.fire(event);
-        }
+        notifier.fire(event);
     }
 });
 


### PR DESCRIPTION
Some android devices (Galaxy S4, Nexus 7) return a difference of one pixel on X and Y sometimes (even if the touchMove didn't get triggered which is odd). 

Rely only on the touchMove removes Android tap issues.
