### PR TITLE
Prefer 'right' for positioning inside RTL nodes (Fix #1569)

### DIFF
--- a/src/dom/js/dom-screen.js
+++ b/src/dom/js/dom-screen.js
@@ -317,39 +317,40 @@ Y.mix(Y_DOM, {
             delta,
             newXY,
             currentXY,
-            x,
-            hAttr,
-            rtl,
-            nodeWidth,
-            winWidth;
+            offsetDir,
+            dir,
+            x;
 
         if (node && xy) {
             pos = Y_DOM.getStyle(node, POSITION);
 
-            delta = Y_DOM._getOffset(node);
+            offsetDir = Y_DOM.OFFSET_XY;
+
+            if (!offsetDir) {
+                dir = Y_DOM.getComputedStyle(node, 'direction');
+
+                offsetDir = (dir === 'rtl' ? 'right' : LEFT);
+            }
+
+            delta = Y_DOM._getOffset(node, offsetDir);
             if (pos == 'static') { // default to relative
                 pos = RELATIVE;
                 setStyle(node, POSITION, pos);
             }
-            currentXY = Y_DOM.getXY(node);
+            currentXY = Y_DOM._getDirXY(node, offsetDir);
 
             x = xy[0];
-            hAttr = LEFT;
 
-            rtl = Y_DOM.getComputedStyle(node, 'direction') === 'rtl' || Y.one(node).ancestor('[dir="rtl"]');
+            if (offsetDir === 'right') {
+                x = Y_DOM.winWidth() - (xy[0] + parseInt(Y_DOM.getComputedStyle(node, 'width'), 10));
 
-            if (rtl) {
-                hAttr = 'right';
-                nodeWidth = Y.one(node).width();
-                winWidth = Y_DOM.winWidth();
-
-                x = winWidth - (xy[0] + nodeWidth);
-                delta[0] = parseInt(Y_DOM.getComputedStyle(node, 'right'), 10);
-                currentXY[0] = (winWidth - (currentXY[0] + nodeWidth));
+                if (!delta[0]) {
+                    noRetry = false;
+                }
             }
 
-            if (xy[0] !== null) {
-                setStyle(node, hAttr, x - currentXY[0] + delta[0] + 'px');
+            if (x !== null) {
+                setStyle(node, offsetDir, x - currentXY[0] + delta[0] + 'px');
             }
 
             if (xy[1] !== null) {
@@ -445,6 +446,16 @@ Y.mix(Y_DOM, {
         }
 
         return { height: root.scrollHeight, width: root.scrollWidth };
+    },
+
+    _getDirXY: function(node, dir) {
+        var xy = Y_DOM.getXY(node);
+
+        if (dir === 'right') {
+            xy[0] = (Y_DOM.winWidth() - (xy[0] + parseInt(Y_DOM.getComputedStyle(node, 'width'), 10)));
+        }
+
+        return xy;
     }
 });
 

--- a/src/dom/js/dom-screen.js
+++ b/src/dom/js/dom-screen.js
@@ -316,7 +316,12 @@ Y.mix(Y_DOM, {
             pos,
             delta,
             newXY,
-            currentXY;
+            currentXY,
+            x,
+            hAttr,
+            rtl,
+            nodeWidth,
+            winWidth;
 
         if (node && xy) {
             pos = Y_DOM.getStyle(node, POSITION);
@@ -328,8 +333,23 @@ Y.mix(Y_DOM, {
             }
             currentXY = Y_DOM.getXY(node);
 
+            x = xy[0];
+            hAttr = LEFT;
+
+            rtl = Y_DOM.getComputedStyle(node, 'direction') === 'rtl' || Y.one(node).ancestor('[dir="rtl"]');
+
+            if (rtl) {
+                hAttr = 'right';
+                nodeWidth = Y.one(node).width();
+                winWidth = Y_DOM.winWidth();
+
+                x = winWidth - (xy[0] + nodeWidth);
+                delta[0] = parseInt(Y_DOM.getComputedStyle(node, 'right'), 10);
+                currentXY[0] = (winWidth - (currentXY[0] + nodeWidth));
+            }
+
             if (xy[0] !== null) {
-                setStyle(node, LEFT, xy[0] - currentXY[0] + delta[0] + 'px');
+                setStyle(node, hAttr, x - currentXY[0] + delta[0] + 'px');
             }
 
             if (xy[1] !== null) {

--- a/src/dom/js/dom-style.js
+++ b/src/dom/js/dom-style.js
@@ -207,21 +207,33 @@ Y.DOM._getAttrOffset = function(node, attr) {
     return val;
 };
 
-Y.DOM._getOffset = function(node) {
+Y.DOM._getOffset = function(node, dir) {
     var pos,
-        xy = null;
+        xy = null,
+        offset = {
+            left: 'offsetLeft',
+            right: 'offsetRight'
+        },
+        margins = {
+            left: 'marginLeft',
+            right: 'marginRight'
+        },
+        margin;
+
+    dir = dir || 'left';
 
     if (node) {
         pos = Y_DOM.getStyle(node, 'position');
+        margin = parseInt(Y_DOM[GET_COMPUTED_STYLE](node, margins[dir]), 10);
         xy = [
-            parseInt(Y_DOM[GET_COMPUTED_STYLE](node, 'left'), 10),
+            parseInt(Y_DOM[GET_COMPUTED_STYLE](node, dir), 10),
             parseInt(Y_DOM[GET_COMPUTED_STYLE](node, 'top'), 10)
         ];
 
         if ( isNaN(xy[0]) ) { // in case of 'auto'
-            xy[0] = parseInt(Y_DOM.getStyle(node, 'left'), 10); // try inline
+            xy[0] = parseInt(Y_DOM.getStyle(node, dir), 10); // try inline
             if ( isNaN(xy[0]) ) { // default to offset value
-                xy[0] = (pos === 'relative') ? 0 : node.offsetLeft || 0;
+                xy[0] = (pos === 'relative') ? 0 : (node[offset[dir]] - margin) || 0;
             }
         }
 

--- a/src/dom/tests/unit/assets/dom-move-xy-test.js
+++ b/src/dom/tests/unit/assets/dom-move-xy-test.js
@@ -1,0 +1,42 @@
+YUI.add('dom-move-xy-test', function(Y) {
+    Y.DOM._testXY = function() {
+        var Assert = Y.Assert,
+            ArrayAssert = Y.ArrayAssert,
+
+            tests = {name: 'Y.DOM.xy'},
+            sel = '.node',
+            nodes = Y.Selector.query(sel);
+
+        function testXY(expected, actual) {
+            var x = actual[0],
+                pass = false;
+
+            // Expected is in pixels from offsetTop/Left, actual may be subpixels.
+            // Browsers don't agree on which way to round, so its
+            // considered a match if rounding up or down yields a match.
+            if ((Math.floor(actual[0]) === expected[0] || Math.ceil(actual[0]) === expected[0]) &&
+                (Math.floor(actual[1]) === expected[1] || Math.ceil(actual[1]) === expected[1])) {
+                pass = true;
+            }
+
+            return pass;
+        }
+
+        Y.each(nodes, function(n) {
+            var xy = [0, 0],
+                actual,
+                id = n.id;
+
+            Y.DOM.setXY(n, xy, true);
+
+            actual = Y.DOM.getXY(n);
+
+            tests['should move ' + id + ' to page coords'] = function() {
+                Assert.isTrue(testXY(xy, actual));
+                Assert.isTrue(testXY(xy, actual));
+            };
+        });
+
+        Y.Test.Runner.add(new Y.Test.Case(tests));
+    };
+}, '@VERSION@' ,{requires:['dom-screen', 'test']});

--- a/src/dom/tests/unit/dom-move-xy.html
+++ b/src/dom/tests/unit/dom-move-xy.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html>
+<head>
+<title>YUI: GetXY</title>
+<script type="text/javascript" src="../../../../build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/dom-move-xy-test.js"></script>
+<style type="text/css" media="screen">
+    .yui3-console {
+        position: absolute;
+        right: 0;
+        top: 0;
+        z-index: 1;
+    }
+
+	.container {
+	    position: relative;
+	    width: 100%;
+	    height: 120px;
+	}
+
+	.node {
+		opacity: 0.5;
+	    position: absolute;
+	    width: 200px;
+	    height: 50px;
+	    background-color: #74ADE8;
+	}
+
+	.node-left {
+		background-color: #f00;
+	    left: 200px;
+	}
+
+	.mr {
+		margin-right: 120px;
+	}
+
+	.ml {
+		margin-left: 120px;
+	}
+
+	.node-right {
+		background-color: #00f;
+	    right: 200px;
+	}
+</style>
+</head>
+<body class="yui3-skin-sam">
+
+<div class="container" dir="ltr">
+    <div id="ltr-left-ml" class="node node-left ml">LTR node left ml</div>
+    <div id="ltr-left-mr" class="node node-left mr">LTR node left mr</div>
+    <div id="ltr-left-ml-mr" class="node node-left mr ml">LTR node left ml mr</div>
+</div>
+
+<div class="container" dir="ltr">
+    <div id="ltr-right-ml" class="node node-right ml">LTR node right ml</div>
+    <div id="ltr-right-mr" class="node node-right mr">LTR node right mr</div>
+    <div id="ltr-right-ml-mr" class="node node-right ml mr">LTR node right ml mr</div>
+</div>
+
+<div class="container" dir="rtl">
+    <div id="rtl-left-ml" class="node node-left ml">RTL node left ml</div>
+    <div id="rtl-left-mr" class="node node-left mr">RTL node left mr</div>
+    <div id="rtl-left-ml-mr" class="node node-left ml mr">RTL node left ml mr</div>
+</div>
+
+<div class="container" dir="rtl">
+    <div id="rtl-right-ml" class="node node-right ml">RTL node right ml</div>
+    <div id="rtl-right-mr" class="node node-right mr">RTL node right mr</div>
+    <div id="rtl-right-ml-mr" class="node node-right ml mr">RTL node right ml mr</div>
+</div>
+
+<script type="text/javascript">
+YUI({
+    coverage: ['dom-screen'],
+    filter: (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw'
+}).use('test-console', 'dom-move-xy-test', function (Y) {
+        Y.DOM._testXY();
+        new Y.Test.Console().render();
+        Y.Test.Runner.setName('Dom: XY');
+        Y.Test.Runner.run();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
This is a working fix for #1569. (Check [this example](http://jsfiddle.net/jbalsas/h9ZYr/7/) about the issue)

It switches to position the node using a right-based calculation for nodes found inside RTL blocks, so that the inline position has preference.

I was looking to add some tests as well, but as far as I could see, the ones inside `dom-xy-tests.js` aren't exactly testing this over existing nodes, but over newly created ones. Is there a place for such tests or should we add them right there with the existing ones?
