### PR TITLE
[test] Assert that next() bounds the function to the test

### DIFF
--- a/src/test/js/TestCase.js
+++ b/src/test/js/TestCase.js
@@ -106,7 +106,8 @@ YUITest.TestCase.prototype = {
 
     @method next
     @param {Function} callback Callback to call after resuming the test.
-    @param {Object} [context] The value of `this` inside the callback. If not given, `this` is the test case.
+    @param {Object} [context] The value of `this` inside the callback.
+        If not given, the original context of the function will be used.
     @return {Function} wrapped callback that resumes the test.
     @example
     ```
@@ -127,11 +128,12 @@ YUITest.TestCase.prototype = {
     **/
     next: function (callback, context) {
         var self = this;
-        if (typeof context !== 'object') {
-            context = this;
-        }
+        context = arguments.length >= 2 ? arguments[1] : undefined;
         return function () {
             var args = arguments;
+            if (context === undefined) {
+                context = this;
+            }
             self.resume(function () {
                 callback.apply(context, args);
             });

--- a/src/test/tests/unit/assets/general-tests.js
+++ b/src/test/tests/unit/assets/general-tests.js
@@ -128,17 +128,34 @@ YUI.add('general-tests', function(Y) {
 
             self.wait();
         },
-        'test: next() bounds the function to the test if no context is given': function () {
-            var self = this;
+        'test: next() preserves the original context of a function': function () {
+            var self = this,
+                foo,
+                bar = { hello: 'world' };
 
-            self.i_am_test = true;
+            function Foo() {}
+            Y.augment(Foo, Y.EventTarget);
+
+            foo = new Foo();
+            foo.on('something', this.next(function () {
+                self.assert(this === bar);
+            }), bar);
+
+            setTimeout(function () {
+                foo.fire('something');
+            }, 0);
+
+            self.wait();
+        },
+        'test: next() bounds the function to Y.config.global if no context is given': function () {
+            var self = this;
 
             function async(callback) {
                 setTimeout(callback, 0);
             }
 
             async(self.next(function () {
-                self.assert(this.i_am_test === true);
+                self.assert(this === Y.config.global);
             }));
 
             self.wait();


### PR DESCRIPTION
Hey @juandopazo,

I like the new `next()` method, quite handy indeed.

I just wanted to make sure that it does bound the context to the test as `resume()` does.

What do you think?
