### PR TITLE
Y.DOM.contains unit test fix, resolves #1109

### DIFF
--- a/src/dom/tests/unit/assets/dom-core-test.js
+++ b/src/dom/tests/unit/assets/dom-core-test.js
@@ -638,7 +638,8 @@ YUI.add('dom-core-test', function(Y) {
 
         'should be true for contained comment node': function() {
             var node = document.createElement('div');
-            node.innerHTML = 'foo<!-- comment -->';
+            node.innerHTML = 'foo';
+            node.appendChild(document.createComment('bar'));
             Assert.isTrue(Y.DOM.contains(node, node.firstChild.nextSibling));
         },
 


### PR DESCRIPTION
The issue is being discussed in #1109.

Basically, WinJS strips comment nodes when setting innerHTML.

```
node.innerHTML = "<!-- foo --><p>bar</p>";
```

becomes

```
node.innerHTML; // <p>bar</p>
```

A workaround is creating the comment node manually, and then appending it. 
