### PR TITLE
When html is rendered server-side and App.showContent is called, do not ...

### DIFF
--- a/src/app/js/app-base.js
+++ b/src/app/js/app-base.js
@@ -784,7 +784,7 @@ AppBase = Y.Base.create('app', Y.Base, [View, Router, PjaxBase], {
 
         // Prevent detaching (thus removing) the view we want to show. Also hard
         // to animate out and in, the same view.
-        if (newView === oldView) {
+        if (newView === oldView || options.render === false) {
             return callback && callback.call(this, newView);
         }
 


### PR DESCRIPTION
...replace html with itself in _uiSetActiveView().

We are having an issue with ads being removed from the DOM when HTML is rendered server-side:

What's happening is:
1. Server returns all html required to display page
2. showContent is fired
3. Our ad script replaces the ad node with actual ad markup
4. after('activeViewChange') fires _uiSetActiveView()
5. _uiSetActiveView replaces HTML (including ad) with original markup from node referenced in original showContent call

showContent passes its options "render=false" flag to the activeViewChange event handler but never uses it. Also, another possible fix might be to check if 'oldView' is null, then don't replace nodes but I am not sure under what other scenarios that might be true.

-Dave S
