### PR TITLE
fix deprecated returnValue warning in chrome

### DIFF
--- a/src/event/js/event-facade-dom.js
+++ b/src/event/js/event-facade-dom.js
@@ -158,7 +158,9 @@ Y.extend(DOMEventFacade, Object, {
     preventDefault: function(returnValue) {
         var e = this._event;
         e.preventDefault();
-        e.returnValue = returnValue || false;
+        if (returnValue) {
+            e.returnValue = returnValue;
+        }
         this._wrapper.prevented = 1;
         this.prevented = 1;
     },


### PR DESCRIPTION
As @hatched reported in #1417

chrome now issues a console warning
event.returnValue is deprecated. Please use the standard event.preventDefault() instead.

More discussion, see #1429
