### PR TITLE
[dom] Move out of color-base module

### DIFF
--- a/src/anim/meta/anim.json
+++ b/src/anim/meta/anim.json
@@ -14,7 +14,8 @@
             "anim-base": {
                 "requires": [
                     "base-base",
-                    "node-style"
+                    "node-style",
+                    "color-base"
                 ]
             },
             "anim-color": {

--- a/src/charts/tests/unit/assets/axes-display-tests.js
+++ b/src/charts/tests/unit/assets/axes-display-tests.js
@@ -1529,4 +1529,4 @@ YUI.add('axes-display-tests', function(Y) {
     suite.add(RightAndTopAxisCustomTickAndLinesNoneTicks);
     
     Y.Test.Runner.add(suite);
-}, '@VERSION@' ,{requires:['charts', 'test']});
+}, '@VERSION@' ,{requires:['charts', 'color-base', 'test']});

--- a/src/charts/tests/unit/assets/combo-tooltip-tests.js
+++ b/src/charts/tests/unit/assets/combo-tooltip-tests.js
@@ -359,4 +359,4 @@ YUI.add('combo-tooltip-tests', function(Y) {
     suite.add(getTooltipTest("combo", null, styledTooltip, null, false));
 
     Y.Test.Runner.add(suite);
-}, '@VERSION@' ,{requires:['charts', 'test']});
+}, '@VERSION@' ,{requires:['charts', 'color-base', 'test']});

--- a/src/dom/js/dom-style.js
+++ b/src/dom/js/dom-style.js
@@ -29,7 +29,6 @@ var DOCUMENT_ELEMENT = 'documentElement',
         'msTransform'
     ],
 
-    re_color = /color$/i,
     re_unit = /width|height|top|left|right|bottom|margin|padding/i;
 
 Y.Array.each(VENDOR_TRANSFORM, function(val) {
@@ -149,21 +148,6 @@ if (DOCUMENT[DOCUMENT_ELEMENT][STYLE][CSS_FLOAT] !== undefined) {
     Y_DOM.CUSTOM_STYLES[FLOAT] = CSS_FLOAT;
 } else if (DOCUMENT[DOCUMENT_ELEMENT][STYLE][STYLE_FLOAT] !== undefined) {
     Y_DOM.CUSTOM_STYLES[FLOAT] = STYLE_FLOAT;
-}
-
-// fix opera computedStyle default color unit (convert to rgb)
-if (Y.UA.opera) {
-    Y_DOM[GET_COMPUTED_STYLE] = function(node, att) {
-        var view = node[OWNER_DOCUMENT][DEFAULT_VIEW],
-            val = view[GET_COMPUTED_STYLE](node, '')[att];
-
-        if (re_color.test(att)) {
-            val = Y.Color.toRGB(val);
-        }
-
-        return val;
-    };
-
 }
 
 // safari converts transparent to rgba(), others use "transparent"

--- a/src/dom/meta/dom.json
+++ b/src/dom/meta/dom.json
@@ -17,7 +17,8 @@
             },
             "dom-style-ie": {
                 "requires": [
-                    "dom-style"
+                    "dom-style",
+                    "color-base"
                 ],
                 "condition": {
                    "trigger": "dom-style",
@@ -55,8 +56,7 @@
             },
             "dom-style": {
                 "requires": [
-                    "dom-base",
-                    "color-base"
+                    "dom-base"
                 ]
             },
             "selector-native": {

--- a/src/dom/tests/unit/dom.html
+++ b/src/dom/tests/unit/dom.html
@@ -772,49 +772,6 @@ form {
                 Assert.areEqual(node.selectedIndex, 1);
             },
 
-            testToHex: function() {
-                var rgb = 'rgb(97, 11, 11)',
-                    hex = Y.Color.toHex(rgb);
-
-                Assert.areEqual("#610B0B", hex.toUpperCase(), 'toHex(' + rgb + ')');
-
-                rgb = 'rgb(255, 255, 255)';
-                hex = Y.Color.toHex(rgb);
-
-                Assert.areEqual("#FFFFFF", hex.toUpperCase(), 'toHex(' + rgb + ')');
-
-                rgb = '#fff';
-                hex = Y.Color.toHex(rgb);
-
-                Assert.areEqual("#FFFFFF", hex.toUpperCase(), 'toHex(' + rgb + ')');
-
-                rgb = 'fff';
-                hex = Y.Color.toHex(rgb);
-
-                Assert.areEqual("#FFFFFF", hex.toUpperCase(), 'toHex(' + rgb + ')');
-
-                rgb = '000';
-                hex = Y.Color.toHex(rgb);
-
-                Assert.areEqual("#000000", hex.toUpperCase(), 'toHex(' + rgb + ')');
-
-                rgb = "rgb(97, 56, 11)" ;
-                hex = Y.Color.toHex(rgb);
-                Assert.areSame(hex.toUpperCase(), "#61380B", " shoudl be #61380B");
-
-                rgb = "rgb(11, 97, 11)" ; // 0B610B
-                hex = Y.Color.toHex(rgb);
-                Assert.areSame(hex.toUpperCase(), "#0B610B", " shoudl be #0B610B");
-
-                rgb = "rgb(56, 11, 97)" ; //380B61
-                hex = Y.Color.toHex(rgb);
-                Assert.areSame(hex.toUpperCase(), "#380B61", " shoudl be #380B61");
-
-                rgb = "rgb(97, 11, 56)" ; //610B38
-                hex = Y.Color.toHex(rgb);
-                Assert.areSame(hex.toUpperCase(), "#610B38", " shoudl be #610B38");
-            },
-
             test_inDoc: function() {
                 var node = document.createElement('div');
                 Assert.isFalse(Y.DOM.inDoc(node), 'new off doc');

--- a/src/graphics/meta/graphics.json
+++ b/src/graphics/meta/graphics.json
@@ -16,7 +16,7 @@
                 }
             },
             "graphics-canvas": {
-                "requires": ["graphics"],
+                "requires": ["graphics", "color-base"],
                 "condition": {
                     "trigger": "graphics",
                     "test": "graphics-canvas.js"
@@ -29,7 +29,7 @@
                 }
             },
             "graphics-vml": {
-                "requires": ["graphics"],
+                "requires": ["graphics", "color-base"],
                 "condition": {
                     "trigger": "graphics",
                     "test": "graphics-vml.js"

--- a/src/graphics/tests/unit/assets/graphics-tests.js
+++ b/src/graphics/tests/unit/assets/graphics-tests.js
@@ -1366,4 +1366,4 @@ suite.add(transformTests);
 
 Y.Test.Runner.add( suite );
 
-}, '@VERSION@' ,{requires:['graphics', 'test']});
+}, '@VERSION@' ,{requires:['graphics', 'color-base', 'test']});


### PR DESCRIPTION
Currently, the `dom-style` module depends on `color-base` module only for falling back to calculate computed style on legacy Opera (<= 12), but the latest Opera (15+) is almost the same Chrome (`Y.UA.webkit` returns truth actually). Many core modules are depending the `dom-style` module, I expect that many YUI modules and applications will benefit to faster from more than a little by this change. I also hope that this resolves #1621.

I'd like to push this into the `dev-3.x` branch because this changes are across some module's dependencies. And I will rebuild `anim`, `dom`, `loader`, `graphics` modules and update the `HISTORY.md` for `dom` module when this has been merged.

Note: The `dom-style-ie` module will still depends on the `color-base` module for the legacy IE (<= 8.0).
