### PR TITLE
update apidoc for `previous` and `next`

### DIFF
--- a/src/dom/js/dom-core.js
+++ b/src/dom/js/dom-core.js
@@ -128,8 +128,9 @@ Y_DOM = {
      * @method elementByAxis
      * @param {HTMLElement} element The html element.
      * @param {String} axis The axis to search (parentNode, nextSibling, previousSibling).
-     * @param {Function} fn optional An optional boolean test to apply.
-     * @param {Boolean} all optional Whether all node types should be returned, or just element nodes.
+     * @param {Function} [fn] An optional boolean test to apply.
+     * @param {Boolean} [all] Whether text nodes as well as element nodes should be returned, or
+     * just element nodes will be returned(default)
      * The optional function is passed the current HTMLElement being tested as its only argument.
      * If no function is given, the first element is returned.
      * @return {HTMLElement | null} The matching element or null if none found.

--- a/src/node/js/node-core.js
+++ b/src/node/js/node-core.js
@@ -587,8 +587,8 @@ Y.mix(Y_Node.prototype, {
      * @method previous
      * @param {String | Function} fn A selector or boolean method for testing elements.
      * If a function is used, it receives the current node being tested as the only argument.
-     * @param {Boolean} all optional Whether or not all node types should be returned, default only element nodes
-     * will be returned
+     * @param {Boolean} [all] Whether text nodes as well as element nodes should be returned, or
+     * just element nodes will be returned(default)
      * @return {Node} Node instance or null if not found
      */
     previous: function(fn, all) {
@@ -601,8 +601,8 @@ Y.mix(Y_Node.prototype, {
      * @method next
      * @param {String | Function} fn A selector or boolean method for testing elements.
      * If a function is used, it receives the current node being tested as the only argument.
-     * @param {Boolean} all optional Whether or not all node types should be returned, default only element nodes
-     * will be returned
+     * @param {Boolean} [all] Whether text nodes as well as element nodes should be returned, or
+     * just element nodes will be returned(default)
      * @return {Node} Node instance or null if not found
      */
     next: function(fn, all) {


### PR DESCRIPTION
update the comments of `node-core.js`
the  `previous` and next have two arguments but only the first one is included in the comment.

see #1459
