### PR TITLE
Convert Y.log to Y.message for deprecations

### DIFF
--- a/src/app/js/model.js
+++ b/src/app/js/model.js
@@ -914,7 +914,7 @@ Y.Model = Y.extend(Model, Y.Base, {
         if (self.validate.length === 1) {
             // Backcompat for 3.4.x-style synchronous validate() functions that
             // don't take a callback argument.
-            Y.log('Synchronous validate() methods are deprecated since YUI 3.5.0.', 'warn', 'Model');
+            Y.message('Synchronous validate() methods are deprecated since YUI 3.5.0.', 'warn', 'Model');
             handler(self.validate(attributes, handler));
         } else {
             self.validate(attributes, handler);

--- a/src/dd/js/drag.js
+++ b/src/dd/js/drag.js
@@ -417,7 +417,7 @@
         */
         bubbles: {
             setter: function(t) {
-                Y.log('bubbles is deprecated use bubbleTargets: HOST', 'warn', 'dd');
+                Y.message('bubbles is deprecated use bubbleTargets: HOST', 'warn', 'dd');
                 this.addTarget(t);
                 return t;
             }

--- a/src/dd/js/drop.js
+++ b/src/dd/js/drop.js
@@ -156,7 +156,7 @@
         */
         bubbles: {
             setter: function(t) {
-                Y.log('bubbles is deprecated use bubbleTargets: HOST', 'warn', 'dd');
+                Y.message('bubbles is deprecated use bubbleTargets: HOST', 'warn', 'dd');
                 this.addTarget(t);
                 return t;
             }

--- a/src/event-custom/js/event-custom.js
+++ b/src/event-custom/js/event-custom.js
@@ -502,7 +502,7 @@ Y.CustomEvent.prototype = {
      * @deprecated use on.
      */
     subscribe: function(fn, context) {
-        Y.log('ce.subscribe deprecated, use "on"', 'warn', 'deprecated');
+        Y.message('ce.subscribe deprecated, use "on"', 'warn', 'deprecated');
         var a = (arguments.length > 2) ? nativeSlice.call(arguments, 2) : null;
         return this._on(fn, context, a, true);
     },

--- a/src/event-custom/js/event-target.js
+++ b/src/event-custom/js/event-target.js
@@ -339,7 +339,7 @@ ET.prototype = {
      * @deprecated use on
      */
     subscribe: function() {
-        Y.log('EventTarget subscribe() is deprecated, use on()', 'warn', 'deprecated');
+        Y.message('EventTarget subscribe() is deprecated, use on()', 'warn', 'deprecated');
         return this.on.apply(this, arguments);
     },
 
@@ -462,7 +462,7 @@ ET.prototype = {
      * @deprecated use detach
      */
     unsubscribe: function() {
-Y.log('EventTarget unsubscribe() is deprecated, use detach()', 'warn', 'deprecated');
+Y.message('EventTarget unsubscribe() is deprecated, use detach()', 'warn', 'deprecated');
         return this.detach.apply(this, arguments);
     },
 
@@ -486,7 +486,7 @@ Y.log('EventTarget unsubscribe() is deprecated, use detach()', 'warn', 'deprecat
      * @deprecated use detachAll
      */
     unsubscribeAll: function() {
-Y.log('EventTarget unsubscribeAll() is deprecated, use detachAll()', 'warn', 'deprecated');
+Y.message('EventTarget unsubscribeAll() is deprecated, use detachAll()', 'warn', 'deprecated');
         return this.detachAll.apply(this, arguments);
     },
 

--- a/src/get/js/get.js
+++ b/src/get/js/get.js
@@ -256,7 +256,7 @@ Y.Get = Get = {
     abort: function (transaction) {
         var i, id, item, len, pending;
 
-        Y.log('`Y.Get.abort()` is deprecated as of 3.5.0. Use the `abort()` method on the transaction instead.', 'warn', 'get');
+        Y.message('`Y.Get.abort()` is deprecated as of 3.5.0. Use the `abort()` method on the transaction instead.', 'warn', 'get');
 
         if (!transaction.abort) {
             id          = transaction;
@@ -614,14 +614,14 @@ Y.Get = Get = {
 
             // Backcompat for <3.5.0 behavior.
             if (req.win) {
-                Y.log('The `win` option is deprecated as of 3.5.0. Use `doc` instead.', 'warn', 'get');
+                Y.message('The `win` option is deprecated as of 3.5.0. Use `doc` instead.', 'warn', 'get');
                 req.doc = req.win.document;
             } else {
                 req.win = req.doc.defaultView || req.doc.parentWindow;
             }
 
             if (req.charset) {
-                Y.log('The `charset` option is deprecated as of 3.5.0. Set `attributes.charset` instead.', 'warn', 'get');
+                Y.message('The `charset` option is deprecated as of 3.5.0. Set `attributes.charset` instead.', 'warn', 'get');
                 req.attributes.charset = req.charset;
             }
 

--- a/src/node-focusmanager/js/node-focusmanager.js
+++ b/src/node-focusmanager/js/node-focusmanager.js
@@ -921,7 +921,7 @@ Y.extend(NodeFocusManager, Y.Plugin.Base, {
 	//	Public methods
 
     initializer: function (config) {
-    	Y.log("WARNING: node-focusmanager is a deprecated module as of YUI 3.9.0. This module will be removed from a later version of the library.", "warn");
+    	Y.message("WARNING: node-focusmanager is a deprecated module as of YUI 3.9.0. This module will be removed from a later version of the library.", "warn");
 		this.start();
 
     },

--- a/src/node-menunav/js/node-menunav.js
+++ b/src/node-menunav/js/node-menunav.js
@@ -697,7 +697,7 @@ Y.extend(NodeMenuNav, Y.Plugin.Base, {
 			aHandlers = [],
 			oDoc;
 
-		Y.log("WARNING: Node-MenuNav is a deprecated module as of YUI 3.9.0. This module will be removed from a later version of the library.", "warn");
+		Y.message("WARNING: Node-MenuNav is a deprecated module as of YUI 3.9.0. This module will be removed from a later version of the library.", "warn");
 
 		if (oRootMenu) {
 

--- a/src/swf/js/swf.js
+++ b/src/swf/js/swf.js
@@ -49,7 +49,7 @@
          *              tabindex, wmode.</code> event from the thumb</dd>
          *        </dl>
          */
-Y.log("The swf module is deprecated as of v3.13.0. YUI has no plans for providing a utility for embedding Flash into HTML pages.", "warn"); 
+Y.message("The swf module is deprecated as of v3.13.0. YUI has no plans for providing a utility for embedding Flash into HTML pages.", "warn"); 
 function SWF (p_oElement /*:String*/, swfURL /*:String*/, p_oAttributes /*:Object*/ ) {
 
     this._id = Y.guid("yuiswf");


### PR DESCRIPTION
When we recently upgraded to 3.13, we had a couple of people experiencing issues in code which was still using Y.get instead of Y.one, as Y.get was recently removed (these were predominantly gallery modules).

These deprecations hadn't been picked up earlier because when developing, we typically run with a config such that:
- the group representing our modules has a filter setting of 'debug'
- core YUI has a filter setting of 'raw'

This means that we can debug our modules complete with all debugging messages, and can still trace through core YUI code where required, without being inundated with messages from core YUI which are less relevant to us. I suspect that we are not alone in this way of developing with YUI.
# Proposed solutions

I can see two reasonable ways forward which would help developers pick up deprecation notices whilst still seeing the wood through the trees and not have all core YUI debug messages. These possible solutions are discussed below.
## Change all deprecation warnings from Y.log to Y.message

Shifter has a regex which is designed to remove Y.log, but not Y.message.
For most people, changing to use this will be sufficient for this purpose and will mean that deprecation notices are more readily visible.
For production use, setting Y.config.debug to false will remove these too. See http://yuilibrary.com/yui/docs/api/classes/config.html#property_debug for documentation on this property.
## Introduce a new Y.deprecated and us this instead of Y.log

This would also not be removed by Shifter and would operate almost identically to the Y.message solution. The difference being that it would be possible to introduce a new property in Y.config, similar to the debug property, but specifically aimed at deprecation warnings. This would allow them to be separated out from standard messages.

Having given it some thought, I suspect that using Y.message would be sufficient for a majority of cases and I can't really think of any reason you'd want one, but not the other.
