### PR TITLE
Tidy up log calls in event

### DIFF
--- a/src/event/js/event-dom.js
+++ b/src/event/js/event-dom.js
@@ -217,8 +217,6 @@ Event._interval = setInterval(Event._poll, Event.POLL_INTERVAL);
 
             var a = Y.Array(id), i, availHandle;
 
-            // Y.log('onAvailable registered for: ' + id);
-
             for (i=0; i<a.length; i=i+1) {
                 _avail.push({
                     id:         a[i],
@@ -387,8 +385,7 @@ Event._interval = setInterval(Event._poll, Event.POLL_INTERVAL);
             }
 
             if (!fn || !fn.call) {
-// throw new TypeError(type + " attach call failed, callback undefined");
-Y.log(type + " attach call failed, invalid callback", "error", "event");
+                Y.log(type + " attach call failed, invalid callback", "error", "event");
                 return false;
             }
 
@@ -440,9 +437,7 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
                 // Not found = defer adding the event until the element is available
                 } else {
 
-                    // Y.log(el + ' not found');
                     ret = Event.onAvailable(el, function() {
-                        // Y.log('lazy attach: ' + args);
 
                         ret.handle = Event._attach(args, conf);
 
@@ -632,7 +627,6 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
          */
         _load: function(e) {
             if (!_loadComplete) {
-                // Y.log('Load Complete', 'info', 'event');
                 _loadComplete = true;
 
                 // Just in case DOMReady did not go off for some reason
@@ -672,7 +666,6 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
 
             Event.locked = true;
 
-            // Y.log.debug("poll");
             // keep trying until after the page is loaded.  We need to
             // check the page load state prior to trying to bind the
             // elements so that we can be certain all elements have been
@@ -719,11 +712,9 @@ Y.log(type + " attach call failed, invalid callback", "error", "event");
                     el = (item.compat) ? Y.DOM.byId(item.id) : Y.Selector.query(item.id, null, true);
 
                     if (el) {
-                        // Y.log('avail: ' + el);
                         executeItem(el, item);
                         _avail[i] = null;
                     } else {
-                        // Y.log('NOT avail: ' + el);
                         notAvail.push(item);
                     }
                 }

--- a/src/event/js/event-facade-dom-touch.js
+++ b/src/event/js/event-facade-dom-touch.js
@@ -31,10 +31,10 @@ Y.DOMEventFacade.prototype._touch = function(e, currentTarget, wrapper) {
 
     var i,l, etCached, et,touchCache;
 
-    Y.log("Calling facade._touch() with e = " + e, "info", "event-touch");
+    Y.log("Calling facade._touch() with e = " + e, "debug", "event-touch");
 
     if (e.touches) {
-        Y.log("Found e.touches. Replicating on facade");
+        Y.log("Found e.touches. Replicating on facade", "info", "event-touch");
 
         /**
          * Array of individual touch events for touch points that are still in


### PR DESCRIPTION
This reduces the category of some noisy log events, adds a category to
those missing one, and removes a number of commented-out calls.

Hopefully this will make it easier to develop on a page which has drag and drop enabled.

I considered decreasing the other Y.log calls from info to debug, but from a cursory glance they look like things you'd want to know about whereas the "Calling facade._touch" event appears on any page with dd enabled when you move your mouse.
