### PR TITLE
[experimental][discussion] introducing `baseBase` setting to support `base` inheritance for groups

### DIFF
--- a/src/loader/js/loader.js
+++ b/src/loader/js/loader.js
@@ -964,11 +964,17 @@ Y.Loader.prototype = {
      */
     addGroup: function(o, name) {
         var mods = o.modules,
-            self = this, i, v;
+            self = this,
+            baseBase = o.baseBase || Y.config.baseBase,
+            i, v;
 
         name = name || o.name;
         o.name = name;
         self.groups[name] = o;
+
+        if (!o.base && baseBase && o.root) {
+            o.base = baseBase + o.root;
+        }
 
         if (o.patterns) {
             for (i in o.patterns) {

--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -349,7 +349,7 @@ proto = {
                 mods: {}, // flat module map
                 versions: {}, // version module map
                 base: BASE,
-                cdn: BASE + VERSION + '/build/',
+                cdn: BASE + VERSION + '/',
                 // bootstrapped: false,
                 _idx: 0,
                 _used: {},
@@ -496,8 +496,8 @@ proto = {
 
         Y.config.lang = Y.config.lang || 'en-US';
 
-        Y.config.base = (YUI.config.baseBase && YUI.config.root ?
-                YUI.config.baseBase + YUI.config.root : YUI.config.base) ||
+        Y.config.base = YUI.config.base ||
+                (YUI.config.baseBase && YUI.config.root && YUI.config.baseBase + YUI.config.root) ||
                 Y.Env.getBase(Y.Env._BASE_RE);
 
         if (!filter || (!('mindebug').indexOf(filter))) {


### PR DESCRIPTION
With the upcoming SPDY support, we will have more and more applications using `combine: false` (combo is an anti-pattern when serving assets using SPDY), also, we will see some benefits when serving all assets from the same domain (yes, domain sharding is also an anti-pattern when using SPDY). In an effort to consolidate the inheritance of configurations from groups from the master settings to minimize the amount of settings to define per group, we are proposing to have a new configuration option called `baseBase`.

`baseBase` works similar to `comboBase`, which has to be completed with the `root` value to form the path to a module. If `baseBase` is specified at the top level, along with `comboBase`, and `root` is defined at the top level and per group, then it will be simpler to infer the `base` value per group based on the global `baseBase`.

The ideal configuration will be:

```
YUI({
      baseBase: 'http://mycdn.com/path/to/',
      comboBase: 'http://mycdn.com/path/to/combo?',
      root: 'yui-3.1.5.0/',
      groups: {
           foo: {
               root: 'bar/'
           },
           bar: {
                root: 'foo/'
           }
      }
})
```

In the example above, whether we use use combine or not, the `base` does not have to be defined, because it can be computed based on `baseBase` and the corresponding `root` value.

Few more thoughts:
- `base` is king. If it is set, it will not be combined, so this change is BC.
- `baseBase` CANNOT be infer from parsing the seed url, it always have to be defined manually (BC too).

Open questions:
- [ ] should `combine` be inherited/computed as well?
