### PR TITLE
Add example for the 'filters' property of the YUI config object

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -1792,6 +1792,25 @@ Skin configuration and customizations.
 Hash of per-component filter specifications. If specified for a given component,
 this overrides the global `filter` config.
 
+@example
+    YUI({
+        modules: {
+            'foo': './foo.js',
+            'bar': './bar.js',
+            'baz': './baz.js'
+        },
+        filters: {
+            'foo': {
+                searchExp: '.js',
+                replaceStr: '-coverage.js'
+            }
+        }
+    }).use('foo', 'bar', 'baz', function (Y) {
+        // foo-coverage.js is loaded
+        // bar.js is loaded
+        // baz.js is loaded
+    });
+
 @property {Object} filters
 **/
 


### PR DESCRIPTION
The previous documentation wasn't clear enough for my small brain.
I had to write that piece of code to make sure that I understood how `filters` was supposed to work:

``` html
<!DOCTYPE html>
<html>
    <head>
        <script src="../yui_3.8.1/yui/build/yui/yui.js"></script>
    </head>
    <body>
        <script>
            YUI({
                modules: {
                    'foo': './foo.js',
                    'bar': './bar.js',
                    'baz': './baz.js'
                },
                filters: {
                    'foo': {
                        searchExp: '.js',
                        replaceStr: '-coverage.js'
                    }
                }
            }).use('foo', 'bar', 'baz', function (Y) {
                // foo-coverage.js is loaded
                // bar.js is loaded
                // baz.js is loaded
            });
        </script>
    </body>
</html>
```

So I thought I would just submit this :P
