### PR TITLE
YUI - check to see if reference to loader has getModuleInfo before attempting to call the method.

### DIFF
--- a/src/yui/js/yui.js
+++ b/src/yui/js/yui.js
@@ -641,7 +641,7 @@ with any configuration info required for the module.
                 if (!applied[inst.id]) {
                     applied[inst.id] = true;
                     loader = inst.Env._loader;
-                    if (loader) {
+                    if (loader && loader.getModuleInfo) {
                         modInfo = loader.getModuleInfo(name);
                         if (!modInfo || modInfo.temp) {
                             loader.addModule(details, name);


### PR DESCRIPTION
With little context, a potential fix for #1758.
This is just a strawman pull request as there may be a larger underlying issue of which I'm not aware.
