### PR TITLE
Fix issues with calendarnavigation month :hover and disabled styles

### DIFF
--- a/src/calendar/assets/calendarnavigator/skins/night/calendarnavigator-skin.css
+++ b/src/calendar/assets/calendarnavigator/skins/night/calendarnavigator-skin.css
@@ -16,37 +16,61 @@
   _filter: chroma(color=black);
 }
 
-.yui3-skin-night .yui3-calendarnav-prevmonth:hover, .yui3-skin-night .yui3-calendarnav-nextmonth:hover {
-  color: #0066CC;
+.yui3-skin-night .yui3-calendarnav-prevmonth:hover,
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-nextmonth:hover,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-nextmonth:hover {
+    border-right-color: #0066CC;
 }
 
-.yui3-skin-night .yui3-calendarnav-month-disabled, .yui3-skin-night .yui3-calendarnav-month-disabled:hover {
-  cursor: default;
-  color: #CCCCCC;
+.yui3-skin-night .yui3-calendarnav-nextmonth:hover,
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-prevmonth:hover,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-prevmonth:hover {
+    border-left-color: #0066CC;
 }
 
-.yui3-skin-night .yui3-calendarnav-prevmonth, .yui3-skin-night .yui3-calendarnav-prevmonth:hover {
-  border-right-color: #FFFFFF;
-  left: 0;
-  margin-left: -10px;
+.yui3-skin-night .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-night .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled:hover,
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled,
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled:hover,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled:hover {
+    cursor: default;
+    border-right-color: #CCCCCC;
+    border-left-color: transparent;
+}
+.yui3-skin-night .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-night .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled:hover,
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled,
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled:hover,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled:hover {
+    cursor: default;
+    border-left-color: #CCCCCC;
+    border-right-color: transparent;
 }
 
-.yui3-skin-night .yui3-calendarnav-nextmonth, .yui3-skin-night .yui3-calendarnav-nextmonth:hover {
-  border-left-color: #FFFFFF;
-  right: 0;
-  margin-right: -10px;
+.yui3-skin-night .yui3-calendarnav-prevmonth {
+    border-right-color: #FFFFFF;
+    left: 0;
+    margin-left: -10px;
 }
 
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth,
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth:hover, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth:hover {
+.yui3-skin-night .yui3-calendarnav-nextmonth {
+    border-left-color: #FFFFFF;
+    right: 0;
+    margin-right: -10px;
+}
+
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-prevmonth,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-prevmonth {
     left: auto;
     right: 0;
     border-left-color: #FFFFFF;
     border-right-color: transparent;
 }
 
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth,
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth:hover, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth:hover {
+[dir="rtl"] .yui3-skin-night .yui3-calendarnav-nextmonth,
+.yui3-skin-night [dir="rtl"] .yui3-calendarnav-nextmonth {
     left: 0;
     right: auto;
     border-right-color: #FFFFFF;

--- a/src/calendar/assets/calendarnavigator/skins/sam/calendarnavigator-skin.css
+++ b/src/calendar/assets/calendarnavigator/skins/sam/calendarnavigator-skin.css
@@ -16,37 +16,61 @@
   _filter: chroma(color=white);
 }
 
-.yui3-skin-sam .yui3-calendarnav-prevmonth:hover, .yui3-skin-sam .yui3-calendarnav-nextmonth:hover {
-  color: #0066CC;
+.yui3-skin-sam .yui3-calendarnav-prevmonth:hover,
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth:hover,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth:hover {
+    border-right-color: #0066CC;
 }
 
-.yui3-skin-sam .yui3-calendarnav-month-disabled, .yui3-skin-sam .yui3-calendarnav-month-disabled:hover {
-  cursor: default;
-  color: #CCCCCC;
+.yui3-skin-sam .yui3-calendarnav-nextmonth:hover,
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth:hover,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth:hover {
+    border-left-color: #0066CC;
 }
 
-.yui3-skin-sam .yui3-calendarnav-prevmonth, .yui3-skin-sam .yui3-calendarnav-prevmonth:hover {
-  border-right-color: #000000;
-  left: 0;
-  margin-left: -10px;
+.yui3-skin-sam .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-sam .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled:hover,
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled,
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled:hover,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled:hover {
+    cursor: default;
+    border-right-color: #CCCCCC;
+    border-left-color: transparent;
+}
+.yui3-skin-sam .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-sam .yui3-calendarnav-nextmonth.yui3-calendarnav-month-disabled:hover,
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled,
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled:hover,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth.yui3-calendarnav-month-disabled:hover {
+    cursor: default;
+    border-left-color: #CCCCCC;
+    border-right-color: transparent;
 }
 
-.yui3-skin-sam .yui3-calendarnav-nextmonth, .yui3-skin-sam .yui3-calendarnav-nextmonth:hover {
-  border-left-color: #000000;
-  right: 0;
-  margin-right: -10px;
+.yui3-skin-sam .yui3-calendarnav-prevmonth {
+    border-right-color: #000000;
+    left: 0;
+    margin-left: -10px;
 }
 
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth,
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth:hover, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth:hover {
+.yui3-skin-sam .yui3-calendarnav-nextmonth {
+    border-left-color: #000000;
+    right: 0;
+    margin-right: -10px;
+}
+
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-prevmonth,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-prevmonth {
     left: auto;
     right: 0;
     border-left-color: #000000;
     border-right-color: transparent;
 }
 
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth,
-[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth:hover, .yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth:hover {
+[dir="rtl"] .yui3-skin-sam .yui3-calendarnav-nextmonth,
+.yui3-skin-sam [dir="rtl"] .yui3-calendarnav-nextmonth {
     left: 0;
     right: auto;
     border-right-color: #000000;


### PR DESCRIPTION
I noticed while testing #1719 that the :hover and disabled states were broken and no longer showing any difference.

I've fixed those, and also applied the changes to RTL.
