### PR TITLE
Fix for #1623, missing `indexOf` error in Loader

### DIFF
--- a/src/loader/js/loader.js
+++ b/src/loader/js/loader.js
@@ -1882,7 +1882,7 @@ Y.Loader.prototype = {
     * @param {String} pname The pattern to match
     */
     _patternTest: function(mname, pname) {
-        return (mname.indexOf(pname) > -1);
+        return (Y.Array.indexOf(mname, pname) > -1);
     },
     /**
     * Get's the loader meta data for the requested module


### PR DESCRIPTION
`Array.prototype.indexOf` doesn't exist in oldIE - this replaces it with the shim in `Y.Array.indexOf`.
