### PR TITLE
Fix issue 1513: YUI violates Content-Security-Policy

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -199,7 +199,7 @@ available.
             YUI.Env.DOMReady = true;
             if (hasWin) {
                 remove(doc, 'DOMContentLoaded', handleReady);
-            }        
+            }
         },
         handleLoad = function() {
             YUI.Env.windowLoaded = true;
@@ -431,7 +431,10 @@ proto = {
 
                             // use CDN default
                             return path;
-                        }
+                        },
+                getGlobal: (function () {
+                            return this;
+                          }())
 
             };
 
@@ -476,7 +479,7 @@ proto = {
             useBrowserConsole: true,
             useNativeES5: true,
             win: win,
-            global: Function('return this')()
+            global: Y.Env.getGlobal
         };
 
         //Register the CSS stamp element


### PR DESCRIPTION
Simple change to remove use of 'eval' like code from yui.js in order to satisfy any strict Content-Security-Policy headers.

Ran complete unit tests with YETI on my OSX Version 10.8.2 with Chrome Version 31.0.1650.63, Safari Version 6.0.2 (8536.26.17), and Firefox Version: 17.
