### PR TITLE
Finishing the removal of scoped from style blocks started in pr#1577

### DIFF
--- a/src/attribute/docs/attribute-basic-speeddate.mustache
+++ b/src/attribute/docs/attribute-basic-speeddate.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     #speeddate h1 {
         font-size: 108%;
         color:#000;

--- a/src/attribute/docs/attribute-basic.mustache
+++ b/src/attribute/docs/attribute-basic.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     .example-out .myclass-attrs {
         font-family:courier;
         margin-top:2px;

--- a/src/attribute/docs/attribute-event-speeddate.mustache
+++ b/src/attribute/docs/attribute-event-speeddate.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     #speeddate h1 {
         font-size: 108%;
         color:#000;

--- a/src/attribute/docs/attribute-event.mustache
+++ b/src/attribute/docs/attribute-event.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     #example-out .event {
         padding:2px 2px 2px 5px;
     }

--- a/src/attribute/docs/attribute-getset.mustache
+++ b/src/attribute/docs/attribute-getset.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 
     #boxParent {
         overflow:hidden;

--- a/src/attribute/docs/attribute-rw.mustache
+++ b/src/attribute/docs/attribute-rw.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     .example-out .myclass-attrs {
         font-family:courier;
         margin-top:2px;

--- a/src/io/docs/get.mustache
+++ b/src/io/docs/get.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 #container li {margin-left:2em;}
 #container { background-color:#FFFFFF; border:1px dotted #666666; padding:1em; margin-bottom:1em;}
 </style>

--- a/src/io/docs/weather.mustache
+++ b/src/io/docs/weather.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 #weatherModule li {margin-left:2em;}
 #weatherModule { background-color:#FFFFFF; border:1px dotted #666666; padding:1em; margin-bottom:1em;}
 </style>

--- a/src/io/docs/xdr.mustache
+++ b/src/io/docs/xdr.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 #output li {margin-left:2em;}
 #output { background-color:#FFFFFF; border:1px dotted #666666; padding:1em; margin-top:1em;}
 </style>

--- a/src/overlay/docs/overlay-align.mustache
+++ b/src/overlay/docs/overlay-align.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 {{>overlay-css}}
 
 /* Example Layout CSS */

--- a/src/overlay/docs/overlay-anim-plugin.mustache
+++ b/src/overlay/docs/overlay-anim-plugin.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     /* If js is enabled, hide overlay markup off screen while the overlay is being instantiated */
     .yui3-js-enabled .yui3-overlay-loading {
         top:-1000em;

--- a/src/overlay/docs/overlay-constrain.mustache
+++ b/src/overlay/docs/overlay-constrain.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 
 {{>overlay-css}}
 

--- a/src/overlay/docs/overlay-io-plugin.mustache
+++ b/src/overlay/docs/overlay-io-plugin.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 {{>overlay-css}}
 
     .yui3-overlay .yui3-widget-bd .yui3-feed-data {

--- a/src/overlay/docs/overlay-stack.mustache
+++ b/src/overlay/docs/overlay-stack.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 /* Hide overlay markup while loading, if js is enabled */
 .yui3-js-enabled .yui3-overlay-loading {
     top:-1000em;

--- a/src/overlay/docs/overlay-stdmod.mustache
+++ b/src/overlay/docs/overlay-stdmod.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 /* Hide overlay markup while loading, if js is enabled */
 .yui3-js-enabled .yui3-overlay-loading {
     top:-1000em;

--- a/src/overlay/docs/overlay-tooltip.mustache
+++ b/src/overlay/docs/overlay-tooltip.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 /* Hide overlay markup while loading, if js is enabled */
 .yui3-js-enabled .yui3-overlay-loading {
     top:-1000em;

--- a/src/overlay/docs/overlay-xy.mustache
+++ b/src/overlay/docs/overlay-xy.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 /* Hide overlay markup while loading, if js is enabled */
 .yui3-js-enabled .yui3-overlay-loading {
     top:-1000em;

--- a/src/widget/docs/widget-build.mustache
+++ b/src/widget/docs/widget-build.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 
 /* Standard Module Widget CSS */
 .yui3-standardmodule-hidden {

--- a/src/widget/docs/widget-extend.mustache
+++ b/src/widget/docs/widget-extend.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     .yui3-js-enabled .yui3-spinner-loading {
         display:none;
     }

--- a/src/widget/docs/widget-parentchild-listbox.mustache
+++ b/src/widget/docs/widget-parentchild-listbox.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
 
     #mylistbox em {
         font-style:normal;

--- a/src/widget/docs/widget-tooltip.mustache
+++ b/src/widget/docs/widget-tooltip.mustache
@@ -1,4 +1,4 @@
-<style type="text/css" scoped>
+<style>
     .yui3-tooltip {
         position:absolute;
     }


### PR DESCRIPTION
In PR#1577 I had overlooked cases of `<style type="text/css" scoped>` there were 21 of those
