### PR TITLE
[dom] Move color-base out of dom-style

### DIFF
--- a/src/dom/meta/dom.json
+++ b/src/dom/meta/dom.json
@@ -55,8 +55,7 @@
             },
             "dom-style": {
                 "requires": [
-                    "dom-base",
-                    "color-base"
+                    "dom-base"
                 ]
             },
             "selector-native": {


### PR DESCRIPTION
This change resolves an oversight in #576. Fix #1621.
