### PR TITLE
[promise] Remove Promise.cast

### DIFF
--- a/src/promise/HISTORY.md
+++ b/src/promise/HISTORY.md
@@ -4,7 +4,8 @@ Promise Change History
 @VERSION@
 ------
 
-* No changes.
+* Remove `Promise.resolve` and rename `Promise.cast` to `Promise.resolve` as per
+  the last TC39 decision.
 
 3.14.1
 ------

--- a/src/promise/js/promise.js
+++ b/src/promise/js/promise.js
@@ -288,7 +288,7 @@ Promise.all = function (values) {
         }
 
         for (; i < length; i++) {
-            Promise.cast(values[i]).then(oneDone(i), reject);
+            Promise.resolve(values[i]).then(oneDone(i), reject);
         }
     });
 };
@@ -315,7 +315,7 @@ Promise.race = function (values) {
         // This abuses the fact that calling resolve/reject multiple times
         // doesn't change the state of the returned promise
         for (var i = 0, count = values.length; i < count; i++) {
-            Promise.cast(values[i]).then(resolve, reject);
+            Promise.resolve(values[i]).then(resolve, reject);
         }
     });
 };

--- a/src/promise/js/when.js
+++ b/src/promise/js/when.js
@@ -16,7 +16,7 @@ are provided, the original promise is returned.
 @return {Promise}
 **/
 Y.when = function (promise, callback, errback) {
-    promise = Promise.cast(promise);
+    promise = Promise.resolve(promise);
 
     return (callback || errback) ? promise.then(callback, errback) : promise;
 };

--- a/src/promise/tests/unit/assets/promise-tests.js
+++ b/src/promise/tests/unit/assets/promise-tests.js
@@ -464,11 +464,11 @@ YUI.add('promise-tests', function (Y) {
         name: 'Promise.resolve() tests',
 
         'a promise should not be modified': function () {
-            var promise = new Promise(),
+            var promise = new Promise(function () {}),
                 wrapped = Promise.resolve(promise);
 
-            Assert.isTrue(Promise.isPromise(promise), 'Promise.cast should always return a promise');
-            Assert.areSame(promise, wrapped, 'Promise.cast should not modify a promise');
+            Assert.isTrue(Promise.isPromise(promise), 'Promise.resolve should always return a promise');
+            Assert.areSame(promise, wrapped, 'Promise.resolve should not modify a promise');
         },
 
         'values should be wrapped in a promise': function () {


### PR DESCRIPTION
During yesterday's TC39 meeting it was decided to remove `Promise.resolve` and rename `Promise.cast` to `Promise.resolve`, essentially keeping only one method (:+1: considering how similar they behaved).
