### PR TITLE
Node dependency issues, resolves #464

### DIFF
--- a/src/node/build.json
+++ b/src/node/build.json
@@ -3,7 +3,8 @@
     "builds": {
         "node-style": {
             "jsfiles": [
-                "node-style.js"
+                "node-style.js",
+                "node-view.js"
             ]
         },
         "node-event-simulate": {
@@ -52,7 +53,6 @@
                 "node-attrs.js",
                 "node-event.js",
                 "node-size.js",
-                "node-view.js",
                 "node-ie.js",
                 "node-data.js"
             ]

--- a/src/node/js/node-ie.js
+++ b/src/node/js/node-ie.js
@@ -31,7 +31,7 @@ Y.Node.ATTRS.type = {
             try {
                 this._node.type = 'hidden';
             } catch(e) {
-                this.setStyle('display', 'none');
+                this._node.style.display = 'none';
                 this._inputType = 'hidden';
             }
         } else {
@@ -59,4 +59,3 @@ if (Y.config.doc.createElement('form').elements.nodeType) {
             }
     };
 }
-


### PR DESCRIPTION
Changes made: 
- `node-style` now includes `node-view`, which fixes #464. There was an issue where `node-base` depended on `node-view`, which in turn depended on `node-style`. However, `node-base` does not include `node-style`, so an error was caused when methods from `node-view` were used. 
  _ex_: http://jsfiddle.net/HegLW/6/
- `node-ie` doesn't depend on `node-style` anymore.
