### PR TITLE
Charts - Address issue in which column/bar graphs with missing data and groupMarkers set to true

### DIFF
--- a/src/charts/js/Histogram.js
+++ b/src/charts/js/Histogram.js
@@ -117,7 +117,7 @@ Histogram.prototype = {
             yMarkerPlaneBottom = yMarkerPlaneTop + seriesSize;
             xMarkerPlane.push({start: xMarkerPlaneLeft, end: xMarkerPlaneRight});
             yMarkerPlane.push({start: yMarkerPlaneTop, end: yMarkerPlaneBottom});
-            if(isNaN(xcoords[i]) || isNaN(ycoords[i]))
+            if(!groupMarkers && (isNaN(xcoords[i]) || isNaN(ycoords[i])))
             {
                 this._markers.push(null);
                 continue;


### PR DESCRIPTION
Proposed fix for: https://github.com/yui/yui3/issues/1392

Need to test:
- [x] ie6
- [x] ie7
- [x] ie8
- [x] ie9
- [x] ie10
- [x] ie11
- [x] mac safari
- [x] ios safari
- [x] android 2.3.4
- [x] android 4.1.1
- [x] firefox
- [x] chrome
