### PR TITLE
Improve the Promise subclass example test

### DIFF
--- a/src/promise/docs/assets/subclass-example-tests.js
+++ b/src/promise/docs/assets/subclass-example-tests.js
@@ -1,6 +1,7 @@
 YUI.add('subclass-example-tests', function (Y) {
 
     var Assert = Y.Assert,
+        ArrayAssert = Y.ArrayAssert,
         suite = new Y.Test.Suite('subclass-example');
 
     suite.add(new Y.Test.Case({
@@ -12,13 +13,26 @@ YUI.add('subclass-example-tests', function (Y) {
 
         'test correct results from GitHub API': function () {
             var node = Y.one('#demo'),
-                expectedOutput = '<div>Fetching GitHub data for users: "yui", "yahoo" and "davglass"...</div><div>Getting name for user "yui"...</div><div>Getting name for user "yahoo"...</div><div>Getting name for user "davglass"...</div><div>Checking if the name "YUI Library" starts with "Y"...</div><div>Checking if the name "Yahoo! Inc." starts with "Y"...</div><div>Checking if the name "Dav Glass" starts with "Y"...</div><div>Done!</div><div>0. YUI Library</div><div>1. Yahoo! Inc.</div>';
+                expectedOutput = [
+                    'Fetching GitHub data for users: "yui", "yahoo" and "davglass"...',
+                    'Getting name for user "yui"...',
+                    'Getting name for user "yahoo"...',
+                    'Getting name for user "davglass"...',
+                    'Checking if the name "YUI Library" starts with "Y"...',
+                    'Checking if the name "Yahoo Inc." starts with "Y"...',
+                    'Checking if the name "Dav Glass" starts with "Y"...',
+                    'Done!',
+                    '0. YUI Library',
+                    '1. Yahoo Inc.'
+                ];
 
             this.poll(function() {
-                return node.get('children').size() > 1;
+                return node.get('children').size() === 10;
             }, 100, 10000, function () {
-                // Remove whitespace and case due to old IE differences
-                Assert.areEqual(expectedOutput.toLowerCase().replace(/\s+/g, ''), node.getHTML().toLowerCase().replace(/\s+/g, ''), 'Request output does not match');
+                var children = node.get('children'),
+                    data = children.get('text');
+
+                ArrayAssert.itemsAreSame(expectedOutput, data);
             }, function() {
                 Assert.fail('Polling failed for success node');
             });


### PR DESCRIPTION
Fixes a few common causes of error:
- Yahoo! is now Yahoo with no exclamation mark :exclamation: 
- Changes the poll check to check the node for 10 children, rather than > 1.  This previously caused problems when the "Done!" nodes were not yet appended.

Improves clarity of the test:
- It's no longer comparing a giant blob of HTML.
