### PR TITLE
fix flaky yql cli test

### DIFF
--- a/src/yql/tests/unit/assets/yql-tests.js
+++ b/src/yql/tests/unit/assets/yql-tests.js
@@ -12,7 +12,9 @@ YUI.add('yql-tests', function(Y) {
     if (Y.UA.winjs || Y.UA.nodejs) {
         //Auto set live when in WinJS and Node (for testing)
         live = true;
+    }
 
+    if (Y.UA.nodejs) {
         // Bypass SSL cert validation
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
     }


### PR DESCRIPTION
The https CLI test was throwing a UNABLE_TO_VERIFY_LEAF_SIGNATURE error roughly 50% of the time. I'm not sure exactly what was failing, but there's no need to introduce an SSL verification dependency in this test. This PR should stabilize this test by disabling the ssl cert validation in node.

Fixes #1739 
