### PR TITLE
Defaulting Y.ButtonCore's template to type=button (#973, #968)

### DIFF
--- a/src/button/js/core.js
+++ b/src/button/js/core.js
@@ -27,7 +27,7 @@ ButtonCore.prototype = {
      * @type {String}
      * @default <button/>
      */
-    TEMPLATE: '<button/>',
+    TEMPLATE: '<button type="button"/>',
 
     /**
      *
@@ -57,7 +57,7 @@ ButtonCore.prototype = {
      * @private
      */
     _initNode: function(config) {
-        if (config.host) {
+        if (config && config.host) {
             this._host = Y.one(config.host);
         } else {
             this._host = Y.Node.create(this.TEMPLATE);

--- a/src/button/tests/unit/assets/button-core-test.js
+++ b/src/button/tests/unit/assets/button-core-test.js
@@ -3,7 +3,7 @@ YUI.add('button-core-test', function (Y) {
     var Assert      = Y.Assert,
         ArrayAssert = Y.ArrayAssert,
         suite;
-    
+
     suite = new Y.Test.Suite('button-core');
 
     suite.add(new Y.Test.Case({
@@ -15,7 +15,7 @@ YUI.add('button-core-test', function (Y) {
                 host: Y.one("#testButton")
             });
         },
-    
+
         tearDown: function () {
             Y.one('#container').empty(true);
             delete this.button;
@@ -24,10 +24,10 @@ YUI.add('button-core-test', function (Y) {
         'Disabling a button should set the `disable` attribute to `true`': function () {
             var button = this.button;
             var node = button.getNode();
-        
+
             Assert.isFalse(button.get('disabled'));
             Assert.isFalse(node.hasClass('yui3-button-disabled'));
-            
+
             button.set('disabled', true);
             Assert.isTrue(button.get('disabled'));
             Assert.isTrue(node.hasClass('yui3-button-disabled'));
@@ -36,11 +36,11 @@ YUI.add('button-core-test', function (Y) {
         'Enabling a button should set the `disabled` attribute to `false`': function () {
             var button = this.button;
             var node = button.getNode();
-            
+
             button.disable();
             Assert.isTrue(button.get('disabled'));
             Assert.isTrue(node.hasClass('yui3-button-disabled'));
-        
+
             button.enable();
             Assert.isFalse(button.get('disabled'));
             Assert.isFalse(node.hasClass('yui3-button-disabled'));
@@ -50,48 +50,48 @@ YUI.add('button-core-test', function (Y) {
             var button = this.button;
             var defaultText = Y.ButtonCore.ATTRS.label.value;
             var newText = 'foobar';
-        
+
             button.set('label', newText);
             Assert.areEqual(newText, button.get('label'));
         },
-    
+
         'Changing the label should change the `innerHTML` value of a button node': function () {
             var button = this.button;
             var node = button.getNode();
             var defaultText = Y.ButtonCore.ATTRS.label.value;
             var newText = 'foobar';
-        
+
             button.set('label', newText);
             Assert.areEqual(newText, node.get('innerHTML'));
         },
-    
+
         'Changing the `disabled` attribute should fire a `disabledChange` event': function () {
             var button = this.button;
             var eventsTriggered = 0;
-        
+
             Y.augment(button, Y.Attribute);
-        
+
             button.on('disabledChange', function(){
                 eventsTriggered+=1;
             });
-        
+
             Assert.areEqual(0, eventsTriggered);
             button.set('disabled', true);
             Assert.areEqual(1, eventsTriggered);
             button.set('disabled', true);
             Assert.areEqual(2, eventsTriggered);
         },
-    
+
         'Changing the `label` attribute should fire a `labelChange` event': function () {
             var button = this.button;
             var eventsTriggered = 0;
-        
+
             Y.augment(button, Y.Attribute);
-        
+
             button.on('labelChange', function(){
                 eventsTriggered+=1;
             });
-        
+
             Assert.areEqual(0, eventsTriggered);
             button.set('label', 'something');
             Assert.areEqual(1, eventsTriggered);
@@ -123,48 +123,54 @@ YUI.add('button-core-test', function (Y) {
             Assert.areSame('&lt;div&gt;foo&lt;/div&gt;', button.getNode().get('innerHTML'));
          }
     }));
-    
+
     suite.add(new Y.Test.Case({
         name: 'Instantiation',
 
         setUp : function () {
 
         },
-    
+
         tearDown: function () {
             Y.one('#container').empty(true);
         },
-        
+
         'Creating an unattached button should create a Y.ButtonCore instance': function () {
             var button = new Y.ButtonCore({label:'foo'});
             Assert.areEqual(button.get('label'), 'foo');
             Assert.isInstanceOf(Y.ButtonCore, button);
         },
-    
+
         'Modifying the label of a nested button structure should not modify the non-label elements': function () {
             Y.one("#container").setContent('<button id="testButton">**<span class="yui3-button-label">Hello</span>**</button>');
             var button = new Y.ButtonCore({
                 host: Y.one("#testButton")
             });
             var node = button.getNode();
-            
+
             Assert.areEqual(node.get('text'), '**Hello**');
             button.set('label', button.get('label') + ' World');
             Assert.areEqual(button.get('label'), 'Hello World');
             Assert.areEqual(node.get('text'), '**Hello World**');
         },
-    
+
         'modifying the `label` attribute should work properly on <input> elements': function () {
             Y.one("#container").setContent('<input type="button" id="testButton" value="foo">');
             var button = new Y.ButtonCore({
                 host: Y.one("#testButton")
             });
-            
+
             Assert.areEqual(button.get('label'), 'foo');
             button.set('label', 'bar');
             Assert.areEqual(button.get('label'), 'bar');
-        }
-    
+        },
+
+        'Buttons should render as type=button': function () {
+            var button = new Y.ButtonCore();
+
+            Assert.areSame('button', button.getNode().get('type'));
+         }
+
     }));
 
     Y.Test.Runner.add(suite);


### PR DESCRIPTION
As issue https://github.com/yui/yui3/pull/968 mentions, any Buttons rendered without a `host`/`srcNode` config option will default to `type=submit`.  This is the correct behavior for any `<button>` element without a `type` attribute ([spec](http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#the-button-element)), however, in the context of Y.Button, that is certainly not the ideal default.  It is much more likely that someone would like to listen in on a click events instead of submit the parent form.  So this change updates the default `TEMPLATE` to include `type=button`.  

If the intent actually is to have `type=submit`, the implementer can either override Y.ButtonCore.prototype.TEMPLATE, or specify it in a new Y.Node instance in the config (as a new test does).

```
✓ Testing started on Firefox (24.0) / Mac OS, Chrome (30.0.1599.69) / Mac OS, Safari (6.0.5) / Mac OS, Safari (4.0) / Linux, Safari (4.0) / Linux, Safari (7.0) / iOS 7.0.2
✓ Agent completed: Safari (6.0.5) / Mac OS
✓ Agent completed: Chrome (30.0.1599.69) / Mac OS
✓ Agent completed: Firefox (24.0) / Mac OS
✓ Agent completed: Safari (4.0) / Android 2.3
✓ Agent completed: Safari (7.0) / iOS 7.0.2
✓ Agent completed: Safari (4.0) / Android 4
✓ Agent completed: Internet Explorer (9.0) / Windows 7
✓ Agent completed: Internet Explorer (10.0) / Windows 8
✓ Agent completed: Internet Explorer (8.0) / Windows XP
✓ Agent completed: Internet Explorer (7.0) / Windows XP
✓ Agent completed: Internet Explorer (6.0) / Windows XP
✓ 539 tests passed! (1 minutes, 14 seconds)
```
