### PR TITLE
Remove coverage files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 src
 sandbox
 !build
+*-coverage.js


### PR DESCRIPTION
Removing the *-coverage.js files from the build reduced the package size from 33mb to 17mb. I'm unaware of whether the coverage files are used in production for YUI loaders filter option or just for code coverage purposes. If the latter, given tests are already removed, seems that coverage files should be removed as well.

For the results, I ran `npm pack` with and without the changes. Then expanded the files and ran `du` to check the size:

```
// before the change
orig.tgz is 5.2mb
$ tar -xf orig.tgz
$ du -h -d 1 orig
 34M    orig

// after removing coverage files
minus-coverage.tgz 2.7mb
$ tar -xf minus-coverage.tgz
$ du -h -d 1 minus-coverage
 17M    minus-coverage
```
