### PR TITLE
Update event-do.js

### DIFF
--- a/src/event-custom/js/event-do.js
+++ b/src/event-custom/js/event-do.js
@@ -1,4 +1,3 @@
-
 /**
  * Custom event engine, DOM event listener abstraction layer, synthetic DOM
  * events.
@@ -56,7 +55,7 @@ DO = {
      * @param c The execution context for fn
      * @param arg* {mixed} 0..n additional arguments to supply to the subscriber
      * when the event fires.
-     * @return {string} handle for the subscription
+     * @return {EventHandle} handle for the subscription
      * @static
      */
     before: function(fn, obj, sFn, c) {
@@ -94,7 +93,7 @@ DO = {
      * @param sFn {string} the name of the method to displace
      * @param c The execution context for fn
      * @param arg* {mixed} 0..n additional arguments to supply to the subscriber
-     * @return {string} handle for the subscription
+     * @return {EventHandle} handle for the subscription
      * @static
      */
     after: function(fn, obj, sFn, c) {
@@ -117,7 +116,7 @@ DO = {
      * @param obj the object hosting the method to displace
      * @param sFn {string} the name of the method to displace
      * @param c The execution context for fn
-     * @return {string} handle for the subscription
+     * @return {EventHandle} handle for the subscription
      * @private
      * @static
      */
@@ -155,7 +154,7 @@ DO = {
      * Detach a before or after subscription.
      *
      * @method detach
-     * @param handle {string} the subscription handle
+     * @param handle {EventHandle} the subscription handle
      * @static
      */
     detach: function(handle) {


### PR DESCRIPTION
Fix the API docs for Y.Do.after, Y.Do.before, Y.Do.detach, and Y.Do._inject to show that event handles are instances of Y.EventHandle and not String.
