### PR TITLE
Fix #1816: ScrollViewPaginator partial transition

### DIFF
--- a/src/scrollview/HISTORY.md
+++ b/src/scrollview/HISTORY.md
@@ -4,7 +4,9 @@ ScrollView Change History
 @VERSION@
 ------
 
-* No changes.
+* [#1816][]: ScrollViewPaginator partial transition (@mairatma)
+
+[#1816]: https://github.com/yui/yui3/issues/1816
 
 3.16.0
 ------

--- a/src/scrollview/js/paginator-plugin.js
+++ b/src/scrollview/js/paginator-plugin.js
@@ -349,8 +349,13 @@ Y.extend(PaginatorPlugin, Y.Plugin.Base, {
             canScroll = paginatorAxis[flickAxis],
             rtl = host.rtl;
 
-        // Store the flick data in the this._host._gesture object so it knows this was a flick
         if (gesture) {
+            // The gesture axis is not the flick axis, so do nothing
+            if (gesture.axis !== flickAxis) {
+                return new Y.Do.Prevent();
+            }
+
+            // Store the flick data in the this._host._gesture object so it knows this was a flick
             gesture.flick = flick;
         }
 

--- a/src/scrollview/tests/unit/assets/scrollview-paginator-unit-tests.js
+++ b/src/scrollview/tests/unit/assets/scrollview-paginator-unit-tests.js
@@ -258,6 +258,18 @@ YUI.add('scrollview-paginator-unit-tests', function (Y, NAME) {
             Y.Assert.isInstanceOf(Y.Do.Prevent, response);
         },
 
+        "Flicks on the opposite axis should be prevented": function() {
+            var Test = this,
+                scrollview = this.scrollview,
+                paginator = scrollview.pages,
+                mockEvent = this.mockEvent,
+                response;
+
+            scrollview._gesture = {axis: 'y'};
+            response = paginator._beforeHostFlick(mockEvent);
+            Y.Assert.isInstanceOf(Y.Do.Prevent, response);
+        },
+
         "Flick right should advance the page" : function () {
             var Test = this,
                 scrollview = this.scrollview,
@@ -265,7 +277,7 @@ YUI.add('scrollview-paginator-unit-tests', function (Y, NAME) {
                 mockEvent = this.mockEvent,
                 response;
 
-            scrollview._gesture = true;
+            scrollview._gesture = {axis: 'x'};
 
             response = paginator._beforeHostFlick(mockEvent);
             Y.Assert.areEqual(1, paginator.get('index'));


### PR DESCRIPTION
This is fixing the issue described in #1816, which causes diagonal flicks to change the paginator's index even though the image showing up is not updated.
To fix this I'm just adding one more check to _beforeHostFlick to ignore flicks that don't happen in the specified flick axis. This is the default behavior of scrollview-base, but paginator-plugin prevents it and runs its own code, so we need the check there as well.
