### PR TITLE
Charts - Remove Y.clone

### DIFF
--- a/src/charts/js/BarSeries.js
+++ b/src/charts/js/BarSeries.js
@@ -58,7 +58,7 @@ Y.BarSeries = Y.Base.create("barSeries", Y.MarkerSeries, [Y.Histogram], {
     {
         if(this._markers && this._markers[i])
         {
-            var styles = Y.clone(this.get("styles").marker),
+            var styles = this._copyObject(this.get("styles").marker),
                 markerStyles,
                 state = this._getState(type),
                 xcoords = this.get("xcoords"),

--- a/src/charts/js/ColumnSeries.js
+++ b/src/charts/js/ColumnSeries.js
@@ -58,7 +58,7 @@ Y.ColumnSeries = Y.Base.create("columnSeries", Y.MarkerSeries, [Y.Histogram], {
     {
         if(this._markers && this._markers[i])
         {
-            var styles = Y.clone(this.get("styles").marker),
+            var styles = this._copyObject(this.get("styles").marker),
                 markerStyles,
                 state = this._getState(type),
                 xcoords = this.get("xcoords"),
@@ -75,7 +75,7 @@ Y.ColumnSeries = Y.Base.create("columnSeries", Y.MarkerSeries, [Y.Histogram], {
                 xs = [],
                 order = this.get("order"),
                 config;
-            markerStyles = state === "off" || !styles[state] ? Y.clone(styles) : Y.clone(styles[state]);
+            markerStyles = state === "off" || !styles[state] ? this._copyObject(styles) : this._copyObject(styles[state]);
             markerStyles.fill.color = this._getItemColor(markerStyles.fill.color, i);
             markerStyles.border.color = this._getItemColor(markerStyles.border.color, i);
             config = this._getMarkerDimensions(xcoords[i], ycoords[i], styles.width, offset);

--- a/src/charts/js/Histogram.js
+++ b/src/charts/js/Histogram.js
@@ -29,7 +29,7 @@ Histogram.prototype = {
         {
             return;
         }
-        var style = Y.clone(this.get("styles").marker),
+        var style = this._copyObject(this.get("styles").marker),
             graphic = this.get("graphic"),
             setSize,
             calculatedSize,

--- a/src/charts/js/PieSeries.js
+++ b/src/charts/js/PieSeries.js
@@ -491,7 +491,7 @@ Y.PieSeries = Y.Base.create("pieSeries", Y.SeriesBase, [Y.Plots], {
     {
         var graphic = this.get("graphic"),
             marker,
-            cfg = Y.clone(styles);
+            cfg = this._copyObject(styles);
         marker = graphic.addShape(cfg);
         marker.addClass(SERIES_MARKER);
         return marker;

--- a/src/charts/js/Plots.js
+++ b/src/charts/js/Plots.js
@@ -51,7 +51,7 @@ Plots.prototype = {
 			return;
 		}
         var isNumber = Y_Lang.isNumber,
-            style = Y.clone(this.get("styles").marker),
+            style = this._copyObject(this.get("styles").marker),
             w = style.width,
             h = style.height,
             xcoords = this.get("xcoords"),
@@ -259,7 +259,7 @@ Plots.prototype = {
     {
         var graphic = this.get("graphic"),
             marker,
-            cfg = Y.clone(styles);
+            cfg = this._copyObject(styles);
         cfg.type = cfg.shape;
         marker = graphic.addShape(cfg);
         marker.addClass(SERIES_MARKER);
@@ -403,7 +403,7 @@ Plots.prototype = {
         {
             var w,
                 h,
-                styles = Y.clone(this.get("styles").marker),
+                styles = this._copyObject(this.get("styles").marker),
                 state = this._getState(type),
                 xcoords = this.get("xcoords"),
                 ycoords = this.get("ycoords"),

--- a/src/charts/js/Renderer.js
+++ b/src/charts/js/Renderer.js
@@ -111,6 +111,36 @@ Renderer.prototype = {
     },
 
     /**
+     * Copies an object literal.
+     *
+     * @method _copyObject
+     * @param {Object} obj Object literal to be copied.
+     * @return Object
+     * @private
+     */
+    _copyObject: function(obj) {
+        var newObj = {},
+            key,
+            val;
+        for(key in obj)
+        {
+            if(obj.hasOwnProperty(key))
+            {
+                val = obj[key];
+                if(typeof val === "object" && !Y_Lang.isArray(val))
+                {
+                    newObj[key] = this._copyObject(val);
+                }
+                else
+                {
+                    newObj[key] = val;
+                }
+            }
+        }
+        return newObj;
+    },
+
+    /**
      * Gets the default value for the `styles` attribute.
      *
      * @method _getDefaultStyles

--- a/src/charts/js/StackedBarSeries.js
+++ b/src/charts/js/StackedBarSeries.js
@@ -33,7 +33,7 @@ Y.StackedBarSeries = Y.Base.create("stackedBarSeries", Y.BarSeries, [Y.StackingU
         }
 
         var isNumber = Y_Lang.isNumber,
-            style = Y.clone(this.get("styles").marker),
+            style = this._copyObject(this.get("styles").marker),
             w = style.width,
             h = style.height,
             xcoords = this.get("xcoords"),
@@ -212,7 +212,7 @@ Y.StackedBarSeries = Y.Base.create("stackedBarSeries", Y.BarSeries, [Y.StackingU
                 marker = this._markers[i],
                 styles = this.get("styles").marker,
                 h = styles.height,
-                markerStyles = state === "off" || !styles[state] ? Y.clone(styles) : Y.clone(styles[state]),
+                markerStyles = state === "off" || !styles[state] ? this._copyObject(styles) : this._copyObject(styles[state]),
                 fillColor,
                 borderColor;
             markerStyles.y = (ycoords[i] - h/2);

--- a/src/charts/js/StackedColumnSeries.js
+++ b/src/charts/js/StackedColumnSeries.js
@@ -31,7 +31,7 @@ Y.StackedColumnSeries = Y.Base.create("stackedColumnSeries", Y.ColumnSeries, [Y.
             return;
         }
         var isNumber = Y_Lang.isNumber,
-            style = Y.clone(this.get("styles").marker),
+            style = this._copyObject(this.get("styles").marker),
             w = style.width,
             h = style.height,
             xcoords = this.get("xcoords"),
@@ -215,7 +215,7 @@ Y.StackedColumnSeries = Y.Base.create("stackedColumnSeries", Y.ColumnSeries, [Y.
                 borderColor;
             styles = this.get("styles").marker;
             offset = styles.width * 0.5;
-            markerStyles = state === "off" || !styles[state] ? Y.clone(styles) : Y.clone(styles[state]);
+            markerStyles = state === "off" || !styles[state] ? this._copyObject(styles) : this._copyObject(styles[state]);
             markerStyles.height = marker.get("height");
             markerStyles.x = (xcoords[i] - offset);
             markerStyles.y = marker.get("y");


### PR DESCRIPTION
Replaces Y.clone with an application specific method that only deep copies object literals. Initial testing indicates perf improvements but more testing is needed. 
