### PR TITLE
bound the right context to the aftersubscriber of _afterModelChange

### DIFF
--- a/src/app/js/lazy-model-list.js
+++ b/src/app/js/lazy-model-list.js
@@ -67,7 +67,7 @@ var AttrProto = Y.Attribute.prototype,
 Y.LazyModelList = Y.Base.create('lazyModelList', Y.ModelList, [], {
     // -- Lifecycle ------------------------------------------------------------
     initializer: function () {
-        this.after('*:change', this._afterModelChange);
+        this.after('*:change', Y.bind(this._afterModelChange, this));
     },
 
     // -- Public Methods -------------------------------------------------------


### PR DESCRIPTION
Making 'this' refer to the current LML-instance (inside _afterModelChange)
