### PR TITLE
[Panel] Accessibility Enhancements

### DIFF
--- a/src/panel/assets/skins/night/panel-skin.css
+++ b/src/panel/assets/skins/night/panel-skin.css
@@ -41,6 +41,10 @@
         to(#3E3F41)
     );
 }
+.yui3-skin-night .yui3-panel-title {
+    margin: 0;
+    font-size: inherit;
+}
 .yui3-skin-night .yui3-panel .yui3-widget-hd .yui3-widget-buttons {
     padding: 11px;
 }

--- a/src/panel/assets/skins/sam/panel-skin.css
+++ b/src/panel/assets/skins/sam/panel-skin.css
@@ -30,6 +30,10 @@
     TODO: Add support for IE and W3C gradients
     */
 }
+.yui3-skin-sam .yui3-panel-title {
+    margin: 0;
+    font-size: inherit;
+}
 .yui3-skin-sam .yui3-panel .yui3-widget-hd .yui3-widget-buttons {
     padding: 8px;
 }

--- a/src/panel/js/panel.js
+++ b/src/panel/js/panel.js
@@ -8,7 +8,24 @@ header/footer button support.
 @module panel
 **/
 
-var getClassName = Y.ClassNameManager.getClassName;
+var getClassName = Y.ClassNameManager.getClassName,
+
+  BOUNDING_BOX = 'boundingBox',
+  TITLE = 'title',
+  PANEL_TYPE = 'panelType',
+  HEADER = 'header',
+  BODY = 'body',
+  SIMPLE = 'simple',
+  COMPLEX = 'complex',
+  DIALOG = 'dialog',
+  ALERT_DIALOG = 'alertdialog',
+  ARIA_DESCRIBEDBY = 'aria-describedby',
+  ARIA_LABELLEDBY = 'aria-labelledby',
+  ROLE = 'role',
+
+  FOCUSABLE_SELECTORS = 'a[href], area[href], input:not([disabled]), ' +
+    'select:not([disabled]), textarea:not([disabled]), button:not([disabled]), ' +
+    'iframe, object, embed, *[tabindex], *[contenteditable]';
 
 // TODO: Change this description!
 /**
@@ -33,20 +50,20 @@ button support.
 @since 3.4.0
  */
 Y.Panel = Y.Base.create('panel', Y.Widget, [
-    // Other Widget extensions depend on these two.
-    Y.WidgetPosition,
-    Y.WidgetStdMod,
+  // Other Widget extensions depend on these two.
+  Y.WidgetPosition,
+  Y.WidgetStdMod,
 
-    Y.WidgetAutohide,
-    Y.WidgetButtons,
-    Y.WidgetModality,
-    Y.WidgetPositionAlign,
-    Y.WidgetPositionConstrain,
-    Y.WidgetStack
+  Y.WidgetAutohide,
+  Y.WidgetModality,
+  Y.WidgetButtons,
+  Y.WidgetPositionAlign,
+  Y.WidgetPositionConstrain,
+  Y.WidgetStack
 ], {
-    // -- Public Properties ----------------------------------------------------
+  // -- Public Properties ----------------------------------------------------
 
-    /**
+  /**
     Collection of predefined buttons mapped from name => config.
 
     Panel includes a "close" button which can be use by name. When the close
@@ -72,23 +89,289 @@ Y.Panel = Y.Base.create('panel', Y.Widget, [
     @default {close: {}}
     @since 3.5.0
     **/
-    BUTTONS: {
-        close: {
-            label  : 'Close',
-            action : 'hide',
-            section: 'header',
+  BUTTONS: {
+    close: {
+      label: 'Close',
+      action: 'hide',
+      section: HEADER,
 
-            // Uses `type="button"` so the button's default action can still
-            // occur but it won't cause things like a form to submit.
-            template  : '<button type="button" />',
-            classNames: getClassName('button', 'close')
-        }
+      // Uses `type="button"` so the button's default action can still
+      // occur but it won't cause things like a form to submit.
+      template: '<button type="button" />',
+      classNames: getClassName('button', 'close'),
+      isDefault: true
     }
+  },
+
+  /**
+   * Template for Panel's title. Wrapped in a `<h1>` for accessibility.
+   * For multi-line titles, it is recommended to use additional markup inside
+   * the title and style as necessary.
+   *
+   * @example
+   *
+   *     <h1>This is the main title <span>This is a sub-ttile on a second line</span></h1>
+   *
+   * @property TITLE_TEMPLATE
+   * @type {String}
+   * @default '<h1 class="{className}">{title}</h1>'
+   */
+  TITLE_TEMPLATE: '<h1 class="{className}">{title}</h1>',
+
+  /**
+   * Additional classes for the Panel
+   *
+   * @property PANEL_CLASSES
+   * @type {Object}
+   */
+  PANEL_CLASSES: {
+    title: getClassName(this.name, TITLE)
+  },
+
+  // -- Private Properties ----------------------------------------------------
+
+  /**
+   * Internal cache for storing cycleFocusTab's event handle
+   *
+   * @property _focusHandle
+   * @type {EventHandle}
+   * @default null
+   */
+  _focusHandles: null,
+
+  /**
+   *
+   * @method bindUI
+   * @protected
+   */
+  bindUI: function () {
+    this.after('panelTypeChange', this._afterPanelTypeChange, this);
+    this.after('titleChange', this._afterTitleChange, this);
+    this.after('visibleChange', this._afterPanelVisibleChange, this);
+  },
+
+  /**
+   *
+   * @method render
+   */
+  render: function () {
+
+    var title = this.get(TITLE);
+
+    Y.Panel.superclass.render.apply(this, arguments);
+
+    if (title) {
+      this._renderTitle(title);
+    }
+
+    this._setAria(this.get(PANEL_TYPE));
+  },
+
+  /**
+   * Reacts to the `panelType` attribute change by setting proper aria roles
+   * on the Panel
+   *
+   * @method _afterPanelTypeChange
+   * @param {EventFacade} e The relevant change event
+   * @protected
+   */
+  _afterPanelTypeChange: function (e) {
+    this._setAria(e.newVal);
+  },
+
+  /**
+   * Reacts to the `visible` attribute change by binding or unbinding tab press
+   * events
+   *
+   * @method _afterPanelTypeChange
+   * @param {EventFacade} e The relevant change event
+   * @protected
+   */
+  _afterPanelVisibleChange: function (e) {
+
+    if (e.newVal) {
+      this._bindTabCycle();
+    } else {
+      this._unbindTabCycle();
+    }
+  },
+
+  /**
+   * Reacts to the `title` attribute change by the Panel's title
+   *
+   * @method _afterPanelTypeChange
+   * @param {EventFacade} e The relevant change event
+   * @protected
+   */
+  _afterTitleChange: function (e) {
+    this._renderTitle(e.newVal);
+  },
+
+  /**
+   * Binds tab press to the bounding box and last focusable node in the Panel
+   *
+   * @method _bindTabCycle
+   * @protected
+   */
+  _bindTabCycle: function () {
+
+    var bb = this.get(BOUNDING_BOX),
+      focusableNodes = bb.all(FOCUSABLE_SELECTORS),
+      lastNode = focusableNodes.item(focusableNodes.size() - 1),
+      nodes = {
+        firstNode: bb,
+        lastNode: lastNode
+      };
+
+    this._unbindTabCycle();
+    this._focusHandle = bb.on('key', this._onTabPress, 'down:9', this, nodes);
+  },
+
+  /**
+   * Handler for tab presses, for cycling focus inside the Panel
+   *
+   * @method _onTabPress
+   * @param {EventFacade} e The relevant change event
+   * @protected
+   */
+  _onTabPress: function (e, nodes) {
+
+    var target = e.target;
+
+    if (target === nodes.firstNode && e.shiftKey) {
+      e.preventDefault();
+      nodes.lastNode.focus();
+    } else if (target === nodes.lastNode && !e.shiftKey) {
+      e.preventDefault();
+      nodes.firstNode.focus();
+    }
+  },
+
+  /**
+   * Either wraps and renders the specified title in a `h1` tag or updates
+   * an existing title
+   *
+   * @method _renderTitle
+   * @param {String} title The title for Panel instance
+   * @protected
+   */
+  _renderTitle: function (title) {
+
+    var titleNode = this.getStdModNode(HEADER).one('.' + this.PANEL_CLASSES.title);
+
+    if (titleNode) {
+      titleNode.set('text', title);
+    } else {
+      this.setStdModContent(HEADER, Y.Lang.sub(this.TITLE_TEMPLATE, {
+        className: this.PANEL_CLASSES.title,
+        title: title
+      }), 'before');
+    }
+
+  },
+
+  /**
+   * Panel type, either `simple` or `complex` which helps determine the proper
+   * ARIA role for the Panel. Also sets the aria-labelledby and aria-describedby
+   * properties
+   *
+   * @method _setAria
+   * @param {String} panelType
+   * @protected
+   */
+  _setAria: function (panelType) {
+
+    var bb = this.get(BOUNDING_BOX),
+      bodyNode = this.getStdModNode(BODY),
+      role;
+
+    if (panelType === SIMPLE) {
+      role = ALERT_DIALOG;
+      bodyNode.removeAttribute(ROLE);
+    } else if (panelType === COMPLEX) {
+      role = DIALOG;
+      bodyNode.set(ROLE, 'document');
+    }
+
+    if (this.get(TITLE)) {
+      bb.set(ARIA_LABELLEDBY, this.getStdModNode(HEADER).one('.' + this.PANEL_CLASSES.title).generateID());
+    }
+
+    bb.set(ROLE, role);
+    bb.set(ARIA_DESCRIBEDBY, bodyNode.generateID());
+  },
+
+  /**
+   * Detaches tab cycle listener
+   *
+   * @method _unbindTabCycle
+   * @protected
+   */
+  _unbindTabCycle: function () {
+
+    if (this._focusHandle) {
+      this._focusHandle.detach();
+      this._focusHandle = null;
+    }
+  },
+
+  /**
+   * Panel type, either `simple` or `complex` which helps determine the proper
+   * ARIA role for the Panel
+   *
+   * @method _validatePanelType
+   * @param {String} val
+   */
+  _validatePanelType: function (val) {
+    return (val === SIMPLE || val === COMPLEX);
+  }
 }, {
-    ATTRS: {
-        // TODO: API Docs.
-        buttons: {
-            value: ['close']
-        }
+  ATTRS: {
+    // TODO: API Docs.
+    buttons: {
+      value: ['close']
+    },
+
+    /**
+     * Panel type, either `simple` or `complex` which helps determine the proper
+     * ARIA role for the Panel
+     *
+     * @attribute panelType
+     * @value 'simple'
+     */
+    panelType: {
+      value: SIMPLE,
+      validator: '_validatePanelType',
+    },
+
+    /**
+     * Panel's title, wrapped in a `<h1>`
+     *
+     * @attribute title
+     * @value null
+     */
+    title: {
+      value: null
     }
+  },
+
+  /**
+   * The HTML parsing rules for the Panel
+   *
+   * @property HTML_PARSER
+   * @static
+   * @type Object
+   */
+  HTML_PARSER: {
+    title: function (srcNode) {
+
+      var titleNode = srcNode.one('.' + this.PANEL_CLASSES.title);
+
+      if (titleNode) {
+        return titleNode.get('innerHTML');
+      }
+
+      return null;
+    }
+  }
 });


### PR DESCRIPTION
This initial PR is for feedback only.

Adding the following accessibility improvements to Panel:
- Focus Management
  - `Tab` and `Shift + Tab` cycle focus within the Panel
  - Upon dismissing the Panel, focus is returned to the trigger that initially launched the Panel (via Widget-Modality)
  - The default Close button is configured with `isDefault` so that focus is immediately applied upon displaying the Panel
- ARIA Roles/ Properties
  - A new attribute `panelType` that accepts values of `simple` or `complex` which are used to determine whether the Panel has an ARIA role of `alertdialog` (panelType: simple) or `dialog` (panelType: complex). Documentation and examples will show that that a simple Panel is defined as having a small amount of text or a message that alerts, warns, or requests information. A complex Panel is a Panel that includes large amounts of text or Form elements/ other interactive elements. A complex Panel also adds a role of `document` on the Panel body. Default panelType is `simple`
  - The property `aria-describedby` is placed on the bounding box and references the Panel's body.
  - A new attribute `title` is added and is wrapped by a `<h1>` tag. HTML_PARSER is included. `aria-labelledby` is placed on the bounding box and references the title. Documentation and examples will show how to properly markup subtitles within the title and how `headerContent` can still be used in conjunction with the title. CSS styles have been updated to  maintain the `<h1>` style
  - Panel visibility is communicated via the 'aria-hidden' property on the bounding box.
  - If the Panel is modal, 'aria-hidden' is set to `true` on the body so as not to confuse AT users  (via Widget-Modality)

User Guides/ examples and unit tests have not been updated yet because I wanted to get feedback and finalize the code. The unit tests are still passing with these modifications though.
