### PR TITLE
Charts - address issue with independently create cartesian series destructor method.

### DIFF
--- a/src/charts/js/CartesianSeries.js
+++ b/src/charts/js/CartesianSeries.js
@@ -570,8 +570,14 @@ Y.CartesianSeries = Y.Base.create("cartesianSeries", Y.SeriesBase, [], {
             {
                 this._yDataUpdateHandle.detach();
             }
-            this._xAxisChangeHandle.detach();
-            this._yAxisChangeHandle.detach();
+            if(this._xAxisChangeHandle)
+            {
+                this._xAxisChangeHandle.detach();
+            }
+            if(this._yAxisChangeHandle)
+            {
+                this._yAxisChangeHandle.detach();
+            }
         }
     }
         /**

--- a/src/charts/tests/unit/assets/series-cartesian-tests.js
+++ b/src/charts/tests/unit/assets/series-cartesian-tests.js
@@ -1003,11 +1003,11 @@ YUI.add('series-cartesian-tests', function(Y) {
             };
             DestructorMockSeries = Y.Base.create("destructorMockSeries", Y.CartesianSeries, [], {
                 init: function() {
-                    this._xAxisChangeHandle = new Destroyer(this);
-                    this._yAxisChangeHandle = new Destroyer(this);
                     DestructorMockSeries.superclass.init.apply(this, arguments);
                 },
                 addSomeListeners: function() {
+                    this._xAxisChangeHandle = new Destroyer(this);
+                    this._yAxisChangeHandle = new Destroyer(this);
                     this._xDataReadyHandle = new Destroyer(this);
                     this._xDataUpdateHandle = new Destroyer(this);
                     this._yDataReadyHandle = new Destroyer(this);
@@ -1021,19 +1021,19 @@ YUI.add('series-cartesian-tests', function(Y) {
             });
             mockSeries = new DestructorMockSeries();
             series.destructor.apply(mockSeries);
-            Y.Assert.isTrue(mockSeries._xAxisChangeHandle._attached, "The _xAxisChangeHandle should be attached.");
-            Y.Assert.isTrue(mockSeries._yAxisChangeHandle._attached, "The _yAxisChangeHandle should be attached.");
             mockSeries.set("rendered", true);
             series.destructor.apply(mockSeries);
-            Y.Assert.isFalse(mockSeries._xAxisChangeHandle._attached, "The _xAxisChangeHandle should be detached.");
-            Y.Assert.isFalse(mockSeries._yAxisChangeHandle._attached, "The _yAxisChangeHandle should be detached.");
             mockSeries.addSomeListeners();
+            Y.Assert.isTrue(mockSeries._xAxisChangeHandle._attached, "The _xAxisChangeHandle should be attached.");
+            Y.Assert.isTrue(mockSeries._yAxisChangeHandle._attached, "The _yAxisChangeHandle should be attached.");
             Y.Assert.isTrue(mockSeries._xDataReadyHandle._attached, "The _xDataReadyHandle should be attached.");
             Y.Assert.isTrue(mockSeries._yDataReadyHandle._attached, "The _yDataReadyHandle should be attached.");
             Y.Assert.isTrue(mockSeries._xDataUpdateHandle._attached, "The _xDataUpdateHandle should be attached.");
             Y.Assert.isTrue(mockSeries._yDataUpdateHandle._attached, "The _yDataUpdateHandle should be attached.");
             mockSeries.set("markers", []);
             series.destructor.apply(mockSeries); 
+            Y.Assert.isFalse(mockSeries._xAxisChangeHandle._attached, "The _xAxisChangeHandle should be detached.");
+            Y.Assert.isFalse(mockSeries._yAxisChangeHandle._attached, "The _yAxisChangeHandle should be detached.");
             Y.Assert.isFalse(mockSeries._xDataReadyHandle._attached, "The _xDataReadyHandle should be detached.");
             Y.Assert.isFalse(mockSeries._yDataReadyHandle._attached, "The _yDataReadyHandle should be detached.");
             Y.Assert.isFalse(mockSeries._xDataUpdateHandle._attached, "The _xDataUpdateHandle should be detached.");


### PR DESCRIPTION
Propose fix for #1472.

Need to test:
- [x] ie6 (vm)
- [x] ie7 (vm)
- [x] ie8 (vm)
- [x] ie9 (vm)
- [x] ie10 (vm)
- [x] ie11 (vm)
- [x] mac safari
- [x] ios safari
- [x] android 2.3.x (vm)
- [x] android 4.1.x (vm)
- [x] firefox (vm)
- [x] chrome (vm)
