### PR TITLE
Graphics - Fix for issue 1375

### DIFF
--- a/src/graphics/js/SVGShape.js
+++ b/src/graphics/js/SVGShape.js
@@ -777,11 +777,11 @@ Y.extend(SVGShape, Y.GraphicBase, Y.mix({
         if(stroke && stroke.weight)
         {
             wt = stroke.weight;
+            w = (x + w + wt) - (x - wt);
+            h = (y + h + wt) - (y - wt);
+            x -= wt;
+            y -= wt;
         }
-        w = (x + w + wt) - (x - wt);
-        h = (y + h + wt) - (y - wt);
-        x -= wt;
-        y -= wt;
 		return this._normalizedMatrix.getContentRect(w, h, x, y);
 	},
 


### PR DESCRIPTION
Addressed issue in which stroke was not considered in calculating bounds of an svg path. 
All graphics and charts unit tests pass on:
ios 7 safari
mac safari
android 2.3.4
android 4.1.1
ff
chrome
ie 6,7,8,9,10,11
