### PR TITLE
Ignore .idea directory on Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ CVS/
 .DS_Store
 .*.swp
 .svn
+.idea
 *~
 src/build.log
 .com.apple.timemachine.supported


### PR DESCRIPTION
I started using [WebStorm](http://www.jetbrains.com/webstorm/) to write JavaScript recently.

WebStorm automatically creates a `.idea` directory in the root of the repository. Actually this directory is unnecessary on VCS.
