### PR TITLE
[YUI] Change data type from Int to Number

### DIFF
--- a/src/yui-throttle/js/throttle.js
+++ b/src/yui-throttle/js/throttle.js
@@ -22,7 +22,7 @@ to the `Y` object and is <a href="../classes/YUI.html#method_throttle">documente
  * @method throttle
  * @for YUI
  * @param fn {function} The function call to throttle.
- * @param ms {int} The number of milliseconds to throttle the method call.
+ * @param ms {Number} The number of milliseconds to throttle the method call.
  * Can set globally with Y.config.throttleTime or by call. Passing a -1 will
  * disable the throttle. Defaults to 150.
  * @return {function} Returns a wrapped function that calls fn throttled.

--- a/src/yui/js/yui-later.js
+++ b/src/yui/js/yui-later.js
@@ -14,7 +14,7 @@ var NO_ARGS = [];
  * single time unless periodic is set to true.
  * @for YUI
  * @method later
- * @param when {int} the number of milliseconds to wait until the fn
+ * @param when {Number} the number of milliseconds to wait until the fn
  * is executed.
  * @param o the context object.
  * @param fn {Function|String} the function to execute or the name of


### PR DESCRIPTION
Fix data type because we should use Number instead of Int on the our API documents and JavaScript world.

The related document:
http://yuilibrary.com/yui/docs/api/classes/YUI.html
