### PR TITLE
Ensure req.params is correctly populated for Routers with a non-default root path.

### DIFF
--- a/src/app/js/router.js
+++ b/src/app/js/router.js
@@ -782,7 +782,7 @@ Y.Router = Y.extend(Router, Y.Base, {
 
                 // Decode each of the path matches so that the any URL-encoded
                 // path segments are decoded in the `req.params` object.
-                matches = YArray.map(route.regex.exec(path) || [], function (match) {
+                matches = YArray.map(route.regex.exec(self.removeRoot(path)) || [], function (match) {
                     // Decode matches, or coerce `undefined` matches to an empty
                     // string to match expectations of working with `req.params`
                     // in the content of route dispatching, and normalize

--- a/src/app/tests/unit/assets/router-test.js
+++ b/src/app/tests/unit/assets/router-test.js
@@ -1171,6 +1171,57 @@ routerSuite.add(new Y.Test.Case({
         Assert.areSame(5, calls);
     },
 
+    'request object should contain captured route parameters for Router with non-default root': function () {
+        var calls  = 0,
+            router = this.router = new Y.Router({
+                root: '/root/'
+            });
+
+        router.route('/foo/:bar/:baz', function (req) {
+            calls += 1;
+
+            ArrayAssert.itemsAreSame(['bar', 'baz'], Y.Object.keys(req.params));
+            ArrayAssert.itemsAreSame(['one', 'two'], Y.Object.values(req.params));
+        });
+
+        router.route('/bar/*path', function (req) {
+            calls += 1;
+
+            Assert.isObject(req.params);
+            ArrayAssert.itemsAreSame(['path'], Y.Object.keys(req.params));
+            ArrayAssert.itemsAreSame(['one/two'], Y.Object.values(req.params));
+        });
+
+        router.route(/^\/(baz)\/(quux)$/, function (req) {
+            calls += 1;
+
+            Assert.isArray(req.params);
+            ArrayAssert.itemsAreSame(['/baz/quux', 'baz', 'quux'], req.params);
+        });
+
+        router.route(/^\/((fnord)|(fnarf))\/(quux)$/, function (req) {
+            calls += 1;
+
+            Assert.isArray(req.params);
+            ArrayAssert.itemsAreSame(['/fnord/quux', 'fnord', 'fnord', '', 'quux'], req.params);
+        });
+
+        router.route(/^\/((blorp)|(blerf))\/(quux)$/, function (req) {
+            calls += 1;
+
+            Assert.isArray(req.params);
+            ArrayAssert.itemsAreSame(['/blerf/quux', 'blerf', '', 'blerf', 'quux'], req.params);
+        });
+
+        router._dispatch('/root/foo/one/two', {});
+        router._dispatch('/root/bar/one/two', {});
+        router._dispatch('/root/baz/quux', {});
+        router._dispatch('/root/fnord/quux', {});
+        router._dispatch('/root/blerf/quux', {});
+
+        Assert.areSame(5, calls);
+    },
+
     'route parameters should be decoded': function () {
         var calls       = 0,
             router      = this.router = new Y.Router(),


### PR DESCRIPTION
Found what I believe to be a bug after pulling down the changes in https://github.com/yui/yui3/pull/1198 where the route regex's aren't correctly matched (and hence the req.params aren't correctly populated) if the Router has a non-default root path. This was because the route regex is run over the full path being dispatched rather than the rootless path.
