### PR TITLE
[promise] Deprecate `resolver.then`

### DIFF
--- a/src/promise/js/resolver.js
+++ b/src/promise/js/resolver.js
@@ -128,6 +128,7 @@ Y.mix(Resolver.prototype, {
                 resolves unsuccessfully
     @return {Promise} The promise of a new Resolver wrapping the resolution
                 of either "resolve" or "reject" callback
+    @deprecated
     **/
     then: function (callback, errback) {
         // When the current promise is fulfilled or rejected, either the


### PR DESCRIPTION
Resolvers having a `then` method was a terrible idea from the beginning because it made resolvers be promises. Deprecating this method is also a necessary step to remove the circular reference between promises and resolvers.

Nobody should be using it, but if they are, the sooner they stop using it, the better.

/cc @clarle
