### PR TITLE
[Calendar] Fix #1030: Fix a issue with cloudn't select a date when passing minimumDate

### DIFF
--- a/src/calendar/js/calendar-base.js
+++ b/src/calendar/js/calendar-base.js
@@ -409,6 +409,7 @@ Y.CalendarBase = Y.extend( CalendarBase, Y.Widget, {
      * @private
      */
     _addDateToSelection : function (oDate, index) {
+        oDate.setHours(12);
 
         if (this._canBeSelected(oDate)) {
 

--- a/src/calendar/tests/unit/assets/calendar-tests.js
+++ b/src/calendar/tests/unit/assets/calendar-tests.js
@@ -225,6 +225,20 @@ YUI.add('calendar-tests', function(Y) {
 
             },
 
+            testMinDatesSelection : function () {
+                var cfg = {
+                    contentBox: "#firstcontainer",
+                    date: new Date(2011,11,5),
+                    minimumDate: new Date(2011,11,5)
+                };
+
+                this.firstcalendar = new Y.Calendar(cfg);
+                this.firstcalendar.render();
+                this.firstcalendar.selectDates(new Date(2011,11,5));
+
+                Y.Assert.isTrue(this.firstcalendar._dateToNode(new Date(2011,11,5)).hasClass("yui3-calendar-day-selected"));
+            },
+
             testRules : function () {
                 var myRules = {
                    "2011": "fullyear",


### PR DESCRIPTION
This issue happen in select any dates by selectDates() method when passing minimumDate configuration. Fix #1030.
