### PR TITLE
Regression 3.16 drag and drop blocks "contenteditable" elements

### DIFF
--- a/src/dd/HISTORY.md
+++ b/src/dd/HISTORY.md
@@ -4,7 +4,7 @@ Drag and Drop Change History
 @VERSION@
 ------
 
-* No changes.
+* [#1831][] Add `[contenteditable]` to the list of invalid drag handles. (Andrew Nicols)
 
 3.17.2
 ------

--- a/src/dd/docs/index.mustache
+++ b/src/dd/docs/index.mustache
@@ -73,7 +73,7 @@ You can also use the `removeHandle` method to remove a previously added handle.
 <p>
 The opposite of handles are Invalid Handles. This is a selector string that will never
 fire a drag event. By default the following HTML elements will not be draggable since adding
-the mouse events to them prohibit their actual use: `textarea, input, a, button, select`
+the mouse events to them prohibit their actual use: `textarea, input, a, button, select, [contenteditable]`
 </p>
 
 <p>If you need to drag one of these items, you will have to call `removeInvalid` on your

--- a/src/dd/js/drag.js
+++ b/src/dd/js/drag.js
@@ -614,12 +614,12 @@
         */
         _invalids: null,
         /**
-        * A private hash of the default invalid selector strings: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true}
+        * A private hash of the default invalid selector strings: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true, '[contenteditable]': true}
         * @private
         * @property _invalidsDefault
         * @type {Object}
         */
-        _invalidsDefault: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true },
+        _invalidsDefault: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true, '[contenteditable]': true },
         /**
         * Private flag to see if the drag threshhold was met
         * @private

--- a/src/dd/meta/dd.json
+++ b/src/dd/meta/dd.json
@@ -62,7 +62,8 @@
             },
             "dd-drag": {
                 "requires": [
-                    "dd-ddm-base"
+                    "dd-ddm-base",
+                    "selector-css2"
                 ]
             },
             "dd-drop": {


### PR DESCRIPTION
modify the 3.17rc  http://stage.yuilibrary.com/yui/docs/panel/panel-form-example.html to contain a contenteditable element and you will find you can gain focus on the element.

//cc @tilomitra 
//cc @triptych 
