### PR TITLE
Fix for failing Button selleck test

### DIFF
--- a/src/button/docs/partials/button-source-js.mustache
+++ b/src/button/docs/partials/button-source-js.mustache
@@ -9,7 +9,7 @@ YUI().use('button', function(Y){
             'pressedChange': function () {
                 var button = this,
                     pressed = button.get('pressed'),
-                    newLabel = 'this ' + (pressed ? 'pressed ' : 'depressed') + ' button :' + (pressed ? ')' : '(');
+                    newLabel = 'this ' + (pressed ? 'pressed' : 'depressed') + ' button :' + (pressed ? ')' : '(');
                 
                 button.set('label', newLabel);
             }


### PR DESCRIPTION
Additional whitespace was causing a failure during a string match.
