### PR TITLE
Support for {nested.placeholder} in Lang.sub

### DIFF
--- a/src/yui/js/yui-lang.js
+++ b/src/yui/js/yui-lang.js
@@ -266,8 +266,40 @@ L.now = Date.now || function () {
  * @since 3.2.0
  */
 L.sub = function(s, o) {
+
+    /**
+    Finds the value of `key` in given object.
+    If the key has a 'dot' notation e.g. 'foo.bar.baz', the function will
+    try to resolve this path if it doesn't exist as a property
+    @example
+        value({ 'a.b': 1, a: { b: 2 } }, 'a.b'); // 1
+        value({ a: { b: 2 } }          , 'a.b'); // 2
+    @param {Object} obj A key/value pairs object
+    @param {String} key
+    @return {Any}
+    @private
+    **/
+    function value(obj, key) {
+
+        var subkey;
+
+        if ( typeof obj[key] !== 'undefined' ) {
+            return obj[key];
+        }
+
+        key    = key.split('.');         // given 'a.b.c'
+        subkey = key.slice(1).join('.'); // 'b.c'
+        key    = key[0];                 // 'a'
+
+        // special case for null as typeof returns object and we don't want that.
+        if ( subkey && typeof obj[key] === 'object' && obj[key] !== null ) {
+            return value(obj[key], subkey);
+        }
+    }
+
     return s.replace ? s.replace(SUBREGEX, function (match, key) {
-        return L.isUndefined(o[key]) ? match : o[key];
+        var val = key.indexOf('.')>-1 ? value(o, key) : o[key];
+        return typeof val === 'undefined' ? match : val;
     }) : s;
 };
 

--- a/src/yui/tests/unit/assets/lang-test.js
+++ b/src/yui/tests/unit/assets/lang-test.js
@@ -220,6 +220,28 @@ suite.add(new Y.Test.Case({
     'anything after a pipe inside a placeholder is ignored': function () {
         Assert.areSame('foo', Lang.sub('{foo|moo}'    , { foo: 'foo' }) );
         Assert.areSame('foo', Lang.sub('{ foo | moo }', { foo: 'foo' }) );
+    },
+
+    'should replace nested placeholders': function () {
+        Assert.areSame('123', Lang.sub('{a}{b.c}{d.e.f}', {
+            a: 1,
+            b: { c: 2 },
+            d: { e: { f: 3 } }
+        }));
+    },
+
+    'should resolve nested placeholders at the closest level': function () {
+        Assert.areSame('21', Lang.sub('{c.d.e}{a.b}', {
+            'a.b': 1,
+            'a': { 'b': 'no' },
+            'c': { 'd.e': 2, 'd': { 'e': 'nono'}}
+        }));
+    },
+
+    'if a nested placeholder cannot be resolved, it is left intact': function () {
+        Assert.areSame('{foo.bar.baz}', Lang.sub('{foo.bar.baz}', {}) );
+        Assert.areSame('{foo.bar.baz}', Lang.sub('{foo.bar.baz}', { foo: {} }) );
+        Assert.areSame('{foo.bar.baz}', Lang.sub('{foo.bar.baz}', { foo: { bar: {} } }) );
     }
 }));
 


### PR DESCRIPTION
Hey,

We're producing static html files for our tests that we would like to quickly tokenize with Lang.sub and a global config object:

``` javascript
var config = {
    templates: {
        product_a: {
            text: 'foo'
        },
        product_b: {
            text: 'bar'
        }
        // ...
    }
};
```

``` html
<!-- ... -->
<p>{product_a.text}</p>
<!-- ... -->
<p>{product_b.text}</p>
<!-- ... -->
```

This PR updates `Lang.sub` to support nested placeholders. I've also taken the liberty to refactor a bit the existing unit tests prior to adding my changes.

It seemed to me that this was an obvious feature for `Lang.sub` but in retrospect if you didn't include it there must have been a good reason for it? Anyway, pushing it for your perusal and subsequent approval or destruction with fire :-)

I'm expecting this PR to fail the build and I've got no idea why to be honest:
- Opened tests/unit/lang.html in a browser: OK
- Ran grover tests/unit/lang.html: OK
- yogi serve + open lang.html: OK
- yogi serve + click on grover: FAIL
- yogi test: FAIL

The fact that "native" grover works fine but grover via `yogi serve` doesn't, is a bit odd.

Cheers,
