### PR TITLE
Bump project version to 3.14.1

### DIFF
--- a/src/common/docs/project.json
+++ b/src/common/docs/project.json
@@ -5,7 +5,7 @@
 
     "yuiBuildUrl"     : "build",
     "yuiLocalBuildUrl": "build",
-    "yuiVersion"      : "3.6.0",
+    "yuiVersion"      : "3.14.1",
     "yuiSeedUrl"      : "build/yui/yui-min.js",
 
     "componentDefaults": {


### PR DESCRIPTION
Hey,

Ran `selleck --server` to read at some docs and noticed that the version number was slightly outdated. Is this still maintained? This PR just in case it is.
