### PR TITLE
fixes #1431: Removing 'scoped from 'style' blocks in all library example...

### DIFF
--- a/src/app/docs/app/app-contributors.mustache
+++ b/src/app/docs/app/app-contributors.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .scrollable pre {
     overflow-y: auto;
     max-height: 40em;

--- a/src/app/docs/app/app-todo.mustache
+++ b/src/app/docs/app/app-todo.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .scrollable pre {
     overflow-y: auto;
     max-height: 40em;

--- a/src/app/docs/app/partials/app-contributors-css.mustache
+++ b/src/app/docs/app/partials/app-contributors-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /*-- Override Styles ---------------------------------------------------------*/
 
 .example {

--- a/src/app/docs/app/partials/app-todo-css.mustache
+++ b/src/app/docs/app/partials/app-todo-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #todo-app {
     margin: 1em;
     text-align: center;

--- a/src/async-queue/docs/partials/queue-app-css.mustache
+++ b/src/async-queue/docs/partials/queue-app-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #init {
         margin-top: 1em;
     }

--- a/src/autocomplete/docs/ac-datasource.mustache
+++ b/src/autocomplete/docs/ac-datasource.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #ac-input { width: 250px; }
 </style>
 

--- a/src/autocomplete/docs/ac-tagging.mustache
+++ b/src/autocomplete/docs/ac-tagging.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #ac-input { width: 250px; }
 </style>
 

--- a/src/autocomplete/docs/ac-yql.mustache
+++ b/src/autocomplete/docs/ac-yql.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #ac-input { width: 250px; }
 </style>
 

--- a/src/autocomplete/docs/partials/ac-filter-source.mustache
+++ b/src/autocomplete/docs/partials/ac-filter-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
   #photos {
     border: 1px solid #cfcfcf;
     list-style: none;

--- a/src/autocomplete/docs/partials/ac-flickr-source.mustache
+++ b/src/autocomplete/docs/partials/ac-flickr-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
   #ac-input { width: 300px; }
 
   #photos {

--- a/src/cache/docs/partials/cache-basic-source.mustache
+++ b/src/cache/docs/partials/cache-basic-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo fieldset {display:block; border:0;}
 #demo .short {width:2em;}

--- a/src/cache/docs/partials/cache-offline-source.mustache
+++ b/src/cache/docs/partials/cache-offline-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .demo fieldset {display:block; border:0;}
 .demo .short {width:2em;}

--- a/src/charts/docs/charts-axisupdate.mustache
+++ b/src/charts/docs/charts-axisupdate.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-column.mustache
+++ b/src/charts/docs/charts-column.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-customizedtooltip.mustache
+++ b/src/charts/docs/charts-customizedtooltip.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-dualaxes.mustache
+++ b/src/charts/docs/charts-dualaxes.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-globalstyles.mustache
+++ b/src/charts/docs/charts-globalstyles.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-gridlines.mustache
+++ b/src/charts/docs/charts-gridlines.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-groupmarkers.mustache
+++ b/src/charts/docs/charts-groupmarkers.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-legend.mustache
+++ b/src/charts/docs/charts-legend.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-multiseries.mustache
+++ b/src/charts/docs/charts-multiseries.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-objectstyles.mustache
+++ b/src/charts/docs/charts-objectstyles.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/charts/docs/charts-pie.mustache
+++ b/src/charts/docs/charts-pie.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width: 400px;

--- a/src/charts/docs/charts-seriesupdate.mustache
+++ b/src/charts/docs/charts-seriesupdate.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mychart {

--- a/src/charts/docs/charts-simple.mustache
+++ b/src/charts/docs/charts-simple.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mychart {

--- a/src/charts/docs/charts-stackedarea.mustache
+++ b/src/charts/docs/charts-stackedarea.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mychart {

--- a/src/charts/docs/charts-stackedcolumn.mustache
+++ b/src/charts/docs/charts-stackedcolumn.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mychart {

--- a/src/charts/docs/charts-timeaxis.mustache
+++ b/src/charts/docs/charts-timeaxis.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #mychart {
     margin:10px 10px 10px 10px;
     width:90%;

--- a/src/console-filters/docs/partials/console-filters-intro-css.mustache
+++ b/src/console-filters/docs/partials/console-filters-intro-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #yconsole {
     margin: 0 auto 1em;
 }

--- a/src/console/docs/partials/console-basic-css.mustache
+++ b/src/console/docs/partials/console-basic-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #basic, #add_to_bottom {
     margin-bottom: 1em;
 }

--- a/src/console/docs/partials/console-yui-config-css.mustache
+++ b/src/console/docs/partials/console-yui-config-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #console {
     float: left;
 }

--- a/src/dataschema/docs/partials/dataschema-array-source.mustache
+++ b/src/dataschema/docs/partials/dataschema-array-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/dataschema/docs/partials/dataschema-json-source.mustache
+++ b/src/dataschema/docs/partials/dataschema-json-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/dataschema/docs/partials/dataschema-parsing-source.mustache
+++ b/src/dataschema/docs/partials/dataschema-parsing-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/dataschema/docs/partials/dataschema-table-source.mustache
+++ b/src/dataschema/docs/partials/dataschema-table-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 #complex tbody, #complex thead {

--- a/src/dataschema/docs/partials/dataschema-xml-source.mustache
+++ b/src/dataschema/docs/partials/dataschema-xml-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datasource/docs/datasource-caching.mustache
+++ b/src/datasource/docs/datasource-caching.mustache
@@ -1,6 +1,6 @@
 {{>datasource-mock-config}}
 
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {
     margin-bottom:1em;

--- a/src/datasource/docs/datasource-function.mustache
+++ b/src/datasource/docs/datasource-function.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datasource/docs/datasource-get.mustache
+++ b/src/datasource/docs/datasource-get.mustache
@@ -1,6 +1,6 @@
 {{>datasource-mock-config}}
 
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datasource/docs/datasource-offlinecache.mustache
+++ b/src/datasource/docs/datasource-offlinecache.mustache
@@ -1,6 +1,6 @@
 {{>datasource-mock-config}}
 
-<style scoped>
+<style>
 #demo .output {
     margin-bottom:1em;
     padding:10px;

--- a/src/datasource/docs/datasource-polling.mustache
+++ b/src/datasource/docs/datasource-polling.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datasource/docs/partials/datasource-io-source.mustache
+++ b/src/datasource/docs/partials/datasource-io-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datasource/docs/partials/datasource-local-source.mustache
+++ b/src/datasource/docs/partials/datasource-local-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datatable/docs/datatable-basic.mustache
+++ b/src/datatable/docs/datatable-basic.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .example .yui3-datatable {
     margin-bottom: 1em;

--- a/src/datatable/docs/datatable-chkboxselect.mustache
+++ b/src/datatable/docs/datatable-chkboxselect.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* css to counter global site css */
 .example table {
     width: auto;

--- a/src/datatable/docs/datatable-dsget.mustache
+++ b/src/datatable/docs/datatable-dsget.mustache
@@ -1,6 +1,6 @@
 {{>datasource-mock-config}}
 
-<style scoped>
+<style>
 /* css to counter global site css */
 .example table {
     width: auto;

--- a/src/datatable/docs/datatable-formatting.mustache
+++ b/src/datatable/docs/datatable-formatting.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .example .yui3-datatable {
     margin-bottom: 1em;

--- a/src/datatable/docs/datatable-masterdetail.mustache
+++ b/src/datatable/docs/datatable-masterdetail.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
   .yui3-skin-sam .yui3-datatable-caption {
     font-size: 13px;
     font-style: normal;

--- a/src/datatable/docs/datatable-nestedcols.mustache
+++ b/src/datatable/docs/datatable-nestedcols.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .example .yui3-datatable {
     margin-bottom: 1em;

--- a/src/datatable/docs/datatable-recordtype.mustache
+++ b/src/datatable/docs/datatable-recordtype.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .example .yui3-datatable {
     margin-bottom: 1em;

--- a/src/datatable/docs/datatable-scroll.mustache
+++ b/src/datatable/docs/datatable-scroll.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .example .yui3-datatable {
     margin-bottom: 1em;

--- a/src/datatable/docs/datatable-sort.mustache
+++ b/src/datatable/docs/datatable-sort.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .example .yui3-datatable {
     margin-bottom: 1em;

--- a/src/datatable/docs/index.mustache
+++ b/src/datatable/docs/index.mustache
@@ -411,7 +411,7 @@ var columns = [
 <p>This code produces this table:</p>
 
 <div id="formatter-example" class="yui3-skin-sam">
-    <style scoped>
+    <style>
         .yui3-datatable .yui3-datatable-data .expensive {
             background-color: #ffe;
         }

--- a/src/datatable/docs/partials/datatable-dsio-source.mustache
+++ b/src/datatable/docs/partials/datatable-dsio-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 .example .yui3-datatable {
     margin-bottom: 1em;

--- a/src/datatable/docs/partials/datatable-paginator-css.mustache
+++ b/src/datatable/docs/partials/datatable-paginator-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .numeric {
     text-align: right;
 }

--- a/src/datatype/docs/datatype-dateformat-lang.mustache
+++ b/src/datatype/docs/datatype-dateformat-lang.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 
 #default_lang_output, #single_lang_output {

--- a/src/datatype/docs/datatype-dateparse.mustache
+++ b/src/datatype/docs/datatype-dateparse.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datatype/docs/datatype-numberformat.mustache
+++ b/src/datatype/docs/datatype-numberformat.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo label {display:block;}
 #demo fieldset {margin:1em;}

--- a/src/datatype/docs/datatype-numberparse.mustache
+++ b/src/datatype/docs/datatype-numberparse.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo label {display:block;}
 #demo fieldset {margin:1em;}

--- a/src/datatype/docs/datatype-xmlformat.mustache
+++ b/src/datatype/docs/datatype-xmlformat.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo .output {margin-bottom:1em; padding:10px; border:1px solid #D9D9D9;}
 </style>

--- a/src/datatype/docs/datatype-xmlparse.mustache
+++ b/src/datatype/docs/datatype-xmlparse.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #demo input, #demo label {display:block;}
 #demo fieldset {margin:1em;}

--- a/src/event/docs/basic-example.mustache
+++ b/src/event/docs/basic-example.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #container {
     background-color: #F5E3B1;
     border: 1px solid #C2AE6D;

--- a/src/event/docs/focus-example.mustache
+++ b/src/event/docs/focus-example.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     .yui3-js-enabled .yui3-checkboxes-loading { display: none;	}
 </style>
 

--- a/src/event/docs/synth-example.mustache
+++ b/src/event/docs/synth-example.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #demo {
         position: relative;
     }

--- a/src/graphics/docs/graphics-customshape.mustache
+++ b/src/graphics/docs/graphics-customshape.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mygraphiccontainer {

--- a/src/graphics/docs/graphics-drag.mustache
+++ b/src/graphics/docs/graphics-drag.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mygraphiccontainer {

--- a/src/graphics/docs/graphics-gradients.mustache
+++ b/src/graphics/docs/graphics-gradients.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mygraphiccontainer {

--- a/src/graphics/docs/graphics-muddyglass.mustache
+++ b/src/graphics/docs/graphics-muddyglass.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mygraphiccontainer {

--- a/src/graphics/docs/graphics-path.mustache
+++ b/src/graphics/docs/graphics-path.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mygraphiccontainer {

--- a/src/graphics/docs/graphics-simple.mustache
+++ b/src/graphics/docs/graphics-simple.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mygraphiccontainer {

--- a/src/graphics/docs/graphics-transforms.mustache
+++ b/src/graphics/docs/graphics-transforms.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #mygraphiccontainer {

--- a/src/graphics/docs/graphics-violin.mustache
+++ b/src/graphics/docs/graphics-violin.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #custom-doc { width: 95%; min-width: 950px; }
 #pagetitle {background-image: url(../../assets/bg_hd.gif);}
 #outerframe {

--- a/src/graphics/docs/partials/graphics-radial-tool-source.mustache
+++ b/src/graphics/docs/partials/graphics-radial-tool-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .example{
     position: relative;
     background-color: #000;

--- a/src/handlebars/docs/index.mustache
+++ b/src/handlebars/docs/index.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .handlebars-code pre.code {
     height: 100%;
     margin: 0;

--- a/src/history/docs/history-tabview.mustache
+++ b/src/history/docs/history-tabview.mustache
@@ -13,7 +13,7 @@ to return to the current page with the same tab selected.
 </div>
 
 <div class="example">
-    <style scoped>
+    <style>
         #demo { width: 300px; }
 
         #demo img {

--- a/src/intl/docs/intl-basic.mustache
+++ b/src/intl/docs/intl-basic.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #out .word {
     margin:0.3em 0.3em 0.3em 1em;
 }

--- a/src/json/docs/partials/json-freeze-thaw-source.mustache
+++ b/src/json/docs/partials/json-freeze-thaw-source.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #demo pre {
     background: #fff;
     border: 1px solid #ccc;

--- a/src/jsonp/docs/partials/jsonp-gallery-css.mustache
+++ b/src/jsonp/docs/partials/jsonp-gallery-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #out {
         margin-top: 2em;
     }

--- a/src/jsonp/docs/partials/jsonp-github-css.mustache
+++ b/src/jsonp/docs/partials/jsonp-github-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #out {
     margin-top: 1em;
 }

--- a/src/node-focusmanager/docs/node-focusmanager-button.mustache
+++ b/src/node-focusmanager/docs/node-focusmanager-button.mustache
@@ -10,7 +10,7 @@
 </div>
 
 <div class="example">
-    <style scoped>
+    <style>
         /*  The following two styles are necessary to override style rules in the
             YUI CSS file. */
 

--- a/src/node-focusmanager/docs/node-focusmanager-toolbar.mustache
+++ b/src/node-focusmanager/docs/node-focusmanager-toolbar.mustache
@@ -7,7 +7,7 @@ Focus Manager Node Plugin and Node's support for the
 </div>
 
 <div class="example">
-    <style scoped>
+    <style>
     .yui3-toolbar {
         border: solid 1px #999;
         background-color: #ccc;

--- a/src/paginator/docs/partials/search-css-styles.mustache
+++ b/src/paginator/docs/partials/search-css-styles.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /** DEMO BOX **/
 #demo {
     position: relative;

--- a/src/paginator/docs/partials/slideshow-css-styles.mustache
+++ b/src/paginator/docs/partials/slideshow-css-styles.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #spiffySlides {
     position: relative;
     overflow: hidden;

--- a/src/paginator/docs/partials/table-css-styles.mustache
+++ b/src/paginator/docs/partials/table-css-styles.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #demo {
     color: #333;
     font-size: 11pt;

--- a/src/promise/docs/partials/github-cache-css.mustache
+++ b/src/promise/docs/partials/github-cache-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #demo div {
         padding: 5px;
         margin: 2px;

--- a/src/promise/docs/partials/node-plugin-css.mustache
+++ b/src/promise/docs/partials/node-plugin-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #square {
         width: 100px;
         height: 100px;

--- a/src/promise/docs/partials/subclass-css.mustache
+++ b/src/promise/docs/partials/subclass-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     .error {
         background: #ffc5c4;
     }

--- a/src/recordset/docs/recordset-indexer.mustache
+++ b/src/recordset/docs/recordset-indexer.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 #htContainer {
 	font-size:90%;

--- a/src/recordset/docs/recordset-sort.mustache
+++ b/src/recordset/docs/recordset-sort.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 /* custom styles for this example */
 
 #buttonControl input {

--- a/src/slider/docs/partials/slider-from-markup-css.mustache
+++ b/src/slider/docs/partials/slider-from-markup-css.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #demo {
         background: #fff;
         border: 1px solid #999;

--- a/src/slider/docs/slider-basic.mustache
+++ b/src/slider/docs/slider-basic.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #demo input {
         width: 2em;
     }

--- a/src/slider/docs/slider-skin.mustache
+++ b/src/slider/docs/slider-skin.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
     #demo .light {
         padding: 1em;
     }

--- a/src/tabview/docs/tabview-add-remove.mustache
+++ b/src/tabview/docs/tabview-add-remove.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .yui3-tabview {
     margin-bottom: 1em;
 }

--- a/src/template/docs/index.mustache
+++ b/src/template/docs/index.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 .micro-code pre.code {
     height: 100%;
     margin: 0;

--- a/src/test-console/docs/index.mustache
+++ b/src/test-console/docs/index.mustache
@@ -112,7 +112,7 @@ Here's a working example you can play with. Try checking the "pass" checkbox to 
 </p>
 
 <div id="log" class="yui3-skin-sam">
-    <style scoped>
+    <style>
     #log h4 {
         border: none;
         margin: default;

--- a/src/transition/docs/transition-view.mustache
+++ b/src/transition/docs/transition-view.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 div.demo {
     margin: 1em 0;
     width: 300px;

--- a/src/widget/docs/widget-plugin.mustache
+++ b/src/widget/docs/widget-plugin.mustache
@@ -1,4 +1,4 @@
-<style scoped>
+<style>
 #demo {
     width: 50em;
 }


### PR DESCRIPTION
... .mustache files

Fixes bugs in Firefox that gives incorrect values when using getComputedStyle() on nodes inside `<style scoped>` blocks.

Other browsers do not yet support `<style scoped>`

https://gist.github.com/jconniff/e7c780544d91771bffd9
https://gist.github.com/sdesai/6002726
