### PR TITLE
Fix for flaky Promise test in IE9

### DIFF
--- a/src/promise/docs/assets/plugin-example-tests.js
+++ b/src/promise/docs/assets/plugin-example-tests.js
@@ -82,7 +82,7 @@ YUI.add('plugin-example-tests', function (Y) {
                     width = square.getComputedStyle('width');
                     height = square.getComputedStyle('height');
                     left = square.getComputedStyle('left');
-                }, 1100);
+                }, 1500);
                 setTimeout(function () {
                     test.resume(function () {
                         left = +left.substr(0, left.length - 2);
@@ -112,7 +112,7 @@ YUI.add('plugin-example-tests', function (Y) {
                         Assert.areEqual('300px', square.getComputedStyle('height'), 'Test div does not have the correct height after transition');
                         Assert.areEqual('200px', square.getComputedStyle('left'), 'Test div does not have the correct position after transition');
                     });
-                }, 1600);
+                }, 2000);
             });
 
             button.simulate('click');


### PR DESCRIPTION
Upping these timeouts on example tests resolves intermittent failures in IE9.

Failures
![screen shot 2013-09-30 at 2 55 52 pm](https://f.cloud.github.com/assets/14372/1241540/0a4aad7e-2a20-11e3-9058-c0116378986a.png)
