### PR TITLE
`event-valuechange` error when `vcData` is null

### DIFF
--- a/src/event-valuechange/js/event-valuechange.js
+++ b/src/event-valuechange/js/event-valuechange.js
@@ -86,9 +86,8 @@ VC = {
         var domNode  = node._node, // performance cheat; getValue() is a big hit when polling
             event    = options.e,
             vcData   = node._data && node._data[DATA_KEY], // another perf cheat
-            nodeName  = vcData.nodeName,
             stopped  = 0,
-            facade, prevVal, newVal, selectedOption, stopElement;
+            facade, prevVal, newVal, nodeName, selectedOption, stopElement;
 
         if (!(domNode && vcData)) {
             Y.log('_poll: node #' + node.get('id') + ' disappeared; stopping polling and removing all notifiers.', 'warn', 'event-valuechange');
@@ -97,6 +96,7 @@ VC = {
         }
 
         prevVal = vcData.prevVal;
+        nodeName  = vcData.nodeName;
 
         if (vcData.isEditable) {
             // Use innerHTML for performance


### PR DESCRIPTION
This changes the check for `nodeName` to only occur after `vcData` is shown to be non-null.
