### PR TITLE
Don't prevent-default in 'on' for document node

### DIFF
--- a/src/event-gestures/js/Move.js
+++ b/src/event-gestures/js/Move.js
@@ -109,7 +109,7 @@
     The user can over-ride this by setting a more lenient -ms-touch-action property on a node (such as pan-x, pan-y, etc.) via CSS when subscribing to the 'gesturemovestart' event.
     */
     _setTouchActions = function (node) {
-        var elem = _checkDocumentElem(node) || node.getDOMNode(),
+        var elem = node.getDOMNode(),
             num = node.getData(MS_TOUCH_ACTION_COUNT);
 
         //Checks to see if msTouchAction is supported.
@@ -128,7 +128,7 @@
     Resets the element's -ms-touch-action property back to the original value, This is called on detach() and detachDelegate().
     */
     _unsetTouchActions = function (node) {
-        var elem = _checkDocumentElem(node) || node.getDOMNode(),
+        var elem = node.getDOMNode(),
             num = node.getData(MS_TOUCH_ACTION_COUNT),
             initTouchAction = node.getData(MS_INIT_TOUCH_ACTION);
 
@@ -189,8 +189,10 @@ define(GESTURE_MOVE_START, {
     on: function (node, subscriber, ce) {
 
         //Set -ms-touch-action on IE10 and set preventDefault to true
-        _setTouchActions(node);
-
+        if (!_checkDocumentElem(node)) {
+            _setTouchActions(node);
+        }
+        
         subscriber[_MOVE_START_HANDLE] = node.on(EVENT[START],
             this._onStart,
             this,
@@ -218,7 +220,9 @@ define(GESTURE_MOVE_START, {
             subscriber[_DEL_MOVE_START_HANDLE] = null;
         }
 
-        _unsetTouchActions(node);
+        if (!_checkDocumentElem(node)) {
+            _unsetTouchActions(node);
+        }
     },
 
     detach: function (node, subscriber, ce) {
@@ -229,7 +233,9 @@ define(GESTURE_MOVE_START, {
             subscriber[_MOVE_START_HANDLE] = null;
         }
 
-        _unsetTouchActions(node);
+        if (!_checkDocumentElem(node)) {
+            _unsetTouchActions(node);
+        }
     },
 
     processArgs : function(args, delegate) {
@@ -383,16 +389,23 @@ define(GESTURE_MOVE_START, {
 define(GESTURE_MOVE, {
 
     on : function (node, subscriber, ce) {
+        var moveHandle,
+            root;
 
-        _setTouchActions(node);
-        var root = _getRoot(node, subscriber, EVENT[MOVE]),
+        // if the passed node is NOT the document itself, modify the ms-pointer
+        // behavior to prevent scrolling, highlighting, etc.
+        if (!_checkDocumentElem(node)) {
+            _setTouchActions(node);         
+        }
 
-            moveHandle = root.on(EVENT[MOVE],
-                this._onMove,
-                this,
-                node,
-                subscriber,
-                ce);
+        root = _getRoot(node, subscriber, EVENT[MOVE]);
+
+        moveHandle = root.on(EVENT[MOVE],
+            this._onMove,
+            this,
+            node,
+            subscriber,
+            ce);
 
         subscriber[_MOVE_HANDLE] = moveHandle;
 
@@ -417,7 +430,9 @@ define(GESTURE_MOVE, {
             subscriber[_MOVE_HANDLE] = null;
         }
 
-        _unsetTouchActions(node);
+        if (!_checkDocumentElem(node)) {
+            _unsetTouchActions(node);
+        }
     },
 
     detachDelegate : function(node, subscriber, ce, filter) {
@@ -428,7 +443,9 @@ define(GESTURE_MOVE, {
             subscriber[_DEL_MOVE_HANDLE] = null;
         }
 
-        _unsetTouchActions(node);
+        if (!_checkDocumentElem(node)) {
+            _unsetTouchActions(node);
+        }
 
     },
 
@@ -509,15 +526,20 @@ define(GESTURE_MOVE, {
 define(GESTURE_MOVE_END, {
 
     on : function (node, subscriber, ce) {
-        _setTouchActions(node);
-        var root = _getRoot(node, subscriber),
+        var endHandle,
+            root;
 
-            endHandle = root.on(EVENT[END],
-                this._onEnd,
-                this,
-                node,
-                subscriber,
-                ce);
+        if (!_checkDocumentElem(node)) {
+            _setTouchActions(node);
+        }
+        
+        root = _getRoot(node, subscriber);
+        endHandle = root.on(EVENT[END],
+            this._onEnd,
+            this,
+            node,
+            subscriber,
+            ce);
 
         subscriber[_MOVE_END_HANDLE] = endHandle;
     },
@@ -541,7 +563,9 @@ define(GESTURE_MOVE_END, {
             subscriber[_DEL_MOVE_END_HANDLE] = null;
         }
 
-        _unsetTouchActions(node);
+        if (!_checkDocumentElem(node)) {
+            _unsetTouchActions(node);
+        }
 
     },
 
@@ -553,7 +577,9 @@ define(GESTURE_MOVE_END, {
             subscriber[_MOVE_END_HANDLE] = null;
         }
 
-        _unsetTouchActions(node);
+        if (!_checkDocumentElem(node)) {
+            _unsetTouchActions(node);
+        }
     },
 
     processArgs : function(args, delegate) {


### PR DESCRIPTION
The _setMsTouchActions method modifies node behavior during touch events and prevents the default response from the browser.

This will prevent pages from being scrolled in any direction if there is _any_ event listener set on the document node. For example in https://github.com/yui/yui3/issues/1343 DDM sets an 'ongesturemove' listener on the document  in order to know when to update the locations of dragged elements. BUT, the document can no longer be scrolled via touch because of the side-effect in _setTouchActions.

This fixes #1343 and maybe #1795
