### PR TITLE
Fixed typo

### DIFF
--- a/src/yui/docs/index.mustache
+++ b/src/yui/docs/index.mustache
@@ -215,12 +215,12 @@ Within any given YUI instance, there are three possible states for a module:
 */
 
 YUI().use('calendar', function(Y) {
-    //Now calender and all if it's dependencies are 'Loaded' and 'Attached' on this instance
+    //Now calendar and all if it's dependencies are 'Loaded' and 'Attached' on this instance
 });
 
 YUI().use('node', function(Y) {
     //Now node and all of it's dependencies are 'Loaded' and 'Attached' on this instance
-    //Calender and it's un-used dependencies are in the 'Loaded' state on this instance
+    //Calendar and it's un-used dependencies are in the 'Loaded' state on this instance
 });
 
 ```


### PR DESCRIPTION
Fixed typo where calendar was spelled calender.
