### PR TITLE
Fix for default log category breaks YUI Test

### DIFF
--- a/src/yui/js/yui-log.js
+++ b/src/yui/js/yui-log.js
@@ -55,12 +55,6 @@ INSTANCE.log = function(msg, cat, src, silent) {
                 bail = excl[src];
             }
 
-            // Set a default category of info if the category was not defined or was not
-            // a real category.
-            if ((typeof cat === 'undefined') || !(cat in LEVELS)) {
-                cat = 'info';
-            }
-
             // Determine the current minlevel as defined in configuration
             Y.config.logLevel = Y.config.logLevel || 'debug';
             minlevel = LEVELS[Y.config.logLevel.toLowerCase()];

--- a/src/yui/tests/unit/assets/core-tests.js
+++ b/src/yui/tests/unit/assets/core-tests.js
@@ -54,7 +54,6 @@ YUI.add('core-tests', function(Y) {
                 'getLocation() should return the location object': (Y.UA.nodejs ? true : false),
                 'getLocation() should return `null` when executing in node.js': (!Y.UA.nodejs || (Y.UA.nodejs && Y.config.win)), //If there is a window object, ignore too
                 test_log_params: (typeof console == "undefined" || !console.info || Y.UA.nodejs),
-                test_log_default_category: (typeof console == "undefined" || !console.info || Y.UA.nodejs),
                 'test: domready delay': !Y.config.win,
                 'test: window.onload delay': !Y.config.win,
                 'test: contentready delay': !Y.config.win,
@@ -439,68 +438,6 @@ YUI.add('core-tests', function(Y) {
                 Y.log('This should NOT be ignored', 'error', 'logleveltest');
                 Assert.areEqual(last, 'logleveltest', 'Failed to include log param');
             });
-
-            console.info = l;
-        },
-        test_log_default_category: function() {
-            if (typeof console == "undefined" || !console.info) {
-                return;
-            }
-            var l = console.info,
-                Assert = Y.Assert,
-                consoleFn,
-                last, lastCategory;
-
-            // Override all of the console functions so that we can check
-            // their return values.
-            consoleFn = function(str) {
-                last = str.split(':')[0];
-            };
-            console.error = function(str) {
-                lastCategory = 'error';
-                consoleFn(str);
-            };
-            console.log = function(str) {
-                lastCategory = 'log';
-                consoleFn(str);
-            };
-            console.warn = function(str) {
-                lastCategory = 'warn';
-                consoleFn(str);
-            };
-            console.debug = function(str) {
-                lastCategory = 'debug';
-                consoleFn(str);
-            };
-            console.info = function(str) {
-                lastCategory = 'info';
-                consoleFn(str);
-            };
-
-            YUI().use(function (Y) {
-                Y.applyConfig({
-                    logLevel: 'debug'
-                });
-                lastCategory = undefined;
-                Y.log('This has a valid log level', 'debug');
-                Assert.areEqual(lastCategory, 'debug', 'Failed to log at debug log category');
-                lastCategory = undefined;
-                Y.log('This has a valid log level', 'info');
-                Assert.areEqual(lastCategory, 'info', 'Failed to log at info log category');
-                lastCategory = undefined;
-                Y.log('This has a valid log level', 'warn');
-                Assert.areEqual(lastCategory, 'warn', 'Failed to log at warn log category');
-                lastCategory = undefined;
-                Y.log('This has a valid log level', 'error');
-                Assert.areEqual(lastCategory, 'error', 'Failed to log at error log category');
-                lastCategory = undefined;
-                Y.log('This has no log level and should use the default');
-                Assert.areEqual(lastCategory, 'info', 'Failed to log at default log category of info');
-                lastCategory = undefined;
-                Y.log('This has an invalid log level and should use the default', 'notice');
-                Assert.areEqual(lastCategory, 'info', 'Failed to log at default info log category');
-            });
-
             console.info = l;
         },
         test_global_apply_config: function() {


### PR DESCRIPTION
From IRC: 

"Example: I've added a Tree test that fails. I run the unit tests (in the browser, grover, or yet), and they report 1 failure. Nowhere in grover or yeti does anything actually tell me _which_ test failed. In the browser, the test console no longer highlights failed tests in the log or allows me to filter the log to show only failures, so I have to scroll through every single passing test to find the one that failed.
s/yet/yeti/" 

"...As far as I can tell, log messages from tests just aren't being logged to the correct log levels anymore. Every single message gets logged as "info", and nothing gets logged as "pass" or "fail" or "status".
Used to be only the final summary was logged as "info", only passing tests were logged as "pass", and failing tests were logged as "fail"."

"Looks like this commit is what broke test logging: https://github.com/yui/yui3/commit/dacc8fe4c3dec46622db8790583c733b206fec35
Log categories are no longer allowed to be arbitrary (which is a feature tests depended on), and must now exist in the hard-coded set of levels in yui-log.js."
