### PR TITLE
[Node][IE7] Can't get a BUTTON dom element's value attribute properly in IE7

### DIFF
--- a/src/dom/js/dom-attrs.js
+++ b/src/dom/js/dom-attrs.js
@@ -87,7 +87,8 @@ Y.mix(Y_DOM, {
         var ret = '';
         if (el && attr && el.getAttribute) {
             attr = Y_DOM.CUSTOM_ATTRIBUTES[attr] || attr;
-            ret = el.getAttribute(attr, ieAttr);
+            // BUTTON value issue for IE < 8
+            ret = (el.tagName === "BUTTON" && attr === 'value') ? Y_DOM.getValue(el) : el.getAttribute(attr, ieAttr);
 
             if (ret === null) {
                 ret = ''; // per DOM spec

--- a/src/dom/tests/unit/assets/dom-core-test.js
+++ b/src/dom/tests/unit/assets/dom-core-test.js
@@ -1214,6 +1214,13 @@ YUI.add('dom-core-test', function(Y) {
             Y.DOM.getAttribute(null);
             Y.DOM.getAttribute();
             Assert.isTrue(true);
+        },
+
+        'should return "value" attribute of a button': function () {
+           var node = document.getElementById('test-button-value'),
+               expected = 'button value';
+
+           Assert.areEqual(expected, Y.DOM.getAttribute(node, 'value'));
         }
     }));
 

--- a/src/node/js/node-ie.js
+++ b/src/node/js/node-ie.js
@@ -9,16 +9,6 @@ if (!Y.config.doc.documentElement.hasAttribute) { // IE < 8
         return !!(this._node.attributes[attr] &&
                 this._node.attributes[attr].specified);
     };
-
-    // IE < 8 fails to getAttribute('value') of BUTTON elements
-    // Instead gets the innerText of the element
-    Y.Node.prototype.getAttribute = function(attr) {
-        if (attr === 'value' && this._node.tagName === 'BUTTON') {
-            return this._node.get('value');
-        } else {
-            return this._node.getAttribute('value');
-        }
-    }
 }
 
 // IE throws an error when calling focus() on an element that's invisible, not


### PR DESCRIPTION
## Try it

With a 
`<button id="mybutton" value="1">Click me</button>`
dom element,

`Y.one("#mybutton").getAttribute("value")`will return
`Click me` instead of returning `1`
