### PR TITLE
Fix Amazon Silk detection in Y.UA.

### DIFF
--- a/src/yui/js/yui-ua.js
+++ b/src/yui/js/yui-ua.js
@@ -354,7 +354,7 @@ YUI.Env.parseUA = function(subUA) {
 
                 }
                 if (/Silk/.test(ua)) {
-                    m = ua.match(/Silk\/([^\s]*)\)/);
+                    m = ua.match(/Silk\/([^\s]*)/);
                     if (m && m[1]) {
                         o.silk = numberify(m[1]);
                     }

--- a/src/yui/tests/unit/assets/ua-yui-data.js
+++ b/src/yui/tests/unit/assets/ua-yui-data.js
@@ -265,6 +265,29 @@ Y.UAData["YUI Internal"] = [
                 }
         },
         {
+                "ua": "Mozilla/5.0 (Linux; U; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.4 Safari/535.19 Silk-Accelerated=true",
+                "data": {
+                        "webkit": 535.19,
+                        "safari": 535.19,
+                        "android": 2.34,
+                        "silk": 3.4,
+                        "accel": true,
+                        "os": "Android"
+                }
+        },
+        {
+                "ua": "Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.4 Mobile Safari/535.19 Silk-Accelerated=true",
+                "data": {
+                        "webkit": 535.19,
+                        "safari": 535.19,
+                        "mobile": "Android",
+                        "android": 4.03,
+                        "silk": 3.4,
+                        "accel": true,
+                        "os": "android"
+                }
+        },
+        {
                 "ua": "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5",
                 "data": {
                         "webkit": 533.179,


### PR DESCRIPTION
The UA string for Amazon Silk on recent Kindle Fires changed causing Y.UA.silk to no longer be set.

Amazon updated the UA string as specified here:
http://docs.aws.amazon.com/silk/latest/developerguide/user-agent.html
