### PR TITLE
[dom] Fix DOM XY tests stuff

### DIFF
--- a/src/dom/tests/unit/assets/dom-xy-test.js
+++ b/src/dom/tests/unit/assets/dom-xy-test.js
@@ -11,15 +11,14 @@ YUI.add('dom-xy-test', function(Y) {
         window.scrollTo(100, 100);
         play2.scrollTop = 50;
 
-        function testXY(expected, actual) {
-            var x = actual[0],
-                pass = false;
+        function testXY(actual, expected) {
+            var pass = false;
 
             // Expected is in pixels from offsetTop/Left, actual may be subpixels.
             // Browsers don't agree on which way to round, so its
             // considered a match if rounding up or down yields a match.
-            if ((Math.floor(actual[0]) === expected[0] || Math.ceil(actual[0]) === expected[0]) &&
-                (Math.floor(actual[1]) === expected[1] || Math.ceil(actual[1]) === expected[1])) {
+            if ((Math.floor(actual[0]) === Math.floor(expected[0]) || Math.ceil(actual[0]) === Math.ceil(expected[0])) &&
+                (Math.floor(actual[1]) === Math.floor(expected[1]) || Math.ceil(actual[1]) === Math.ceil(expected[1]))) {
                 pass = true;
             }
 
@@ -29,7 +28,6 @@ YUI.add('dom-xy-test', function(Y) {
         Y.each(nodes, function(n) {
             var el = document.createElement('div'),
                 xy = Y.DOM.getXY(n),
-                box,
                 actual,
                 id = n.id;
 
@@ -39,9 +37,7 @@ YUI.add('dom-xy-test', function(Y) {
             document.body.appendChild(el);
 
             Y.DOM.setXY(el, xy, true);
-            box = el.getBoundingClientRect();
 
-            //actual = [box.left + Y.DOM.docScrollX(), box.top + Y.DOM.docScrollY()];
             actual = [el.offsetLeft, el.offsetTop];
 
             tests['should set ' + id + ' in page coords'] = function() {


### PR DESCRIPTION
This change fixes some stuff on DOM XY tests as follows.
1. Both the expected and actual values should be normalized by `Math.floor()` or `Math.ceil()` functions because the expected values on [Chrome 36](http://blog.chromium.org/2014/05/chrome-36-beta-elementanimate-html.html) (currently Beta) returns fractional values, the actual values on Firefox 29 (Stable) returns fractional values.
2. The `testXY()` function's parameters is opposite. Fix the order of the parameters to avoid the confusion.
3. Clean up some unused variables.

So here is testing results on each browsers.

```
[okuryu.local](yui3@fix-dom-xy-test)$ yeti src/dom/tests/unit/dom-xy.html
  Agent connected: Firefox (29.0) / Mac OS from 127.0.0.1
  Agent connected: Chrome (36.0.1985.32) / Mac OS from 127.0.0.1
  Agent connected: Safari (7.0.4) / Mac OS from 127.0.0.1
  Agent connected: Internet Explorer (6.0) / Windows XP from 10.0.1.15
  Agent connected: Internet Explorer (7.0) / Windows XP from 10.0.1.15
  Agent connected: Internet Explorer (8.0) / Windows XP from 10.0.1.15
  Agent connected: Internet Explorer (9.0) / Windows 7 from 10.0.1.15
  Agent connected: Internet Explorer (10.0) / Windows 7 from 10.0.1.15
  Agent connected: Internet Explorer (11.0) / Windows 7 from 10.0.1.15
  Agent connected: Safari (7.0) / iOS 7.1.1 from 10.0.1.16
✓ Testing started on Firefox (29.0) / Mac OS, Chrome (36.0.1985.32) / Mac OS, Safari (7.0.4) / Mac OS, Internet Explorer (6.0) / Windows XP, Internet Explorer (7.0) / Windows XP, Internet Explorer (8.0) / Windows XP, Internet Explorer (9.0) / Windows 7, Internet Explorer (10.0) / Windows 7, Internet Explorer (11.0) / Windows 7, Safari (7.0) / iOS 7.1.1
✓ Agent completed: Safari (7.0.4) / Mac OS
✓ Agent completed: Firefox (29.0) / Mac OS
✓ Agent completed: Internet Explorer (10.0) / Windows 7
✓ Agent completed: Safari (7.0) / iOS 7.1.1
✓ Agent completed: Internet Explorer (11.0) / Windows 7
✓ Agent completed: Internet Explorer (9.0) / Windows 7
✓ Agent completed: Internet Explorer (8.0) / Windows XP
✓ Agent completed: Chrome (36.0.1985.32) / Mac OS
✓ Agent completed: Internet Explorer (6.0) / Windows XP
✓ Agent completed: Internet Explorer (7.0) / Windows XP
✓ 420 tests passed! (7 seconds)
```
