### PR TITLE
Update proxy.js

### DIFF
--- a/src/dd/js/proxy.js
+++ b/src/dd/js/proxy.js
@@ -1,4 +1,3 @@
-
     /**
      * Plugin for dd-drag for creating a proxy drag node, instead of dragging the original node.
      * @module dd
@@ -209,7 +208,8 @@
             if (ah) {
                 cur = ah.getStyle('cursor');
             }
-            if (cur === 'auto') {
+            
+            if (cur === 'auto' || (cur !== 'auto' && DDM.get('dragCursor') !== 'move')) {
                 cur = DDM.get('dragCursor');
             }
 


### PR DESCRIPTION
There is no way to modify the cursor style on the drag node, unless the initial cursor style is set to "auto". I would like to be able to customize both the initial hovering cursor style as well as the drag cursor style.

I find the whole dragCursor implementation to me clunky to begin with but at least this allows me to use the attribute when I actually want to.

Needs:
- [ ] Unit test
- [ ] History.md update
