### PR TITLE
[calendar] Ignore running some tests by Yeti in Calendar tests (Fix #1363)

### DIFF
--- a/src/calendar/tests/unit/assets/calendar-tests.js
+++ b/src/calendar/tests/unit/assets/calendar-tests.js
@@ -2,10 +2,18 @@ YUI.add('calendar-tests', function(Y) {
 
         // Set up the page
         var ASSERT = Y.Assert,
-            ARRAYASSERT = Y.ArrayAssert;
+            ARRAYASSERT = Y.ArrayAssert,
+            yeti = window && window.$yetify;
 
         var BasicCalendar = new Y.Test.Case({
             name: "Basic Calendar Tests",
+
+            _should: {
+                ignore: {
+                    testFocus: yeti,
+                    testSelectionModes: yeti
+                }
+            },
 
             setUp : function () {
                 var firstcontainer = "<div id='firstcontainer'></div>";


### PR DESCRIPTION
Currently, running Calendar tests containing the focus process will fail in Firefox. The cause of this problem seems to be a problem that test case is not bad, what happens if you are running Yeti while running Firefox in the background. This problem does not occur in a browser other than Firefox. In addition, there is a test that includes a focusing process in the same way with the Widget Button module ([src/widget-buttons/tests/unit/assets/widget-buttons-test.js](https://github.com/yui/yui3/blob/master/src/widget-buttons/tests/unit/assets/widget-buttons-test.js)), so it has to ignore Yeti is here. Therefore, I would like to ignore running some tests by Yeti in the same way in Calendar. Fix #1363.
