### PR TITLE
Loader README update, resolves #570

### DIFF
--- a/src/loader/README.md
+++ b/src/loader/README.md
@@ -1,47 +1,7 @@
 YUI Loader
 ==========
 
-Processes dependencies and dynamically loads script and css for YUI and external modules.
-
-
-Development
------------
-
-The Loader build provides a Makefile for easy building. The Makefile contains the following targets:
-
-   * `all` - Runs `build` then `test` (the default)
-   * `build` - A passthrough to `ant all` (requires nodejs and python)
-   * `meta` - Runs the `scripts/meta_join.py` to build the meta data (requires python)
-   * `check` - Runs the `scripts/meta_check.js` to check meta-data for inconsistencies (requires nodejs)
-   * `test` - Runs a series of NodeJS based CLI tests (requires nodejs with yuitest installed)
-   * `gallery` - Fetches and updates the meta-data with the latest gallery build (requires nodejs)
-
-Testing
--------
-
-    npm -g i yuitest
-
-There is one set of automated CLI tests that can be run with `make test`. This will do a simple
-`Loader` call for a module and then check the Loader's `sorted` array for that module. A very simple
-smoke test to determine if Loader is functioning properly.
-
-There is an advanced test under `tests/server`. This test will attempt to load every yui3 module
-from one of these places:
-
-   * `STATIC` local static files 
-   * `COMBO` local combo handler
-   * `LOADER` local combo handle after fetching loader
-   * `STAR` use star `YUI().use('*')` with a dynamic script generated on the server
-   * `RLS` A local RLS server (not supported until YLS is released)
-
-To run these tests, `cd tests/server`
-
-    npm -g i yui3 express combohandler
-
-    export STAR=1; ./server.js
-    export LOCAL=1; export STAR=1; ./server.js
-    export LOCAL=1; export STAR=1; export COMBO=1; ./server.js
-    export LOCAL=1; export STAR=1; export COMBO=1; export LOADER=1; ./server.js #The normal test to run
-    export LOCAL=1; export STAR=1; export COMBO=1; export RLS=1; ./server.js
-    export LOCAL=1; export STAR=1; export COMBO=1; export LOADER=1; export RLS=1; ./server.js
-    
+Dynamically loads script and CSS files for YUI modules as well as external modules. 
+It includes the dependency information for the version of the library in use, and will automatically 
+pull in dependencies for the modules requested. It can load the files from the Yahoo! CDN as well as 
+local combo servers. 


### PR DESCRIPTION
The new description was taken from here: http://yuilibrary.com/yui/docs/yui/loader.html

The `Development` and `Testing` section were deleted, because learning how to build and test a module should best be left in some other document, such as `Developer Workflow`, located [here](https://github.com/yui/yui3/wiki/Developer-Workflow). And not to mention the information was extremely outdated.

Also, every other module's `README` in YUI never goes into detail as to how to build or test it. Their `README`s always provide a basic description of what the module does, and nothing more.

Examples:
- [Anim](https://github.com/yui/yui3/tree/master/src/anim)
- [DOM](https://github.com/yui/yui3/tree/master/src/dom)
- [Widget](https://github.com/yui/yui3/tree/master/src/widget)

This resolves #570.
