### PR TITLE
Paginator page number, resolves #1383

### DIFF
--- a/src/datatable/js/paginator.js
+++ b/src/datatable/js/paginator.js
@@ -349,7 +349,9 @@ View = Y.Base.create('dt-pg-view', Y.View, [], {
         e.preventDefault();
 
         input = e.target.one('input');
-        this.fire(EVENT_UI, { type: 'page', val: input.get('value') });
+
+        // Note: Convert input's value into a number.
+        this.fire(EVENT_UI, { type: 'page', val: +input.get('value') });
     },
 
     /**


### PR DESCRIPTION
This fixes #1383. It appears Paginator does not convert the values fed to page into a number before setting them. This is especially important when getting the page number from, say, an `input` element.

This fix simply converts the value gotten from the `input` element into a number. This route was ultimately decided after discussion in #1389.
