### PR TITLE
Fix img paths for docs and tests

### DIFF
--- a/src/cssgrids/docs/partials/cssgrids-align-source.mustache
+++ b/src/cssgrids/docs/partials/cssgrids-align-source.mustache
@@ -181,17 +181,17 @@
                 <p>Cras porta venenatis egestas. Vestibulum pretium massa id turpis varius iaculis. Aliquam nec cursus lorem. Sed aliquet hendrerit sem, et consectetur dolor condimentum quis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Suspendisse congue sapien a nibh venenatis sit amet aliquet elit suscipit. Curabitur gravida magna ut diam pellentesque et luctus metus auctor. Nam quis hendrerit enim. Donec tincidunt libero a dolor hendrerit at tempus quam venenatis. In quis tempus ipsum. Vestibulum nulla enim, bibendum ut vestibulum at, laoreet a felis.</p>
                 <div class="yui3-g thumb-captions">
                     <div class="yui3-u-1-3">
-                        <a href="#"><img width="80" height="60" src="http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg">
+                        <a href="#"><img width="80" height="60" src="http://yui.yahooapis.com/testassets/museum.jpg">
                             Lorem ispum
                         </a>
                     </div>
                     <div class="yui3-u-1-3">
-                        <a href="#"><img height="80" width="60" src="http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg">
+                        <a href="#"><img height="80" width="60" src="http://yui.yahooapis.com/testassets/museum.jpg">
                             Lorem ispum
                         </a>
                     </div>
                     <div class="yui3-u-1-3">
-                        <a href="#"><img height="80" width="60" src="http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg">
+                        <a href="#"><img height="80" width="60" src="http://yui.yahooapis.com/testassets/museum.jpg">
                             Lorem ispum
                         </a>
                     </div>

--- a/src/event/docs/ready-example.mustache
+++ b/src/event/docs/ready-example.mustache
@@ -54,7 +54,7 @@
         <!--...100 more of these-->
     </ul>
 
-    <img src="http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/large/uluru.jpg" width="500" alt="Uluru" id="image" />
+    <img src="http://yui.yahooapis.com/testassets/uluru-large.jpg" width="500" alt="Uluru" id="image" />
 
 </div>
 ```

--- a/src/imageloader/docs/below-fold.mustache
+++ b/src/imageloader/docs/below-fold.mustache
@@ -51,11 +51,11 @@
   YUI({filter:"debug", logInclude: {"imageloader":true, "example":true}}).use("imageloader", function(Y) {
 
   	var foldGroup = new Y.ImgLoadGroup({ name: 'fold group', foldDistance: 25 });
-  	foldGroup.registerImage({ domId: 'img1', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg' });
-  	foldGroup.registerImage({ domId: 'img2', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg' });
-  	foldGroup.registerImage({ domId: 'img3', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg' });
-  	foldGroup.registerImage({ domId: 'img4', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/morraine.jpg' });
-  	foldGroup.registerImage({ domId: 'img5', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/japan.jpg' });
+  	foldGroup.registerImage({ domId: 'img1', srcUrl: 'http://yui.yahooapis.com/testassets/museum.jpg' });
+  	foldGroup.registerImage({ domId: 'img2', srcUrl: 'http://yui.yahooapis.com/testassets/uluru.jpg' });
+  	foldGroup.registerImage({ domId: 'img3', srcUrl: 'http://yui.yahooapis.com/testassets/katatjuta.jpg' });
+  	foldGroup.registerImage({ domId: 'img4', srcUrl: 'http://yui.yahooapis.com/testassets/morraine.jpg' });
+  	foldGroup.registerImage({ domId: 'img5', srcUrl: 'http://yui.yahooapis.com/testassets/japan.jpg' });
 
   /*
   var foldGroup = new YAHOO.util.ImageLoader.group(window, 'scroll');
@@ -97,11 +97,11 @@
 
 ```
 var foldGroup = new Y.ImgLoadGroup({ name: 'fold group', foldDistance: 25 });
-foldGroup.registerImage({ domId: 'img1', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg' });
-foldGroup.registerImage({ domId: 'img2', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg' });
-foldGroup.registerImage({ domId: 'img3', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg' });
-foldGroup.registerImage({ domId: 'img4', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/morraine.jpg' });
-foldGroup.registerImage({ domId: 'img5', srcUrl: 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/japan.jpg' });
+foldGroup.registerImage({ domId: 'img1', srcUrl: 'http://yui.yahooapis.com/testassets/museum.jpg' });
+foldGroup.registerImage({ domId: 'img2', srcUrl: 'http://yui.yahooapis.com/testassets/uluru.jpg' });
+foldGroup.registerImage({ domId: 'img3', srcUrl: 'http://yui.yahooapis.com/testassets/katatjuta.jpg' });
+foldGroup.registerImage({ domId: 'img4', srcUrl: 'http://yui.yahooapis.com/testassets/morraine.jpg' });
+foldGroup.registerImage({ domId: 'img5', srcUrl: 'http://yui.yahooapis.com/testassets/japan.jpg' });
 ```
 
 <p>

--- a/src/imageloader/docs/imageloader-class-names.mustache
+++ b/src/imageloader/docs/imageloader-class-names.mustache
@@ -32,11 +32,11 @@
 
 
   <div class='everything' id='everything'>
-    <div class='topmain yui3-imgload-maingroup' id='topmain' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg");' title='group 1; mouseover image; 2 sec limit'></div>
-    <div class='duo1 yui3-imgload-duogroup' id='duo1' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg");' title='group 2; mouseover left image, or click on right image; 4 sec limit'></div>
-    <div class='duo2 yui3-imgload-duogroup' id='duo2' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg");' title='group 2; mouseover left image, or click on right image; 4 sec limit'></div>
+    <div class='topmain yui3-imgload-maingroup' id='topmain' style='background-image:url("http://yui.yahooapis.com/testassets/museum.jpg");' title='group 1; mouseover image; 2 sec limit'></div>
+    <div class='duo1 yui3-imgload-duogroup' id='duo1' style='background-image:url("http://yui.yahooapis.com/testassets/uluru.jpg");' title='group 2; mouseover left image, or click on right image; 4 sec limit'></div>
+    <div class='duo2 yui3-imgload-duogroup' id='duo2' style='background-image:url("http://yui.yahooapis.com/testassets/katatjuta.jpg");' title='group 2; mouseover left image, or click on right image; 4 sec limit'></div>
     <div class='scroll' title='group 3; scroll; no time limit'>
-      <img id='scrollImg' class='yui3-imgload-scrollgroup' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/morraine.jpg");' src='http://l.yimg.com/a/i/us/tr/b/1px_trans.gif' width='100' height='72' />
+      <img id='scrollImg' class='yui3-imgload-scrollgroup' style='background-image:url("http://yui.yahooapis.com/testassets/morraine.jpg");' src='http://l.yimg.com/a/i/us/tr/b/1px_trans.gif' width='100' height='72' />
     </div>
   </div>
 
@@ -77,11 +77,11 @@
   ```
   <h5>HTML</h5>
   ```
-  <div class='topmain yui-imgload-maingroup' id='topmain' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg");'></div>
-  <div class='duo1 yui-imgload-duogroup' id='duo1' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg");'></div>
-  <div class='duo2 yui-imgload-duogroup' id='duo2' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg");'></div>
+  <div class='topmain yui-imgload-maingroup' id='topmain' style='background-image:url("http://yui.yahooapis.com/testassets/museum.jpg");'></div>
+  <div class='duo1 yui-imgload-duogroup' id='duo1' style='background-image:url("http://yui.yahooapis.com/testassets/uluru.jpg");'></div>
+  <div class='duo2 yui-imgload-duogroup' id='duo2' style='background-image:url("http://yui.yahooapis.com/testassets/katatjuta.jpg");'></div>
   <div class='scroll'>
-    <img id='scrollImg' class='yui-imgload-scrollgroup' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/morraine.jpg");' src='http://l.yimg.com/a/i/us/tr/b/1px_trans.gif' width='100' height='72' />
+    <img id='scrollImg' class='yui-imgload-scrollgroup' style='background-image:url("http://yui.yahooapis.com/testassets/morraine.jpg");' src='http://l.yimg.com/a/i/us/tr/b/1px_trans.gif' width='100' height='72' />
   </div>
 	```
 </p>

--- a/src/imageloader/tests/unit/assets/imageloader-tests.js
+++ b/src/imageloader/tests/unit/assets/imageloader-tests.js
@@ -9,7 +9,7 @@ YUI.add('imageloader-tests', function(Y) {
 
         setUp: function() {
             // background-image group
-            this.bgImgUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg';
+            this.bgImgUrl = 'http://yui.yahooapis.com/testassets/museum.jpg';
             this.mainGroup = new Y.ImgLoadGroup({ name: 'imgUrlsTestBgImg' });
             this.mainGroup.addTrigger('#topmain', 'mouseover');
             this.mainGroup.registerImage({ domId: 'topmain', bgUrl: this.bgImgUrl });
@@ -34,7 +34,7 @@ YUI.add('imageloader-tests', function(Y) {
 
         setUp: function() {
             // src-image group
-            this.srcImgUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/morraine.jpg';
+            this.srcImgUrl = 'http://yui.yahooapis.com/testassets/morraine.jpg';
             this.srcGroup = new Y.ImgLoadGroup({ name: 'imgUrlsTestSrcImg' });
             this.srcGroup.addTrigger('#srcImgCont', 'click');
             this.srcGroup.registerImage({ domId: 'srcImg', srcUrl: this.srcImgUrl });
@@ -56,9 +56,9 @@ YUI.add('imageloader-tests', function(Y) {
         name: 'Class Name Fetching',
 
         setUp: function() {
-            this.duo1Url = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg';
-            this.duo2Url = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg';
-            this.duo3Url = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg';
+            this.duo1Url = 'http://yui.yahooapis.com/testassets/uluru.jpg';
+            this.duo2Url = 'http://yui.yahooapis.com/testassets/katatjuta.jpg';
+            this.duo3Url = 'http://yui.yahooapis.com/testassets/katatjuta.jpg';
             this.duo1Image = document.getElementById('duo1');
             this.duo2Image = document.getElementById('duo2');
             this.duo3Image = document.getElementById('duo3');
@@ -96,7 +96,7 @@ YUI.add('imageloader-tests', function(Y) {
         name: 'addTrigger test',
 
         setUp: function() {
-            this.imageUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg';
+            this.imageUrl = 'http://yui.yahooapis.com/testassets/museum.jpg';
             this.triggerGroup = new Y.ImgLoadGroup({ name: 'addTriggerGroup' });
             this.triggerGroup.addTrigger('#topmain', 'dblclick').addTrigger('#addlTrigger', 'click');
             this.triggerGroup.registerImage({ domId: 'addlTrigger', bgUrl: this.imageUrl });
@@ -119,7 +119,7 @@ YUI.add('imageloader-tests', function(Y) {
         name: 'custom trigger test',
 
         setUp: function() {
-            this.imageUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg';
+            this.imageUrl = 'http://yui.yahooapis.com/testassets/uluru.jpg';
             // event attached to Y instance
             this.customEvent = 'imageloader_unit_test:custom_trigger_test';
             this.triggerGroup = new Y.ImgLoadGroup({ name: 'customTriggerGroup' });
@@ -144,7 +144,7 @@ YUI.add('imageloader-tests', function(Y) {
         name: 'local object custom trigger test',
 
         setUp: function() {
-            this.imageUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg';
+            this.imageUrl = 'http://yui.yahooapis.com/testassets/uluru.jpg';
             // event attached to custom instance
             this.customEvent2 = 'imageloader_unit_test:custom_trigger_test_2';
             this.customEvent2Obj = new Y.Event.Target();
@@ -170,7 +170,7 @@ YUI.add('imageloader-tests', function(Y) {
         name: 'Image Sizing',
 
         setUp: function() {
-            this.imageUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/japan.jpg';
+            this.imageUrl = 'http://yui.yahooapis.com/testassets/japan.jpg';
             this.sizerGroup = new Y.ImgLoadGroup({ name: 'imgSizingGroup' });
             this.sizerGroup.addTrigger('#sizerImg', 'mouseover');
             var sizerILImg = this.sizerGroup.registerImage({ domId: 'sizerImg', srcUrl: this.imageUrl, width: 200, height: 150, setVisible: true });
@@ -201,8 +201,8 @@ YUI.add('imageloader-tests', function(Y) {
         name: "Trigger Removal for Competing Groups' Triggers",
 
         setUp: function() {
-            this.imageAUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/morraine.jpg';
-            this.imageZUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg';
+            this.imageAUrl = 'http://yui.yahooapis.com/testassets/morraine.jpg';
+            this.imageZUrl = 'http://yui.yahooapis.com/testassets/uluru.jpg';
             this.groupA = new Y.ImgLoadGroup({ name: 'triggerRemovalGroup(A)' });
             this.groupA.addTrigger('#sharedTrigger1', 'click');
             this.groupA.registerImage({ domId: 'sharedTrigger1', bgUrl: this.imageAUrl });
@@ -241,7 +241,7 @@ YUI.add('imageloader-tests', function(Y) {
             var myFoldDistance = 20;
             Y.one('.fold-bottom-visual-indicator').setStyle('height', myFoldDistance);
 
-            this.imageUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/japan.jpg';
+            this.imageUrl = 'http://yui.yahooapis.com/testassets/japan.jpg';
             this.foldGroup = new Y.ImgLoadGroup({ name: 'foldConditionalGroup', foldDistance: myFoldDistance });
             this.foldGroup.registerImage({ domId: 'foldImgTop', srcUrl: this.imageUrl });
             this.foldGroup.registerImage({ domId: 'foldImgMiddle', srcUrl: this.imageUrl });
@@ -293,7 +293,7 @@ YUI.add('imageloader-tests', function(Y) {
 
         setUp: function() {
             this.timeLimit = .5;
-            this.imageUrl = 'http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/museum.jpg';
+            this.imageUrl = 'http://yui.yahooapis.com/testassets/museum.jpg';
             this.timeGroup = new Y.ImgLoadGroup({ name: 'timeLimitGroup', timeLimit: this.timeLimit });
             this.timeGroup.registerImage({ domId: 'timeImg', srcUrl: this.imageUrl });
             this.timeGroupImg = document.getElementById('timeImg');

--- a/src/imageloader/tests/unit/imageloader.html
+++ b/src/imageloader/tests/unit/imageloader.html
@@ -9,7 +9,7 @@
 .everything div { border:1px solid #888; }
 .topmain { position:absolute; top:10px; left:120px; height:75px; width:100px; }
 .duo1 { position:absolute; top:130px; left:20px; height:67px; width:100px; }
-#duo1 { background-image:url('http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/uluru.jpg'); }
+#duo1 { background-image:url('http://yui.yahooapis.com/testassets/uluru.jpg'); }
 .duo2 { position:absolute; top:130px; left:220px; height:53px; width:100px; }
 .src { position:absolute; top:220px; left:120px; height:72px; width:100px; }
 .trigger { position:absolute; top:330px; left:120px; height:75px; width:100px; }
@@ -68,10 +68,10 @@
 	<div class='topmain' id='topmain'></div>
 	<div class='duo1 yui-imgload' id='duo1'></div>
 	<div class='duo2'>
-		<img class='yui-imgload' id='duo2' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg");' width='100' height='53' />
+		<img class='yui-imgload' id='duo2' style='background-image:url("http://yui.yahooapis.com/testassets/katatjuta.jpg");' width='100' height='53' />
 	</div>
 	<div class='duo3'>
-		<img class='yui-newimgload' id='duo3' style='background-image:url("http://developer.yahoo.com/yui/docs/assets/examples/exampleimages/small/katatjuta.jpg");' width='100' height='53' />
+		<img class='yui-newimgload' id='duo3' style='background-image:url("http://yui.yahooapis.com/testassets/katatjuta.jpg");' width='100' height='53' />
 	</div>
 	<div class='src' id='srcImgCont'>
 		<img id='srcImg' />


### PR DESCRIPTION
Recently YDN added redirects from old YUI 2 docs to the GitHub archive. A side effect of this is that URLs that tests and examples were pointing to for images do not work. This manifested itself as a test failure for Android 4.4 but exists in other tests. This PR fixes the URL's to point to permanent URLs from our CDN.
