### PR TITLE
[node-view] Use 'hidden' as the value for the 'hidden' attribute

### DIFF
--- a/src/node/js/node-view.js
+++ b/src/node/js/node-view.js
@@ -41,6 +41,15 @@ Y.mix(Y_Node.prototype, {
 
     },
 
+    /**
+    Returns whether the node is hidden by YUI or not. The hidden status is
+    determined by the 'hidden' attribute and the value of the 'display' CSS
+    property.
+
+    @method _isHidden
+    @return {Boolean} `true` if the node is hidden.
+    @private
+    **/
     _isHidden: function() {
         return  this.hasAttribute('hidden') || Y.DOM.getComputedStyle(this._node, 'display') === 'none';
     },


### PR DESCRIPTION
This is mostly for readability/debuggability. And to somewhat resolve #1490.
