### PR TITLE
Fixing the incorrect isNaN example in the [specialvalues] section

### DIFF
--- a/src/test/docs/index.mustache
+++ b/src/test/docs/index.mustache
@@ -460,7 +460,7 @@ var testCase = new Y.Test.Case({
         Y.Assert.isFalse(false);      //passes
         Y.Assert.isTrue(true);        //passes
         Y.Assert.isNaN(NaN);          //passes
-        Y.Assert.isNaN(5 / "5");      //passes
+        Y.Assert.isNaN(0 / 0);        //passes
         Y.Assert.isNotNaN(5);         //passes
         Y.Assert.isNull(null);        //passes
         Y.Assert.isNotNull(undefined);    //passes


### PR DESCRIPTION
I changed the 5 / "5" isNaN example because it results in 1 as javascript coerces the string into a number before dividing. Instead, 0 / 0 should be used since it will result in NaN.
