### PR TITLE
Fix Calendar cell of next month appears to be selectable

### DIFF
--- a/src/calendar/HISTORY.md
+++ b/src/calendar/HISTORY.md
@@ -4,7 +4,7 @@ Calendar Change History
 @VERSION@
 ------
 
-* No changes.
+* Fix an issue when Feb 1st is Saturday Mar 2nd appears to be selectable. (@shunner)
 
 3.14.1
 ------

--- a/src/calendar/js/calendar-base.js
+++ b/src/calendar/js/calendar-base.js
@@ -1202,7 +1202,7 @@ Y.CalendarBase = Y.extend( CalendarBase, Y.Widget, {
                             curCell.removeClass(CAL_NEXTMONTH_DAY).addClass(CAL_DAY);
                         } else {
                             curCell.setContent("&nbsp;");
-                            curCell.addClass(CAL_NEXTMONTH_DAY).addClass(CAL_DAY);
+                            curCell.removeClass(CAL_DAY).addClass(CAL_NEXTMONTH_DAY);
                         }
                         break;
                     case 1:


### PR DESCRIPTION
Fix an issue of Calendar: when Feb 1st is Saturday, Mar 2nd as one of the next month day appears to be selectable.

See Issue #1540 for more details.

Note: This PR is identical to #1541 except this is against correct branch **dev-master**.
