### PR TITLE
XML: Refactor of feature detecting logic, resolves #1435

### DIFF
--- a/src/xml/js/xml-parse.js
+++ b/src/xml/js/xml-parse.js
@@ -6,8 +6,6 @@
  * @for XML
  */
 
-var LANG = Y.Lang;
-
 Y.mix(Y.namespace("XML"), {
     /**
      * Converts data to type XMLDocument.
@@ -17,32 +15,22 @@ Y.mix(Y.namespace("XML"), {
      * @return {XMLDoc} XML Document.
      */
     parse: function(data) {
-        var xmlDoc = null;
-        if(LANG.isString(data)) {
-            try {
-                if(!LANG.isUndefined(ActiveXObject)) {
-                        xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
-                        xmlDoc.async = false;
-                        xmlDoc.loadXML(data);
-                }
-            }
-            catch(ee) {
-                try {
-                    if (!LANG.isUndefined(DOMParser)) {
-                        xmlDoc = new DOMParser().parseFromString(data, "text/xml");
-                    }
-                    if (!LANG.isUndefined(Windows.Data.Xml.Dom)) {
-                        xmlDoc = new Windows.Data.Xml.Dom.XmlDocument();
-                        xmlDoc.loadXml(data);
-                    }
-                }
-                catch(e) {
-                }
-                    Y.log(ee.message + " (Could not initialize the ActiveX control for XML parsing)", "warn", "xml");
+        var xmlDoc = null, win;
+        if (typeof data === "string") {
+            win = Y.config.win;
+            if (win.DOMParser !== undefined) {
+                xmlDoc = new DOMParser().parseFromString(data, "text/xml");            
+            } else if (win.ActiveXObject !== undefined) {
+                xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
+                xmlDoc.async = false;
+                xmlDoc.loadXML(data);            
+            } else if (win.Windows !== undefined) {
+                xmlDoc = new Windows.Data.Xml.Dom.XmlDocument();
+                xmlDoc.loadXml(data);            
             }
         }
 
-        if( (LANG.isNull(xmlDoc)) || (LANG.isNull(xmlDoc.documentElement)) || (xmlDoc.documentElement.nodeName === "parsererror") ) {
+        if (xmlDoc === null || xmlDoc.documentElement === null || xmlDoc.documentElement.nodeName === "parsererror") {
             Y.log("Could not parse data to type XML Document", "warn", "xml");
         }
 


### PR DESCRIPTION
This fixes #1435.

Because of better feature detection, IE 9, 10, and 11 now use `DOMParser` whenever possible, rather than relying on `ActiveXObject` **first**.

---

Before, `Y.XML.parse` relied on the browser throwing a `ReferenceError` when `ActiveXObject`  did not exist. If, and only if that error was thrown, it would then fall back to `DOMParser`.

IE 11 has now set `ActiveXObject` to `undefined`. So,

``` js
// normally throws a `ReferenceError` if the variable doesn't exist, but *doesn't* in IE 11.
ActiveXObject; // undefined;

typeof ActiveXObject; // undefined

"ActiveXObject" in window; // true
```
