### PR TITLE
Node documentation update

### DIFF
--- a/src/node/js/node-create.js
+++ b/src/node/js/node-create.js
@@ -142,12 +142,16 @@ Y.mix(Y_Node.prototype, {
         Y.one(node).append(this);
         return this;
     },
-
+    
+    // This method is deprecated, and is intentionally left undocumented.
+    // Use `setHTML` instead.
     setContent: function(content) {
         this._insert(content, 'replace');
         return this;
     },
-
+    
+    // This method is deprecated, and is intentionally left undocumented.
+    // Use `getHTML` instead.
     getContent: function() {
         var node = this;
 


### PR DESCRIPTION
Since `setContent` and `getContent` have long been deprecated, I've removed the documentation for them. 
**Note**: It is not safe to actually remove these two methods, as it would most likely break an enormous amount of code in the wild.

I've also updated `setHTML`'s documentation to include a link to `Y.Escape.html`'s page.
