### PR TITLE
Node - address node test failures ie 6, 7. 

### DIFF
--- a/src/node/js/node-view.js
+++ b/src/node/js/node-view.js
@@ -42,8 +42,7 @@ Y.mix(Y_Node.prototype, {
     },
 
     _isHidden: function() {
-        return this._node.hasAttribute('hidden')
-            || Y.DOM.getComputedStyle(this._node, 'display') === 'none';
+        return  this.hasAttribute('hidden') || Y.DOM.getComputedStyle(this._node, 'display') === 'none';
     },
 
     /**


### PR DESCRIPTION
Added implementation of _isHidden for browsers that don't have hasAttribute. (ie 6,7) Fix #1080.
