### PR TITLE
[cssgrids] Typo on demo

### DIFF
--- a/src/cssgrids/docs/cssgrids-units.mustache
+++ b/src/cssgrids/docs/cssgrids-units.mustache
@@ -1,8 +1,8 @@
 <div class="intro">
-    <p>Creating a layout using grids requires a <code>yui3-g</code> container 
-    and any number of <code>yui3-u-*</code> units.  
+    <p>Creating a layout using grids requires a <code>yui3-g</code> container
+    and any number of <code>yui3-u-*</code> units.
     To create a layout that splits the available width into 2 equal parts,
-    use two <code>yui3-u-1-2</code> units. The last two numbers of the class name, "1-2", represent 
+    use two <code>yui3-u-1-2</code> units. The last two numbers of the class name, "1-2", represent
     1/2.</p>
 
 </div>
@@ -14,7 +14,7 @@
 </div>
 
 <h4>Note</h4>
-<p>The only child elements (e.g. direct descendants) of a <code>yui3-g</code> should be <code>yui-3-u-*</code> elements. Any elements within a <code>yui3-g</code> need to be wrapped in a <code>yui3-u-*</code> of some kind, otherwise you may experience side-effects due to the layout system being used.</p>
+<p>The only child elements (e.g. direct descendants) of a <code>yui3-g</code> should be <code>yui3-u-*</code> elements. Any elements within a <code>yui3-g</code> need to be wrapped in a <code>yui3-u-*</code> of some kind, otherwise you may experience side-effects due to the layout system being used.</p>
 <h3>Basic Markup Structure</h3>
 
 ```


### PR DESCRIPTION
It should be `yui3-u-*` instead of `yui-3-u-*`.
