### PR TITLE
Fix for tables in print preview for IE11

### DIFF
--- a/src/datatable/js/table.js
+++ b/src/datatable/js/table.js
@@ -32,20 +32,20 @@ Y.namespace('DataTable').TableView = Y.Base.create('table', Y.View, [], {
 
     @property CAPTION_TEMPLATE
     @type {String}
-    @default '<caption class="{className}"/>'
+    @default '<caption class="{className}"></caption>'
     @since 3.6.0
     **/
-    CAPTION_TEMPLATE: '<caption class="{className}"/>',
+    CAPTION_TEMPLATE: '<caption class="{className}"></caption>',
 
     /**
     The HTML template used to create the table Node.
 
     @property TABLE_TEMPLATE
     @type {String}
-    @default '<table cellspacing="0" class="{className}"/>'
+    @default '<table cellspacing="0" class="{className}"></table>'
     @since 3.6.0
     **/
-    TABLE_TEMPLATE  : '<table cellspacing="0" class="{className}"/>',
+    TABLE_TEMPLATE  : '<table cellspacing="0" class="{className}"></table>',
 
     /**
     The object or instance of the class assigned to `bodyView` that is


### PR DESCRIPTION
When YUI datatables are rendered in the page the closing tags are not
present for tables and captions. This renders the UI incorrectly in
print preview for IE11.
This is a fix for the above issue.
