### PR TITLE
Address issue in which a chart was not visible when the dataProvider changed from large to small values.

### DIFF
--- a/src/charts/js/Graph.js
+++ b/src/charts/js/Graph.js
@@ -780,7 +780,10 @@ Y.Graph = Y.Base.create("graph", Y.Widget, [Y.Renderer], {
             {
                 if(!this._graphic)
                 {
-                    this._graphic = new Y.Graphic({render:this.get("contentBox")});
+                    this._graphic = new Y.Graphic({
+                        render:this.get("contentBox"),
+                        resizeDown: true
+                    });
                     this._graphic.get("node").style.zIndex = 2;
                     this._graphic.set("autoDraw", false);
                 }


### PR DESCRIPTION
Fix #1056. Charts weren't rendering properly when the dataProvider was updated with large values and updated again with smaller values.

This fix has been tested across all a-grade browsers plus win7/ie11 and win8.1/ie11. (unit and functional)
