### PR TITLE
Add Router#use and a router-wide middleware stack

### DIFF
--- a/build/router/router.js
+++ b/build/router/router.js
@@ -183,14 +183,23 @@ Y.Router = Y.extend(Router, Y.Base, {
     @protected
     **/
 
+    /**
+    Collection of registered router middleware.
+
+    @property _middleware
+    @type Array
+    @protected
+    **/
+
     // -- Lifecycle Methods ----------------------------------------------------
     initializer: function (config) {
         var self = this;
 
-        self._html5  = self.get('html5');
-        self._params = {};
-        self._routes = [];
-        self._url    = self._getURL();
+        self._html5      = self.get('html5');
+        self._params     = {};
+        self._routes     = [];
+        self._middleware = [];
+        self._url        = self._getURL();
 
         // Necessary because setters don't run on init.
         self._setRoutes(config && config.routes ? config.routes :
@@ -676,6 +685,19 @@ Y.Router = Y.extend(Router, Y.Base, {
     },
 
     /**
+    Appends a new callback function to this router's middleware stack. Router 
+    middleware will be run before route-specific middleware.
+    
+    @method use
+    @param {Function} [callback] The callback to append to the middleware stack.
+    @chainable
+    **/
+    use: function (callback) {
+      this._middleware.push(callback);
+      return this;
+    },
+
+    /**
     Saves a new browser history entry and dispatches to the first matching route
     handler, if any.
 
@@ -843,7 +865,7 @@ Y.Router = Y.extend(Router, Y.Base, {
             } else if ((route = routes.shift())) {
                 // Make a copy of this route's `callbacks` so the original array
                 // is preserved.
-                callbacks = route.callbacks.concat();
+                callbacks = self._middleware.concat(route.callbacks.concat());
 
                 // Decode each of the path matches so that the any URL-encoded
                 // path segments are decoded in the `req.params` object.

--- a/src/app/tests/unit/assets/router-test.js
+++ b/src/app/tests/unit/assets/router-test.js
@@ -1219,6 +1219,51 @@ routerSuite.add(new Y.Test.Case({
         Assert.areSame(1, calls);
     },
 
+    'router middleware can be added to all routes': function () {
+      var calls  = [],
+          router = this.router = new Y.Router();
+
+      router.use(function(req, res, next) {
+        calls.push('middleware');
+        next();
+      });
+
+      router.route('/foo', function (req, res, next) {
+        calls.push('route');
+      });
+
+      router._dispatch({path: '/foo'}, {});
+
+      ArrayAssert.itemsAreSame(['middleware', 'route'], calls);
+    },
+
+    'router middleware is run before route middleware': function () {
+      var calls  = [],
+          router = this.router = new Y.Router();
+
+      router.use(function(req, res, next) {
+        calls.push('router middleware');
+        next();
+      });
+
+      function middleware(req, res, next) {
+        calls.push('route middleware');
+        next();
+      }
+
+      router.route('/foo', middleware, function (req, res, next) {
+        calls.push('route');
+      });
+
+      router._dispatch({path: '/foo'}, {});
+
+      ArrayAssert.itemsAreSame([
+        'router middleware',
+        'route middleware',
+        'route'
+      ], calls);
+    },
+
     'request object should contain captured route parameters': function () {
         var calls  = 0,
             router = this.router = new Y.Router();


### PR DESCRIPTION
In addition to the route-specific middleware functionality already available in the Router module, I would like to be able to add middleware to a stack that applies to _all_ routes. This patch introduces the `use` method on Router, which mimics the express API for adding middleware.
