### PR TITLE
Charts Axis - Add ability to offset labels.

### DIFF
--- a/src/charts/js/Axis.js
+++ b/src/charts/js/Axis.js
@@ -254,6 +254,7 @@ Y.Axis = Y.Base.create("axis", Y.Widget, [Y.AxisBase], {
                 alpha: 1,
                 fontSize:"85%",
                 rotation: 0,
+                offset: 0.5,
                 margin: {
                     top: undefined,
                     right: undefined,
@@ -1633,6 +1634,11 @@ Y.Axis = Y.Base.create("axis", Y.Widget, [Y.AxisBase], {
          *              <dt>alpha</dt><dd>Number between 0 and 1 indicating the opacity of the labels. The default value is 1.</dd>
          *              <dt>fontSize</dt><dd>The font-size of the labels. The default value is 85%</dd>
          *              <dt>rotation</dt><dd>The rotation, in degrees (between -90 and 90) of the labels. The default value is 0.</dd>
+         *              <dt>offset</td><dd>A number between 0 and 1 indicating the relationship of the label to a tick. For a horizontal axis
+         *              label, a value of 0 will position the label's left side even to the the tick. A position of 1 would position the
+         *              right side of the label with the tick. A position of 0.5 would center the label horizontally with the tick. For a
+         *              vertical axis, a value of 0 would position the top of the label with the tick, a value of 1 would position the bottom
+         *              of the label with the tick and a value 0 would center the label vertically with the tick. The default value is 0.5.</dd>
          *              <dt>margin</dt><dd>The distance between the label and the axis/tick. Depending on the position of the `Axis`,
          *              only one of the properties used.
          *                  <dl>

--- a/src/charts/js/BottomAxisLayout.js
+++ b/src/charts/js/BottomAxisLayout.js
@@ -215,6 +215,7 @@ BottomAxisLayout.prototype = {
     positionLabel: function(label, pt, styles, i)
     {
         var host = this,
+            offset = parseFloat(styles.label.offset),
             tickOffset = host.get("bottomTickOffset"),
             labelStyles = styles.label,
             margin = 0,
@@ -229,18 +230,29 @@ BottomAxisLayout.prototype = {
         {
             margin = labelStyles.margin.top;
         }
-        if(rot > 0)
+        if(rot === 90)
         {
+            topOffset -= labelHeight/2 * rot/90;
+            leftOffset = leftOffset + labelHeight/2 - (labelHeight * offset);
+        }
+        else if(rot === -90)
+        {
+            topOffset -= labelHeight/2 * absRot/90;
+            leftOffset = leftOffset - labelWidth + labelHeight/2 - (labelHeight * offset);
+        }
+        else if(rot > 0)
+        {
+            leftOffset = leftOffset + labelHeight/2 - (labelHeight * offset);
             topOffset -= labelHeight/2 * rot/90;
         }
         else if(rot < 0)
         {
-            leftOffset -= labelWidth;
+            leftOffset = leftOffset - labelWidth + labelHeight/2 - (labelHeight * offset);
             topOffset -= labelHeight/2 * absRot/90;
         }
         else
         {
-            leftOffset -= labelWidth * 0.5;
+            leftOffset -= labelWidth * offset;
         }
         topOffset += margin;
         topOffset += tickOffset;

--- a/src/charts/js/LeftAxisLayout.js
+++ b/src/charts/js/LeftAxisLayout.js
@@ -231,6 +231,7 @@ LeftAxisLayout.prototype = {
     positionLabel: function(label, pt, styles, i)
     {
         var host = this,
+            offset = parseFloat(styles.label.offset),
             tickOffset = host.get("leftTickOffset"),
             totalTitleSize = this._totalTitleSize,
             leftOffset = pt.x + totalTitleSize - tickOffset,
@@ -244,21 +245,22 @@ LeftAxisLayout.prototype = {
         if(rot === 0)
         {
             leftOffset -= labelWidth;
-            topOffset -= labelHeight * 0.5;
+            topOffset -= labelHeight * offset;
         }
         else if(rot === 90)
         {
             leftOffset -= labelWidth * 0.5;
+            topOffset = topOffset + labelWidth/2 - (labelWidth * offset);
         }
         else if(rot === -90)
         {
             leftOffset -= labelWidth * 0.5;
-            topOffset -= labelHeight;
+            topOffset = topOffset - labelHeight + labelWidth/2 - (labelWidth * offset);
         }
         else
         {
             leftOffset -= labelWidth + (labelHeight * absRot/360);
-            topOffset -= labelHeight * 0.5;
+            topOffset -= labelHeight * offset;
         }
         props.labelWidth = labelWidth;
         props.labelHeight = labelHeight;

--- a/src/charts/js/RightAxisLayout.js
+++ b/src/charts/js/RightAxisLayout.js
@@ -217,6 +217,7 @@ RightAxisLayout.prototype = {
     positionLabel: function(label, pt, styles, i)
     {
         var host = this,
+            offset = parseFloat(styles.label.offset),
             tickOffset = host.get("rightTickOffset"),
             labelStyles = styles.label,
             margin = 0,
@@ -233,20 +234,21 @@ RightAxisLayout.prototype = {
         }
         if(rot === 0)
         {
-            topOffset -= labelHeight * 0.5;
+            topOffset -= labelHeight * offset;
         }
         else if(rot === 90)
         {
             leftOffset -= labelWidth * 0.5;
-            topOffset -= labelHeight;
+            topOffset = topOffset - labelHeight + labelWidth/2 - (labelWidth * offset);
         }
         else if(rot === -90)
         {
+            topOffset = topOffset + labelWidth/2 - (labelWidth * offset);
             leftOffset -= labelWidth * 0.5;
         }
         else
         {
-            topOffset -= labelHeight * 0.5;
+            topOffset -= labelHeight * offset;
             leftOffset += labelHeight/2 * absRot/90;
         }
         leftOffset += margin;

--- a/src/charts/js/TopAxisLayout.js
+++ b/src/charts/js/TopAxisLayout.js
@@ -215,6 +215,7 @@ TopAxisLayout.prototype = {
     positionLabel: function(label, pt, styles, i)
     {
         var host = this,
+            offset = parseFloat(styles.label.offset),
             totalTitleSize = this._totalTitleSize,
             maxLabelSize = host._maxLabelSize,
             leftOffset = pt.x,
@@ -226,27 +227,29 @@ TopAxisLayout.prototype = {
             labelHeight = this._labelHeights[i];
         if(rot === 0)
         {
-            leftOffset -= labelWidth * 0.5;
+            leftOffset -= labelWidth * offset;
             topOffset -= labelHeight;
         }
         else
         {
             if(rot === 90)
             {
-                leftOffset -= labelWidth;
+                leftOffset = leftOffset - labelWidth + labelHeight/2 - (labelHeight * offset);
                 topOffset -= (labelHeight * 0.5);
             }
             else if (rot === -90)
             {
+                leftOffset = leftOffset + labelHeight/2 - (labelHeight * offset);
                 topOffset -= (labelHeight * 0.5);
             }
             else if(rot > 0)
             {
-                leftOffset -= labelWidth;
+                leftOffset = leftOffset - labelWidth + labelHeight/2 - (labelHeight * offset);
                 topOffset -= labelHeight - (labelHeight * rot/180);
             }
             else
             {
+                leftOffset = leftOffset + labelHeight/2 - (labelHeight * offset);
                 topOffset -= labelHeight - (labelHeight * absRot/180);
             }
         }


### PR DESCRIPTION
Add label.offset to the axis' style attribute allow labels to positioned above or below a tick on a vertical axis and to the left and right of a horizontal tick.

Proposed fix for https://github.com/yui/yui3/issues/1381

Need to test:
- [x] ie6
- [x] ie7
- [x] ie8
- [x] ie9
- [x] ie10
- [x] ie11
- [x] mac safari
- [x] ios safari
- [x] android 2.3.4
- [x] android 4.1.1
- [x] firefox
- [x] chrome
