### PR TITLE
Fix #1731: Y.Calendar.selectDates fails when passed the maximumDate with...

### DIFF
--- a/src/calendar/HISTORY.md
+++ b/src/calendar/HISTORY.md
@@ -4,7 +4,10 @@ Calendar Change History
 @VERSION@
 ------
 
-* No changes.
+* Fix #1731: Y.Calendar.selectDates fails when passed the maximumDate with minutes/seconds ([#1731][])
+
+
+[#1731]: https://github.com/yui/yui3/issues/1731
 
 3.15.0
 ------

--- a/src/calendar/js/calendar-base.js
+++ b/src/calendar/js/calendar-base.js
@@ -409,7 +409,7 @@ Y.CalendarBase = Y.extend( CalendarBase, Y.Widget, {
      * @private
      */
     _addDateToSelection : function (oDate, index) {
-        oDate.setHours(12);
+        oDate = this._normalizeTime(oDate);
 
         if (this._canBeSelected(oDate)) {
 

--- a/src/calendar/tests/unit/assets/calendar-tests.js
+++ b/src/calendar/tests/unit/assets/calendar-tests.js
@@ -247,6 +247,20 @@ YUI.add('calendar-tests', function(Y) {
                 Y.Assert.isTrue(this.firstcalendar._dateToNode(new Date(2011,11,5)).hasClass("yui3-calendar-day-selected"));
             },
 
+            testMaxDatesSelection: function() {
+                var cfg = {
+                    contentBox: "#firstcontainer",
+                    date: new Date(2014,3,1),
+                    maximumDate: new Date (2014,3,3)
+                };
+
+                this.firstcalendar = new Y.Calendar(cfg);
+                this.firstcalendar.render();
+                this.firstcalendar.selectDates(new Date(2014, 3, 3, 14, 10, 10));
+
+                Y.Assert.isTrue(this.firstcalendar._dateToNode(new Date(2014, 3, 3)).hasClass("yui3-calendar-day-selected"));
+            },
+
             testRules : function () {
                 var myRules = {
                    "2011": "fullyear",


### PR DESCRIPTION
... minutes/seconds

Fixing the issue explained in #1731, which causes selectDates to fail when the user passes the maximumDate with minutes or seconds to it. The calendar code is already resetting the hours part of the date's time, but this diff resets everything to make sure that date selection doesn't take the date's time into account anymore.

From what I saw in other existing pull requests it seems like people only send the /src files, so I'm also just sending those here. Let me know if I should send the respective /build files for this change as well though.
