### PR TITLE
Uploaderror payload includes xhr response

### DIFF
--- a/src/file/js/file-html5.js
+++ b/src/file/js/file-html5.js
@@ -138,7 +138,7 @@
                    }
                    else {
                         this.fire("uploaderror", {originEvent: event,
-                                                  response: xhr.response,
+                                                  data: xhr.responseText,
                                                   status: xhr.status,
                                                   statusText: xhr.statusText,
                                                   source: "http"});
@@ -155,8 +155,8 @@
                    *  <dl>
                    *      <dt>originEvent</dt>
                    *          <dd>The original event fired by the XMLHttpRequest instance.</dd>
-                   *      <dt>response</dt>
-                   *          <dd>The XMLHttpRequest response.</dd>
+                   *      <dt>data</dt>
+                   *          <dd>The data returned by the server.</dd>
                    *      <dt>status</dt>
                    *          <dd>The status code reported by the XMLHttpRequest. If it's an HTTP error,
                                   then this corresponds to the HTTP status code received by the uploader.</dd>
@@ -169,7 +169,7 @@
                    *  </dl>
                    */
                    this.fire("uploaderror", {originEvent: event,
-                                                  response: xhr.response,
+                                                  data: xhr.responseText,
                                                   status: xhr.status,
                                                   statusText: xhr.statusText,
                                                   source: "io"});


### PR DESCRIPTION
If a file upload fails in an uploader-queue, obtaining the `xhr` response is difficult since uploader-queue will call `abort` on the `xhr` in its error handler. Including `xhr.responseText` in the event payload alleviates these difficulties.
