### PR TITLE
Missing dot in property reference, resolves #1354

### DIFF
--- a/src/datatable/js/core.js
+++ b/src/datatable/js/core.js
@@ -667,7 +667,7 @@ Y.mix(Table.prototype, {
                     map[key] = col;
                 }
                 else {Y.log('Key of column matches existing key or name: ' + key, 'warn', NAME);}
-                if (map[col_id]) {Y.log('Key of column matches existing key or name: ' + col._id, 'warn', NAME);}
+                if (map[col._id]) {Y.log('Key of column matches existing key or name: ' + col._id, 'warn', NAME);}
                 //TODO: named columns can conflict with keyed columns
                 map[col._id] = col;
 


### PR DESCRIPTION
This fixes #1354. A dot was missing when referencing `_id`. Not sure how this was missed, but it was...

Pinging @apipkin.
