### PR TITLE
Tree: Adopt children properly when moving a node to another tree. Fixes #1689.

### DIFF
--- a/src/tree/HISTORY.md
+++ b/src/tree/HISTORY.md
@@ -4,27 +4,35 @@ Tree Change History
 @VERSION@
 ------
 
-* No changes.
+* Fixed: Moving a node to another tree fails when that node has children.
+  ([#1689][]: @rgrove)
+
+[#1689]: https://github.com/yui/yui3/issues/1689
+
 
 3.15.0
 ------
 
 * No changes.
 
+
 3.14.1
 ------
 
 * No changes.
+
 
 3.14.0
 ------
 
 * No changes.
 
+
 3.13.0
 ------
 
 * No changes.
+
 
 3.12.0
 ------

--- a/src/tree/js/tree.js
+++ b/src/tree/js/tree.js
@@ -682,17 +682,27 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
     @protected
     **/
     _adoptNode: function (node, options) {
-        var oldTree = node.tree;
+        var oldTree = node.tree,
+            child;
 
         if (oldTree === this) {
             return;
         }
 
         for (var i = 0, len = node.children.length; i < len; i++) {
-            this._adoptNode(node.children[i], {silent: true});
+            child = node.children[i];
+
+            child.parent = null; // Prevents the child from being removed from
+                                 // its parent during the adoption.
+
+            this._adoptNode(child, {silent: true});
+            child.parent = node;
         }
 
-        oldTree.removeNode(node, options);
+        if (node.parent) {
+            oldTree.removeNode(node, options);
+        }
+
         delete oldTree._nodeMap[node.id];
 
         // If this node isn't an instance of this tree's composed _nodeClass,
@@ -705,6 +715,8 @@ var Tree = Y.Base.create('tree', Y.Base, [], {
         }
 
         node.tree = this;
+        node._isIndexStale = true;
+
         this._nodeMap[node.id] = node;
     },
 

--- a/src/tree/tests/unit/assets/tree-test.js
+++ b/src/tree/tests/unit/assets/tree-test.js
@@ -489,6 +489,39 @@ treeSuite.add(new Y.Test.Case({
         Assert.areSame(this.tree, node.tree, "node's tree reference should point to the new tree");
     },
 
+    "insertNode() should adopt an entire node hierarchy if it exists in another tree": function () {
+        var otherTree;
+
+        otherTree = new Y.Tree({
+            nodes: [
+                {id: 'node1', label: 'Node 1', children: [
+                    {id: 'node1.1', label: 'Node 1.1'},
+                    {id: 'node1.2', label: 'Node 1.2'}
+                ]},
+                {id: 'node2', label: 'Node 2'}
+            ]
+        });
+
+        var node = otherTree.children[0];
+
+        this.tree.insertNode(this.tree.rootNode, node, {index: 0});
+
+        Assert.areSame(node, this.tree.children[0], 'parent should be in the new tree');
+        Assert.areSame(this.tree, node.tree, "parent's tree reference should point to the new tree");
+        Assert.areSame(this.tree.rootNode, node.parent, 'parent should have the right parent');
+        Assert.areSame(2, node.children.length, 'parent should have two children');
+
+        Assert.areSame('node1.1', node.children[0].id, 'first child should have the right id');
+        Assert.areSame('node1.2', node.children[1].id, 'second child should have the right id');
+        Assert.areSame(node, node.children[0].parent, 'first child should have the right parent');
+        Assert.areSame(node, node.children[1].parent, 'second child should have the right parent');
+        Assert.areSame(this.tree, node.children[0].tree, 'first child should be in the new tree');
+        Assert.areSame(this.tree, node.children[1].tree, 'second child should be in the new tree');
+
+        Assert.areSame(0, node.indexOf(node.children[0]), 'parent index should contain child 0');
+        Assert.areSame(1, node.indexOf(node.children[1]), 'parent index should contain child 1');
+    },
+
     'insertNode() should remove the inserted node from its current parent if necessary': function () {
         var node      = this.tree.children[0],
             newParent = this.tree.children[1];


### PR DESCRIPTION
See #1689 for a description of the issue.
