### PR TITLE
Addressed issue with path chaining in canvas implementation of graphics....

### DIFF
--- a/src/graphics/js/CanvasPath.js
+++ b/src/graphics/js/CanvasPath.js
@@ -77,6 +77,7 @@ Y.extend(CanvasPath, Y.CanvasShape, {
     end: function()
     {
         this._draw();
+        return this;
     }
 });
 


### PR DESCRIPTION
... Fix #1565

Ran unit tests for graphics and charts modules for ff26, chrome 32, safari 6.0.5, ie, 9, 10, 11. Android 2.4.3 (vm), Android 4.1.1 (vm). Did not test ie 6 - 8 as the change only affects canvas implementation. 
