### PR TITLE
[io] Check whether a form still exists before resetting it

### DIFF
--- a/src/io/js/io-upload-iframe.js
+++ b/src/io/js/io-upload-iframe.js
@@ -296,7 +296,10 @@ Y.mix(Y.IO.prototype, {
                 // Restore HTML form attributes to their original values.
                 form = (typeof form.id === 'string') ? d.getElementById(form.id) : form.id;
 
-                io._resetAttrs(form, this._originalFormAttrs);
+                // Check whether the form still exists before resetting it.
+                if (form) {
+                    io._resetAttrs(form, this._originalFormAttrs);
+                }
             }
         }
 

--- a/src/io/tests/unit/js/upload-iframe-tests.js
+++ b/src/io/tests/unit/js/upload-iframe-tests.js
@@ -19,8 +19,10 @@ YUI.add('upload-iframe-tests', function(Y, NAME) {
         },
 
         tearDown: function () {
-            this.form.remove();
-            delete this.form;
+            if (typeof this.form !== 'undefined') {
+                this.form.remove();
+                delete this.form;
+            }
             form.cloneNode(true).appendTo('body');
         },
 
@@ -215,6 +217,31 @@ YUI.add('upload-iframe-tests', function(Y, NAME) {
                     Y.Assert.areSame("", form.get('action'));
                     Y.Assert.areSame("", form.get('target'));
                 });
+            };
+
+            request = Y.io(Y.IO.URLS.post, config);
+
+            Test.wait();
+        },
+
+        'Form attribute resetting should not happen if the form was removed before completion': function () {
+            var Test = this,
+                form = this.form.cloneNode(true),
+                config = this.config,
+                request;
+
+            config.form.id = 'test-form-removal';
+            form.set('id', config.form.id);
+            form.appendTo('body');
+
+            config.on.end = function () {
+                Test.resume(function () {
+                    Y.Assert.isNull(Y.one('#' + config.form.id));
+                });
+            };
+
+            config.on.start = function() {
+                form.remove(true);
             };
 
             request = Y.io(Y.IO.URLS.post, config);


### PR DESCRIPTION
IO clears the form content on end, but if the caller removed the form soon
after it was called, this fails at a removeAttribute on part of the, now
non-existent form content.

We should check that the form exists before attempting to reset it.

Fixes #1121
