### PR TITLE
[core] Fix coverage tests

### DIFF
--- a/src/yui/tests/unit/coverage.html
+++ b/src/yui/tests/unit/coverage.html
@@ -19,9 +19,16 @@ var YUI = {};
 </script>
 <!-- This is the main test file, notice it's using the `yui-base` seed file
 without Loader on the page, so Loader is fetched before tests are executed. -->
-<script type="text/javascript" src="../../../../build/yui-base/yui-base-coverage.js"></script>
+<script type="text/javascript" src="../../../../build/yui-core/yui-core-coverage.js"></script>
+<script type="text/javascript" src="../../../../build/get/get.js"></script>
+<script type="text/javascript" src="../../../../build/features/features-coverage.js"></script>
+<script type="text/javascript" src="../../../../build/intl-base/intl-base-coverage.js"></script>
+<script type="text/javascript" src="../../../../build/yui-log/yui-log-coverage.js"></script>
+<script type="text/javascript" src="../../../../build/yui-later/yui-later-coverage.js"></script>
+<script type="text/javascript" src="../../../../build/loader/loader.js"></script>
 
 <script type="text/javascript">
+YUI.add('yui', function (Y, NAME) {}, '@VERSION@', {"use": ["get", "features", "intl-base", "yui-log", "yui-later"]});
 
 YUI.GlobalConfig = {
     globalConfig: true,


### PR DESCRIPTION
The original coverage tests used yui-core-coverage and loaded the rest of yui-base by inserting script tags. This seems to have been set up that way to get more granular coverage information than just one entry for yui-base, but it is causing YUI.add to fail in certain cases because Loader is not yet available. This changes the coverage test to do the same as the regular unit tests.

@reid @caridy does this make sense to you? Is there anything you can think of that we wouldn't be testing by making this change?
