### PR TITLE
Typo in yuidoc for Drop

### DIFF
--- a/src/dd/js/drop.js
+++ b/src/dd/js/drop.js
@@ -87,7 +87,7 @@
 
     Drop.ATTRS = {
         /**
-        * Y.Node instanace to use as the element to make a Drop Target
+        * Y.Node instance to use as the element to make a Drop Target
         * @attribute node
         * @type Node
         */


### PR DESCRIPTION
Fix typo in Drop object documentation

Typo in generated docs, here: http://yuilibrary.com/yui/docs/api/classes/DD.Drop.html#attr_node

"Y.Node instanace" => "Y.Node instance"
