### PR TITLE
Fix #1448 - Specify "X-UA-Compatible" at local documents

### DIFF
--- a/src/common/docs/layouts/main.mustache
+++ b/src/common/docs/layouts/main.mustache
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
     <title>{{htmlTitle}}</title>
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic,700italic">
     <link rel="stylesheet" href="{{yuiGridsUrl}}">


### PR DESCRIPTION
IE trying to display examples that generated by `yogi serve` with compatibility view mode. This is due to it isn't `X-UA-Compatible` is specified by `meta` element.

Also, examples that we're providing has meta element at production. So I think we should test on same view mode as production. Fix #1448.
