### PR TITLE
[Calendar] Fix #932: The customRenderer attribute isn't read only

### DIFF
--- a/src/calendar/js/calendar-base.js
+++ b/src/calendar/js/calendar-base.js
@@ -1664,7 +1664,6 @@ Y.CalendarBase = Y.extend( CalendarBase, Y.Widget, {
          * customizing specific calendar cells.
          *
          * @attribute customRenderer
-         * @readOnly
          * @type Object
          * @default {}
          */


### PR DESCRIPTION
This attribute commented as read only on the API document, but it was actually not read only. Fix #932.
