### PR TITLE
Fixes #1145. e.stopProp() edge case for focus

### DIFF
--- a/src/event/HISTORY.md
+++ b/src/event/HISTORY.md
@@ -4,7 +4,10 @@ Event Infrastructure Change History
 @VERSION@
 ------
 
-* No changes.
+* Delegated focus and blur events now behave the same way other events do when
+  a delegate sub from a container closer to the target calls
+  `e.stopPropagation()`. Delegate subs from containers higher in the parent
+  axis are not notified. [#1145](https://github.com/yui/yui3/issues/1145)
 
 3.12.0
 ------

--- a/src/event/js/focusblur.js
+++ b/src/event/js/focusblur.js
@@ -214,7 +214,14 @@ function define(type, proxy, directEvent) {
                             ret = notifier.fire(e);
                         }
 
-                        if (ret === false || e.stopped === 2) {
+                        if (ret === false || e.stopped === 2 ||
+                            // If e.stopPropagation() is called, notify any
+                            // delegate subs from the same container, but break
+                            // once the container changes. This emulates
+                            // delegate() behavior for events like 'click' which
+                            // won't notify delegates higher up the parent axis.
+                            (e.stopped && delegates[i+1] &&
+                             delegates[i+1].container !== notifier.container)) {
                             break;
                         }
                     }

--- a/src/event/tests/unit/focusblur.html
+++ b/src/event/tests/unit/focusblur.html
@@ -314,8 +314,13 @@
                         called = 0;
 
                     // Matches at the same level, stopProp should not prevent
-                    // both delegate callbacks
+                    // delegate callbacks from the same container, but should
+                    // for containers higher up the parent axis.
                     handles.push(
+                        Y.one('#container').delegate('focus', function (e) {
+                            called++;
+                            e.stopPropagation();
+                        }, '.not-focusable'),
                         Y.one('#container').delegate('focus', function (e) {
                             called++;
                             e.stopPropagation();


### PR DESCRIPTION
Multiple delegates for the same node were getting notified when e.stopProp()
was called, even though they were delegating from different containers. This
would be fine (delegate pretends to be individual direct subscriptions) if it
weren't inconsistent with how other events work in that scenario.
