### PR TITLE
Remove `2in3` tests due to deprecation

### DIFF
--- a/src/loader/tests/unit/assets/loader-tests.js
+++ b/src/loader/tests/unit/assets/loader-tests.js
@@ -526,7 +526,7 @@ YUI.add('loader-tests', function(Y) {
                     Assert.areSame(proContext, Y, 'onProgress context does not match');
                     Assert.isUndefined(Y.LOADED, 'Callback executed twice.');
                     Assert.isObject(Y.DOM, 'YUI3 DOM did not load.');
-                    Assert.isFunction(Y.Editor, 'YUI3 Editor did not load.');
+                    Assert.isFunction(Y.EditorBase, 'YUI3 Editor did not load.');
                     Assert.isFunction(Y.bitly, 'gallery-bitly did not load.');
                     Y.LOADED = true;
                 });


### PR DESCRIPTION
This removes portions of the `2in3` assertions inside of Loader, which was previously marked for deprecation.

Let me know if there any better tests to replace them with, or if there's any additional work that needs to be done.

\cc @reid @triptych 
