### PR TITLE
The group comboBase should inherit from the default if no group setting is specified

### DIFF
--- a/src/loader/HISTORY.md
+++ b/src/loader/HISTORY.md
@@ -4,7 +4,7 @@ YUI Loader Change History
 @VERSION@
 ------
 
-* No changes.
+* Fix a bug in 3.17.1 where there comboBase was no longer inheritted from the default group. ([#1837][]: @andrewnicols)
 
 3.17.1
 ------

--- a/src/loader/js/loader.js
+++ b/src/loader/js/loader.js
@@ -2668,7 +2668,7 @@ Y.log('Undefined module: ' + mname + ', matched a pattern: ' +
                     mod.root = group.root;
                 }
 
-                comboBase    = group.comboBase;
+                comboBase    = group.comboBase || comboBase;
                 comboSep     = group.comboSep;
                 maxURLLength = group.maxURLLength;
             } else {

--- a/src/loader/tests/unit/assets/loader-tests.js
+++ b/src/loader/tests/unit/assets/loader-tests.js
@@ -312,6 +312,28 @@ YUI.add('loader-tests', function(Y) {
             Assert.isTrue(out.js.indexOf('http://secondhost.com/combo?3.5.0/foogg/foogg-min.js') >= 0, 'Group combo URL should be included in the result');
             Assert.isTrue(out.js.indexOf('http://yui.yahooapis.com/combo?3.5.0/cookie/cookie-min.js') >= 0, 'Default YUI combo URL should be included in the result');
         },
+        'test inheritted comboBase with groups': function () {
+            var loader = new testY.Loader({
+                combine: true,
+                groups: {
+                    testGroup: {
+                        combine: true,
+                        modules: {
+                            foogg: {
+                                requires: []
+                            }
+                        }
+                    }
+                },
+                require: ['foogg', 'cookie']
+            });
+            var out = loader.resolve(true);
+            Assert.areSame(1, out.js.length, 'Loader generated multiple URLs for a single comboBase');
+
+            var url = out.js[0];
+            Assert.isArray(url.match(/3.5.0\/foogg\/foogg-min\.js/), 'Group match should be combo-loaded with the default URL');
+            Assert.isArray(url.match(/3.5.0\/cookie\/cookie-min\.js/), 'Default match should combo-load with the group result');
+        },
         test_resolve_maxurl_length: function() {
             var loader = new testY.Loader({
                 maxURLLength: 1024,


### PR DESCRIPTION
This fixes the regression caused by #1832.

The other options (combine, comboSep, maxURLLength) are also affected in a similar way, but these are not a regression introduced in 3.17 so I'll submit those in a separate PR.
