### PR TITLE
Fix #1740: Scrollview scrolltoindex breaks after a click-drag down

### DIFF
--- a/src/scrollview/HISTORY.md
+++ b/src/scrollview/HISTORY.md
@@ -4,7 +4,9 @@ ScrollView Change History
 @VERSION@
 ------
 
-* No changes.
+* [#1740][]: Scrollview scrolltoindex breaks after a click-drag down (@mairatma)
+
+[#1740]: https://github.com/yui/yui3/issues/1740
 
 3.16.0
 ------

--- a/src/scrollview/js/paginator-plugin.js
+++ b/src/scrollview/js/paginator-plugin.js
@@ -226,7 +226,8 @@ Y.extend(PaginatorPlugin, Y.Plugin.Base, {
             pageNodes = paginator._getPageNodes(),
             gestureAxis;
 
-        if (gesture) {
+        // Only look at the last gesture if we're not scrolling to a specific index.
+        if (gesture && !this._scrollingToIndex) {
             gestureAxis = gesture.axis;
 
             // Null the opposite axis so it won't be modified by host.scrollTo
@@ -599,11 +600,19 @@ Y.extend(PaginatorPlugin, Y.Plugin.Base, {
         // Makes sure the viewport nodes are visible
         paginator._showNodes(pageNode);
 
+        // Set the flag to indicate that we're scrolling to a specific index,
+        // so _beforeHostScrollTo will not try to adjust the coordinates according
+        // to the last gesture.
+        paginator._scrollingToIndex = true;
+
         // Scroll to the offset
         host.set(scrollAxis, scrollOffset, {
             duration: duration,
             easing: easing
         });
+
+        // Reset the flag to the original value.
+        paginator._scrollingToIndex = false;
     },
 
     /**

--- a/src/scrollview/tests/unit/assets/scrollview-paginator-unit-tests.js
+++ b/src/scrollview/tests/unit/assets/scrollview-paginator-unit-tests.js
@@ -450,6 +450,15 @@ YUI.add('scrollview-paginator-unit-tests', function (Y, NAME) {
             Y.Assert.isNull(response.newArgs[0]);
         },
 
+        '_beforeHostScrollTo through scrollToIndex should keep original values': function() {
+            var scrollview = this.scrollview = renderNewScrollview('x', 'x');
+
+            scrollview._gesture = { axis: 'y' };
+            Y.Assert.areEqual(0, scrollview.get('scrollX'));
+            scrollview.pages.scrollToIndex(1);
+            Y.Assert.areEqual(300, scrollview.get('scrollX'));
+        },
+
         "Gestures against the grain should select the index page's node to transition" : function () {
             var scrollview = this.scrollview = renderNewScrollview('y', 'y'),
                 paginator = this.scrollview.pages,


### PR DESCRIPTION
I've come across the problem described in #1740 and found out that this is happening because _beforeHostScrollTo is always trying to adjust the scroll coordinates according to the last gesture that was made.
It's possible that the scrolling wasn't caused by a gesture though, like on direct calls to scrollToIndex (the buttons on http://yuilibrary.com/yui/docs/scrollview/scrollview-paging-example.html for example). And if this is done right after a gesture which is not on the scrolling axis, _beforeHostScrollTo will clear the coordinates, which is why the index is being changed but the new image is not being scrolled into view.
I've fixed this by making sure that _beforeHostScrollTo doesn't try using the last gesture to adjust the coordinates for a call to scrollToIndex, since this call will already have the right coordinate anyway.
