### PR TITLE
Y.WidgetModality causes page jumps

### DIFF
--- a/src/widget-modality/js/Widget-Modality.js
+++ b/src/widget-modality/js/Widget-Modality.js
@@ -10,6 +10,7 @@ var WIDGET       = 'widget',
     SYNC_UI      = 'syncUI',
     BOUNDING_BOX = 'boundingBox',
     CONTENT_BOX  = 'contentBox',
+    RENDERED     = 'rendered',
     VISIBLE      = 'visible',
     Z_INDEX      = 'zIndex',
     CHANGE       = 'Change',
@@ -332,7 +333,9 @@ var WIDGET       = 'widget',
                 if (isModal) {
                     maskNode.show();
                     Y.later(1, this, '_attachUIHandlesModal');
-                    this._focus();
+                    if (this.get(RENDERED)) {
+                        this._focus();
+                    }
                 }
 
 


### PR DESCRIPTION
It seems that when you create a new Panel which is:
- modal; and
- rendered

then the window position jumps to the top of the document.

The default setting for visible is true.
Specifying a visible value of false, and calling show() separately after the dialogue has rendered works around this issue.

This seems to stem from this line of [Widget Modality](https://github.com/yui/yui3/blob/master/src/widget-modality/js/Widget-Modality.js#L335).

As I understand it, the visible parameter is defaulted to true but the widget isn't yet actually visible. As a result, when the focus call is made, and the dialogue isn't yet visible, the browser jumps to the top of the document

I think that this stems from how, while there is a difference between the 'render' and 'rendered' attributes, there is no comparison for 'visible'.

'visible' sometimes records the desired state, and at other times it records the current state.

Example of breakage at http://sandpit.andrewrn.co.uk/yui-broken-panel.html
