### PR TITLE
Node-MenuNav documentation update, resolves #925

### DIFF
--- a/src/node-menunav/docs/index.mustache
+++ b/src/node-menunav/docs/index.mustache
@@ -1,3 +1,14 @@
+<div class="notice">
+    <p>
+        <strong>NOTICE</strong>: This component is <strong>deprecated</strong>
+        as of YUI 3.9.0 and will be removed in future versions.  
+    </p>
+
+    <p>
+        If you require functionality similar to the one provided by this module, consider taking a look at the various modules in the <a href="http://yuilibrary.com/gallery/">YUI Gallery</a>.
+    </p>
+</div>
+
 <div class="intro">
     <p>
         The MenuNav Node Plugin makes it easy to transform existing list-based
@@ -46,17 +57,6 @@
             in IE 6.
         </dd>
     </dl>
-</div>
-
-<div class="notice">
-    <p>
-        <strong>NOTICE</strong>: This component is <strong>deprecated</strong>
-        as of YUI 3.9.0 and will be removed in future versions.  
-    </p>
-
-    <p>
-        If you require functionality similar to the one provided by this module, consider taking a look at the various modules in the <a href="http://yuilibrary.com/gallery/">YUI Gallery</a>.
-    </p>
 </div>
 
 {{>getting-started}}


### PR DESCRIPTION
This fixes #925. The deprecation banner was simply moved up to increase clarification.
