### PR TITLE
[dom] Normalize setting a node value to null

### DIFF
--- a/src/dom/HISTORY.md
+++ b/src/dom/HISTORY.md
@@ -4,8 +4,10 @@ DOM Change History
 @VERSION@
 ------
 
+* [#1603][]: Set a node value to an empty string setting to null. [Ryuichi Okumura]
 * [#1469][]: Fix a bug with setStyle() cannot set an opacity to 1. [Ryuichi Okumura]
 
+[#1603]: https://github.com/yui/yui3/issues/1603
 [#1469]: https://github.com/yui/yui3/issues/1469
 
 3.14.1

--- a/src/dom/js/dom-attrs.js
+++ b/src/dom/js/dom-attrs.js
@@ -130,7 +130,7 @@ Y.mix(Y_DOM, {
 
         if (node && node[TAG_NAME]) {
             setter = Y_DOM.VALUE_SETTERS[node[TAG_NAME].toLowerCase()];
-
+            val = (val === null) ? '' : val;
             if (setter) {
                 setter(node, val);
             } else {

--- a/src/dom/tests/unit/assets/dom-core-test.js
+++ b/src/dom/tests/unit/assets/dom-core-test.js
@@ -1418,6 +1418,16 @@ YUI.add('dom-core-test', function(Y) {
             node.removeAttribute('value')
         },
 
+        'value updated from null should be empty string': function() {
+            var node = document.getElementById('test-text-no-value'),
+                val = null;
+
+            Y.DOM.setValue(node, val);
+            Assert.areEqual('', Y.DOM.getValue(node));
+            Y.DOM.setValue(node, '');
+            node.removeAttribute('value');
+        },
+
         'textarea from html value should match new value': function() {
             var node = document.getElementById('test-textarea-text-value'),
                 val = 'new textarea test';
@@ -1433,6 +1443,15 @@ YUI.add('dom-core-test', function(Y) {
 
             Y.DOM.setValue(node, val);
             Assert.areEqual(val, Y.DOM.getValue(node));
+            Y.DOM.setValue('');
+        },
+
+        'textarea from null should be empty string': function() {
+            var node = document.getElementById('test-textarea-no-value'),
+                val = null;
+
+            Y.DOM.setValue(node, val);
+            Assert.areEqual('', Y.DOM.getValue(node));
             Y.DOM.setValue('');
         },
 
@@ -1462,6 +1481,16 @@ YUI.add('dom-core-test', function(Y) {
             Assert.areEqual(val, Y.DOM.getValue(node));
             Y.DOM.setValue(node, '');
             node.removeAttribute('value')
+        },
+
+        'button value updated from null should be empty string': function() {
+            var node = document.getElementById('test-button-no-value'),
+                val = null;
+
+            Y.DOM.setValue(node, val);
+            Assert.areEqual('', Y.DOM.getValue(node));
+            Y.DOM.setValue(node, '');
+            node.removeAttribute('value');
         },
 
         'option value should match updated value': function() {
@@ -1499,6 +1528,16 @@ YUI.add('dom-core-test', function(Y) {
             Assert.areEqual(val, Y.DOM.getValue(node));
             Y.DOM.setValue(node, '');
             node.removeAttribute('value')
+        },
+
+        'option value updated from null should be null': function() {
+            var node = document.getElementById('test-option-no-value'),
+                val = null;
+
+            Y.DOM.setValue(node, val);
+            Assert.areEqual('', Y.DOM.getValue(node));
+            Y.DOM.setValue(node, '');
+            node.removeAttribute('value');
         }
     }));
 


### PR DESCRIPTION
When set a node value to `null`, then a node value returns `"null"` as string on the legacy IE (IE <= 9). A node value returns an empty string on the modern browsers (Chrome, Firefox, IE >= 10). This change is to normalize the results of setting a node value to `null` on any browsers. Fix #1603.

Tested with IE6, IE7, IE8, IE9, IE10, IE11, Chrome, Firefox, Safari 7(OS X), Safari 7(iOS).
