### PR TITLE
`Anim#reverse` documentation, resolves #1276

### DIFF
--- a/src/anim/js/anim.js
+++ b/src/anim/js/anim.js
@@ -333,7 +333,8 @@
         },
 
         /**
-         * If true, animation begins from last frame
+         * If true, the `from` and `to` attributes are swapped, 
+         * and the animation is then run starting from `from`.
          * @attribute reverse
          * @type Boolean
          * @default false


### PR DESCRIPTION
Hi,

This fixes the confusion around `reverse` found in #1276.

I updated `Anim`'s `reverse` documentation to better reflect what actually goes on under the hood.
