### PR TITLE
Prevent default page action when starting a gesturemove

### DIFF
--- a/src/dd/js/drag-gestures.js
+++ b/src/dd/js/drag-gestures.js
@@ -44,6 +44,9 @@
 
         this._createPG();
         this._active = true;
-        Y.one(Y.config.doc).on('gesturemove', Y.throttle(Y.bind(DDM._move, DDM), DDM.get('throttleTime')), { standAlone: true });
+        Y.one(Y.config.doc).on('gesturemove', Y.throttle(Y.bind(DDM._move, DDM), DDM.get('throttleTime')), {
+            standAlone: true,
+            preventDefault: true
+        });
     };
 


### PR DESCRIPTION
This prevents some browsers from selecting the page text during a gesture.
