### PR TITLE
[core] Fix value of `this` inside ES6 module definitions

### DIFF
--- a/src/yui/HISTORY.md
+++ b/src/yui/HISTORY.md
@@ -4,6 +4,7 @@ YUI Core Change History
 @VERSION@
 ------
 
+* Fixed value of `this` inside ES6 module definitions.
 * Fixed UA detection in recent versions of the Amazon Silk browser.
   ([#1576][]: @adinardi)
 

--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -799,10 +799,10 @@ with any configuration info required for the module.
                             }
                         }
                         if (Y.config.throwFail) {
-                            __exports__ = mod.fn.apply(mod, modArgs);
+                            __exports__ = mod.fn.apply(esCompat ? undefined : mod, modArgs);
                         } else {
                             try {
-                                __exports__ = mod.fn.apply(mod, modArgs);
+                                __exports__ = mod.fn.apply(esCompat ? undefined : mod, modArgs);
                             } catch (e) {
                                 Y.error('Attach error: ' + name, e, name);
                                 return false;

--- a/src/yui/tests/unit/assets/es-modules-test.js
+++ b/src/yui/tests/unit/assets/es-modules-test.js
@@ -31,6 +31,18 @@ YUI.add('mod5-es', function (Y, NAME, __imports__, __exports__) {
 suite.add(new Y.Test.Case({
     name: 'ES Modules Compat tests',
 
+    _should: {
+        ignore: {
+            'context in module definition functions in sloppy mode': (function () {
+                return this !== Y.config.global;
+            }()),
+            'context in module definition functions in strict mode': (function () {
+                'use strict';
+                return this !== undefined;
+            }())
+        }
+    },
+
     "test legacy module": function () {
         // no need to go async in these tests since all modules are available
         Y.use('mod1-legacy');
@@ -60,6 +72,40 @@ suite.add(new Y.Test.Case({
         Assert.areSame(2, imp['mod2-es-legacy']['default'], "__imports__ should contain a reference to the exports of required es modules");
         Assert.areSame(3, imp['mod3-es-mix']['default'], "__imports__ should contain a reference to the exports of required es modules");
         Assert.isUndefined(imp['mod4-es-without-export'], "__imports__ should contain a reference to undefined if the es module exports nothing");
+    },
+
+    "context in module definition functions in sloppy mode": function () {
+        var test = this;
+
+        YUI.add('mod10-es-sloppy', function (Y, NAME, __imports__, __exports__) {
+            var that = this;
+            test.resume(function () {
+                Assert.areSame(Y.config.global, that, '`this` inside modules should point to the global object in sloppy mode');
+            });
+        }, '', {es: true});
+
+        setTimeout(function () {
+            YUI().use('mod10-es-sloppy');
+        }, 0);
+        test.wait();
+    },
+
+    "context in module definition functions in strict mode": function () {
+        'use strict';
+
+        var test = this;
+
+        YUI.add('mod10-es-strict', function (Y, NAME, __imports__, __exports__) {
+            var that = this;
+            test.resume(function () {
+                Assert.isUndefined(that, '`this` inside modules should be undefined in strict mode');
+            });
+        }, '', {es: true});
+
+        setTimeout(function () {
+            YUI().use('mod10-es-strict');
+        }, 0);
+        test.wait();
     }
 
 }));


### PR DESCRIPTION
Fixes #1596.

The value of `this` inside YUI modules is a `mod` object. ES6 modules need to point to the global object in sloppy mode and to `undefined` in strict mode.

Ping @caridy
