### PR TITLE
[node] Hiding node elements support WAI-ARIA aria-hidden attribute

### DIFF
--- a/src/node/js/node-view.js
+++ b/src/node/js/node-view.js
@@ -33,6 +33,7 @@ Y.mix(Y_Node.prototype, {
      */
     _show: function() {
         this.removeAttribute('hidden');
+        this.removeAttribute('aria-hidden');
 
         // For back-compat we need to leave this in for browsers that
         // do not visually hide a node via the hidden attribute
@@ -108,6 +109,7 @@ Y.mix(Y_Node.prototype, {
      */
     _hide: function() {
         this.setAttribute('hidden', '');
+        this.set('aria-hidden', true);
 
         // For back-compat we need to leave this in for browsers that
         // do not visually hide a node via the hidden attribute

--- a/src/node/tests/unit/node.html
+++ b/src/node/tests/unit/node.html
@@ -1360,19 +1360,24 @@ YUI({
             var node = Y.one('body');
             node.hide();
             Assert.isTrue(node.hasAttribute('hidden'));
+            Assert.isTrue(node.hasAttribute('aria-hidden'));
             Assert.areEqual('none', node.getStyle('display'));
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 
         'should show the node': function() {
             var node = Y.one('body');
             node.setAttribute('hidden', '');
+            node.set('aria-hidden', true);
             node.setStyle('display', 'none');
             node.show(1);
             Assert.isFalse(node.hasAttribute('hidden'));
+            Assert.isFalse(node.hasAttribute('aria-hidden'));
             Assert.areEqual('block', node.getStyle('display'));
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 
@@ -1381,6 +1386,7 @@ YUI({
                 called = false;
 
             node.setAttribute('hidden', '');
+            node.set('aria-hidden', true);
             node.setStyle('display', 'none');
 
             node.show(function() {
@@ -1389,6 +1395,7 @@ YUI({
 
             Assert.isTrue(called);
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 
@@ -1396,7 +1403,8 @@ YUI({
             var node = Y.one('body'),
                 called = false;
 
-            node.setAttribute('hidden', true);
+            node.setAttribute('hidden', '');
+            node.set('aria-hidden', true);
             node.setStyle('display', 'none');
 
             node.show(null, function() {
@@ -1405,6 +1413,7 @@ YUI({
 
             Assert.isTrue(called);
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 
@@ -1418,6 +1427,7 @@ YUI({
 
             Assert.isTrue(called);
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 
@@ -1431,17 +1441,20 @@ YUI({
 
             Assert.isTrue(called);
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 
         'should toggle the node view on': function() {
             var node = Y.one('body');
 
-            node.setAttribute('hidden', true);
+            node.setAttribute('hidden', '');
+            node.set('aria-hidden', true);
             node.setStyle('display', 'none');
             node.toggleView();
 
-            Assert.areEqual('', node.getAttribute('hidden'));
+            Assert.isFalse(node.hasAttribute('hidden'));
+            Assert.isFalse(node.hasAttribute('aria-hidden'));
             Assert.areEqual('block', node.getStyle('display'));
         },
 
@@ -1449,7 +1462,8 @@ YUI({
             var node = Y.one('body'),
                 called = false;
 
-            node.setAttribute('hidden', true);
+            node.setAttribute('hidden', '');
+            node.set('aria-hidden', true);
             node.setStyle('display', 'none');
 
             node.toggleView('foo', function() {
@@ -1458,6 +1472,7 @@ YUI({
 
             Assert.isTrue(called);
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             Assert.areEqual('block', node.getStyle('display'));
         },
 
@@ -1467,7 +1482,8 @@ YUI({
 
             node.toggleView(true);
 
-            Assert.areEqual('', node.getAttribute('hidden'));
+            Assert.isFalse(node.hasAttribute('hidden'));
+            Assert.isFalse(node.hasAttribute('aria-hidden'));
             Assert.areEqual('block', node.getStyle('display'));
         },
 
@@ -1480,7 +1496,8 @@ YUI({
             });
 
             Assert.isTrue(called);
-            Assert.areEqual('', node.getAttribute('hidden'));
+            Assert.isFalse(node.hasAttribute('hidden'));
+            Assert.isFalse(node.hasAttribute('aria-hidden'));
             Assert.areEqual('block', node.getStyle('display'));
         },
 
@@ -1490,8 +1507,10 @@ YUI({
             node.toggleView(false);
 
             Assert.isTrue(node.hasAttribute('hidden'));
+            Assert.isTrue(node.hasAttribute('aria-hidden'));
             Assert.areEqual('none', node.getStyle('display'));
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 
@@ -1505,8 +1524,10 @@ YUI({
 
             Assert.isTrue(called);
             Assert.isTrue(node.hasAttribute('hidden'));
+            Assert.isTrue(node.hasAttribute('aria-hidden'));
             Assert.areEqual('none', node.getStyle('display'));
             node.removeAttribute('hidden');
+            node.removeAttribute('aria-hidden');
             node.setStyle('display', 'block');
         },
 


### PR DESCRIPTION
By this change, It will be added WAI-ARIA `aria-hidden` attribute to hide node elements further. Also, the `aria-hidden` attribute will be removed with `hidden` attribute when it showed node elements.

After called `node.hide()`:

``` html
<p id="box" hidden aria-hidden="true" style="display:none;">Content Text</p>
```

After called `node.show()`:

``` html
<p id="box">Content Text</p>
```

Tested with IE6, IE7, IE8, IE9, IE10, IE11, Firefox (stable), Chrome (stable), Safari 7.0, Safari (iOS 7).

```
[okuryu.local](yui3@node-view-aria)$ yeti tests/unit/node.html
  Agent connected: Internet Explorer (6.0) / Windows XP from 10.0.1.6
  Agent connected: Internet Explorer (7.0) / Windows XP from 10.0.1.6
  Agent connected: Internet Explorer (8.0) / Windows 7 from 10.0.1.6
  Agent connected: Internet Explorer (9.0) / Windows 7 from 10.0.1.6
  Agent connected: Internet Explorer (10.0) / Windows 7 from 10.0.1.6
  Agent connected: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; rv:11.0) like Gecko from 10.0.1.6
  Agent connected: Firefox (26.0) / Mac OS from 127.0.0.1
  Agent connected: Safari (7.0) / Mac OS from 127.0.0.1
  Agent connected: Chrome (31.0.1650.63) / Mac OS from 127.0.0.1
  Agent connected: Safari (7.0) / iOS 7.0.4 from 10.0.1.12
✓ Testing started on Internet Explorer (6.0) / Windows XP, Internet Explorer (7.0) / Windows XP, Internet Explorer (8.0) / Windows 7, Internet Explorer (9.0) / Windows 7, Internet Explorer (10.0) / Windows 7, Mozilla/5.0 (Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; rv:11.0) like Gecko, Firefox (26.0) / Mac OS, Safari (7.0) / Mac OS, Chrome (31.0.1650.63) / Mac OS, Safari (7.0) / iOS 7.0.4
✓ Agent completed: Internet Explorer (10.0) / Windows 7
✓ Agent completed: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; rv:11.0) like Gecko
✓ Agent completed: Safari (7.0) / iOS 7.0.4
✓ Agent completed: Internet Explorer (9.0) / Windows 7
✓ Agent completed: Chrome (31.0.1650.63) / Mac OS
✓ Agent completed: Internet Explorer (8.0) / Windows 7
✓ Agent completed: Safari (7.0) / Mac OS
✓ Agent completed: Internet Explorer (6.0) / Windows XP
✓ Agent completed: Internet Explorer (7.0) / Windows XP
✓ Agent completed: Firefox (26.0) / Mac OS
✓ 2600 tests passed! (19 seconds)
```
