### PR TITLE
Correct comment visibility for parentScroll

### DIFF
--- a/src/dd/js/scroll.js
+++ b/src/dd/js/scroll.js
@@ -33,6 +33,7 @@
         /**
         * Internal config option to hold the node that we are scrolling. Should not be set by the developer.
         * @attribute parentScroll
+        * @protected
         * @type Node
         */
         parentScroll: {


### PR DESCRIPTION
The documentation for parentScroll advises that this should not be set by
the developer, so it should probably be protected.
