### PR TITLE
[promise] Steps for removing the promise/resolver circular reference

### DIFF
--- a/src/promise/js/promise.js
+++ b/src/promise/js/promise.js
@@ -101,7 +101,13 @@ Y.mix(Promise.prototype, {
         // using this.constructor allows for customized promises to be
         // returned instead of plain ones
         return new Constructor(function (resolve, reject) {
-            resolver.addCallbacks(
+            resolver._addCallbacks(
+                // Check if callbacks are functions. If not, default to
+                // `resolve` and `reject` respectively.
+                // The wrapping of the callbacks is done here and not in
+                // `_addCallbacks` because it is a feature specific to  `then`.
+                // If `done` is added to promises it would call `_addCallbacks`
+                // without defaulting to anything and without wrapping
                 typeof callback === 'function' ?
                     Promise._wrap(resolve, reject, callback) : resolve,
                 typeof errback === 'function' ?

--- a/src/promise/js/resolver.js
+++ b/src/promise/js/resolver.js
@@ -180,25 +180,23 @@ Y.mix(Resolver.prototype, {
     "reject" resolutions of this resolver. If the resolver is not pending,
     the correct callback gets called automatically.
 
-    @method addCallbacks
+    @method _addCallbacks
     @param {Function} [callback] function to execute if the Resolver
                 resolves successfully
     @param {Function} [errback] function to execute if the Resolver
                 resolves unsuccessfully
+    @private
     **/
-    addCallbacks: function (callback, errback) {
+    _addCallbacks: function (callback, errback) {
         var callbackList = this._callbacks,
             errbackList  = this._errbacks,
             status       = this._status,
             result       = this._result;
 
-        // Because the callback and errback are represented by a Resolver, it
-        // must be fulfilled or rejected to propagate through the then() chain.
-        // The same logic applies to resolve() and reject() for fulfillment.
-        if (callbackList) {
+        if (callbackList && typeof callback === 'function') {
             callbackList.push(callback);
         }
-        if (errbackList) {
+        if (errbackList && typeof errback === 'function') {
             errbackList.push(errback);
         }
 


### PR DESCRIPTION
The objective is to remove the circular reference between the promise and resolver objects which could have bad memory usage consequences. To do this we need to deprecate `resolver.promise`. But this also opens the door for deprecating `resolver.then` which makes the resolver a promise (not a great idea).

We can also take the opportunity to deprecate `batch` and `when` because the idea is to move this module to a standalone repository that can be imported via `npm` and have the `Promise` class be the default export of that module.
