### PR TITLE
Document usage of Lang.sub()

### DIFF
--- a/src/yui/docs/lang.mustache
+++ b/src/yui/docs/lang.mustache
@@ -100,7 +100,7 @@ Y.Lang.isUndefined(null); // false
 
 <h2>String substitution</h2>
 
-<p>`Y.Lang.sub()` let you replace placeholder(s) within a string:</p>
+<p>`Y.Lang.sub()` lets you replace placeholders within a string:</p>
 
 ```
 Y.Lang.sub('hello {name}', { name: 'john' });


### PR DESCRIPTION
Unless I'm mistaken `Y.Lang.sub()` wasn't documented at all.

This PR documents its basic usage and the support for nested placeholders that I introduced in #1814
