### PR TITLE
dd proxy test fix.

### DIFF
--- a/src/dd/tests/unit/assets/dd-tests.js
+++ b/src/dd/tests/unit/assets/dd-tests.js
@@ -95,7 +95,7 @@ YUI.add('dd-tests', function(Y) {
 
         _should: {
             ignore: {
-                'test: proxy cloneNode with radio inputs': Y.UA.phantomjs
+                'test: proxy cloneNode with radio inputs': Y.UA.phantomjs || (Y.UA.android && Y.UA.android < 4.4)
             }
         },
 


### PR DESCRIPTION
Add android < 4.4 to the ignore bucket for dd-proxy clone node test.

This relates to pr #1666 which addresses #1663. The original fix does not work for lesser versions of android. This is a temporary test fix. (ignore suspect browsers)
