### PR TITLE
NodeList.importMethod should respect the alternative function name

### DIFF
--- a/src/node/HISTORY.md
+++ b/src/node/HISTORY.md
@@ -4,7 +4,7 @@ Node Change History
 @VERSION@
 ------
 
-* No changes.
+* [#1848][] NodeList.importMethod should respect the alternative name it was provided with. (Andrew Nicols)
 
 3.17.1
 ------

--- a/src/node/js/nodelist.js
+++ b/src/node/js/nodelist.js
@@ -98,10 +98,20 @@ NodeList.addMethod = function(name, fn, context) {
     }
 };
 
+/**
+ * Import the named method, or methods from the host onto NodeList.
+ *
+ * @method importMethod
+ * @static
+ * @param {Object} host The object containing the methods to copy. Typically a prototype.
+ * @param {String|String[]} name The name, or an Array of names of the methods to import onto NodeList.
+ * @param {String} [altName] An alternative name to use for the method added to NodeList, which may differ from the name
+ * of the original host object. Has no effect if <em>name</em> is an array of method names.
+ */
 NodeList.importMethod = function(host, name, altName) {
     if (typeof name === 'string') {
         altName = altName || name;
-        NodeList.addMethod(name, host[name]);
+        NodeList.addMethod(altName, host[name]);
     } else {
         Y.Array.each(name, function(n) {
             NodeList.importMethod(host, n);

--- a/src/node/tests/unit/assets/nodelist-test.js
+++ b/src/node/tests/unit/assets/nodelist-test.js
@@ -276,6 +276,21 @@ YUI.add('nodelist-test', function(Y) {
             nodelist.refresh();
             ArrayAssert.itemsAreEqual(node.all('li').size(), nodelist.size(), 'refresh should affect size');
             ArrayAssert.itemsAreEqual(node.all('li')._nodes, nodelist._nodes, 'refreshed nodelist should be in sync');
+        },
+
+        'should accept alternative names in importMethod': function() {
+            var exampleSource = {
+                sourceMethod: function() {
+                    noop();
+                }
+            },
+            NodeList = Y.NodeList;
+
+            Assert.isUndefined(NodeList.prototype.sourceMethod);
+            Assert.isUndefined(NodeList.prototype.targetMethod);
+            NodeList.importMethod(exampleSource, 'sourceMethod', 'targetMethod');
+            Assert.isUndefined(NodeList.prototype.sourceMethod);
+            Assert.isFunction(NodeList.prototype.targetMethod);
         }
     }));
 }, '@VERSION@' ,{requires:['node-base']});


### PR DESCRIPTION
I noticed whilst looking over some of NodeList this evening that we never actually make use of altName.
