### PR TITLE
Detect the transitionend event from the window when possible.

### DIFF
--- a/src/transition/js/transition-native.js
+++ b/src/transition/js/transition-native.js
@@ -113,8 +113,11 @@ TRANSITION_PROPERTY        = VENDOR_PREFIX + 'transition-property';
 TRANSITION_DURATION        = VENDOR_PREFIX + 'transition-duration';
 TRANSITION_TIMING_FUNCTION = VENDOR_PREFIX + 'transition-timing-function';
 TRANSITION_DELAY           = VENDOR_PREFIX + 'transition-delay';
-TRANSITION_END             = 'transitionEnd';
+TRANSITION_END             = 'transitionend';
 
+// Some implementations include the vendor prefix with the transitionEnd event.
+// Webkit populates the window with the appropriate event name, so we key off
+// of that when possible.
 if (Y.config.win && !Y.config.win.ontransitionend) {
     TRANSITION_END = VENDOR_TRANSITION_END[CAMEL_VENDOR_PREFIX] || TRANSITION_END;
 }


### PR DESCRIPTION
Safari 7 removes the prefix from the transitionend event.   Webkit populates the window with `ontransitionend`, so we can key off of that for proper detection.  Fixes #1204.

Tested on: Chrome 29, Firefox 24, IE 10, Safari 6 (desktop and iOS6), Safari 7 (iOS).
