### PR TITLE
[History] : Remove `history-hash-ie`  from roll up.

### DIFF
--- a/src/history/meta/history.json
+++ b/src/history/meta/history.json
@@ -1,7 +1,7 @@
 {
     "history": {
         "use": [
-            "history-base", "history-hash", "history-hash-ie", "history-html5"
+            "history-base", "history-hash", "history-html5"
         ],
 
         "plugins": {


### PR DESCRIPTION
This caused `history-hash-ie` to load on non-IE browsers. It's okay to remove this, as `history-hash-ie` will conditionally load when `history-hash` is requested.

Here's a test of this fix in action: http://jsbin.com/xeci/4

@ericf @rgrove @clarle
