### PR TITLE
Fixes cross-domain REST model.load() in older browsers via a simple (optional) config update

### DIFF
--- a/src/app/HISTORY.md
+++ b/src/app/HISTORY.md
@@ -4,7 +4,10 @@ App Framework Change History
 @VERSION@
 ------
 
-* No changes.
+### Model
+
+* For ModelSync.REST, added optional XDR config pass-through to Y.io in load() 
+  options.
 
 3.13.0
 ------

--- a/src/app/js/model-extensions/model-sync-rest.js
+++ b/src/app/js/model-extensions/model-sync-rest.js
@@ -437,7 +437,9 @@ RESTSync.prototype = {
       @param {Number} [options.timeout] The number of milliseconds before the
         request will timeout and be aborted. This overrides the default provided
         by the static `HTTP_TIMEOUT` property.
-    @param {Function} [callback] Called when the sync operation finishes.
+      @param {Object} [options.xdr] XDR config object to pass through to Y.io().
+        Note that all configs other than { use: 'native' } are deprecated.
+      @param {Function} [callback] Called when the sync operation finishes.
       @param {Error|null} callback.err If an error occurred, this parameter will
         contain the error. If the sync operation succeeded, _err_ will be
         falsy.
@@ -451,6 +453,7 @@ RESTSync.prototype = {
             headers   = Y.merge(RESTSync.HTTP_HEADERS, options.headers),
             timeout   = options.timeout || RESTSync.HTTP_TIMEOUT,
             csrfToken = options.csrfToken || RESTSync.CSRF_TOKEN,
+            xdr       = options.xdr,
             entity;
 
         // Prepare the content if we are sending data to the server.
@@ -487,7 +490,8 @@ RESTSync.prototype = {
             headers : headers,
             method  : method,
             timeout : timeout,
-            url     : url
+            url     : url,
+            xdr     : xdr
         });
     },
 
@@ -589,6 +593,7 @@ RESTSync.prototype = {
             headers: config.headers,
             method : config.method,
             timeout: config.timeout,
+            xdr: config.xdr,
 
             on: {
                 start  : this._onSyncIOStart,

--- a/src/app/tests/unit/assets/model-sync-rest-test.js
+++ b/src/app/tests/unit/assets/model-sync-rest-test.js
@@ -576,7 +576,7 @@ modelSyncRESTSuite.add(new Y.Test.Case({
         Assert.areSame(2, calls);
     },
 
-    'sync() should accept `csrfToken`, `headers`, and `timeout` options': function () {
+    'sync() should accept `csrfToken`, `headers`, `xdr`, and `timeout` options': function () {
         Y.TestModel.prototype.root = '/root/';
 
         var model = new Y.TestModel({name: 'Eric'});
@@ -586,6 +586,8 @@ modelSyncRESTSuite.add(new Y.Test.Case({
             Assert.areSame('application/xml', config.headers['Content-Type']);
             Assert.areSame('blabla', config.headers['X-CSRF-Token']);
             Assert.areSame(10000, config.timeout);
+            Assert.isObject(config.xdr);
+            Assert.areSame('native', config.xdr.use);
 
             this._onSyncIOSuccess(0, {
                 responseText: '{"id":1, "name":"Eric"}'
@@ -599,7 +601,8 @@ modelSyncRESTSuite.add(new Y.Test.Case({
         model.save({
             csrfToken: 'blabla',
             headers  : {'Content-Type': 'application/xml'},
-            timeout  : 10000
+            timeout  : 10000,
+            xdr      : {use: 'native'}
         });
 
         Assert.isFalse(model.isNew());


### PR DESCRIPTION
Using ModelSync.REST with IE 8 and 9 was failing when loading with cross-domain GET requests (i.e. the URL of the source data is in a separate domain from the current browser window). Unlike with Y.io(), there is currently no way to pass an XDR config to the underlying AJAX request to fix these errors.

This change simply allows a user to include an XDR object in the "options" parameter of model.load, which is passed through to the underlying Y.io() call. So the documentation for that option applies (i.e. { use: 'native' }).

In IE 8 and 9, this enables the use of the XDomainRequest which supports XDR; additionally this eliminates the extra preflight OPTIONS request in modern CORS-compliant browsers since setting the XDR config object causes Y.io to remove the "X-Requested-With" header.
