### PR TITLE
Exposing all Promise method docs

### DIFF
--- a/src/promise/js/promise.js
+++ b/src/promise/js/promise.js
@@ -121,7 +121,7 @@ Y.mix(Promise.prototype, {
         });
     },
 
-    /*
+    /**
     A shorthand for `promise.then(undefined, callback)`.
 
     Returns a new promise and the error callback gets the same treatment as in
@@ -133,7 +133,7 @@ Y.mix(Promise.prototype, {
                         rejected
     @return {Promise} A new promise modified by the behavior of the error
                         callback
-    */
+    **/
     'catch': function (errback) {
         return this.then(undefined, errback);
     },
@@ -212,7 +212,7 @@ Promise.isPromise = function (obj) {
     return typeof then === 'function';
 };
 
-/*
+/**
 Ensures that a certain value is a promise. If it is not a promise, it wraps it
 in one.
 
@@ -225,7 +225,7 @@ This means that `PromiseSubclass.resolve()` will always return instances of
 @param {Any} Any object that may or may not be a promise
 @return {Promise}
 @static
-*/
+**/
 Promise.resolve = function (value) {
     return Promise.isPromise(value) && value.constructor === this ? value :
         /*jshint newcap: false */
@@ -235,7 +235,7 @@ Promise.resolve = function (value) {
         });
 };
 
-/*
+/**
 A shorthand for creating a rejected promise.
 
 @method reject
@@ -243,7 +243,7 @@ A shorthand for creating a rejected promise.
     Object
 @return {Promise} A rejected promise
 @static
-*/
+**/
 Promise.reject = function (reason) {
     /*jshint newcap: false */
     return new this(function (resolve, reject) {
@@ -252,7 +252,7 @@ Promise.reject = function (reason) {
     });
 };
 
-/*
+/**
 Returns a promise that is resolved or rejected when all values are resolved or
 any is rejected. This is useful for waiting for the resolution of multiple
 promises, such as reading multiple files in Node.js or making multiple XHR
@@ -262,7 +262,7 @@ requests in the browser.
 @param {Any[]} values An array of any kind of values, promises or not. If a value is not
 @return [Promise] A promise for an array of all the fulfillment values
 @static
-*/
+**/
 Promise.all = function (values) {
     var Promise = this;
     return new Promise(function (resolve, reject) {
@@ -298,7 +298,7 @@ Promise.all = function (values) {
     });
 };
 
-/*
+/**
 Returns a promise that is resolved or rejected when any of values is either
 resolved or rejected. Can be used for providing early feedback in the UI
 while other operations are still pending.
@@ -307,7 +307,7 @@ while other operations are still pending.
 @param {Any[]} values An array of values or promises
 @return {Promise}
 @static
-*/
+**/
 Promise.race = function (values) {
     var Promise = this;
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
The new methods introduced in YUI 3.15 (https://github.com/yui/yui3/wiki/YUI-3.15.0-Change-History-Rollup#promise-change-history) have had documentation since their introduction, but due to not using `/** … **/` comments they weren’t visible to yuidocs and thus they aren't on http://yuilibrary.com/yui/docs/api/classes/Promise.html.

This PR corrects the comment syntax to bring the method information to that page.

/cc @juandopazo
