### PR TITLE
[timers] Specify @module and @submodule for API docs

### DIFF
--- a/src/timers/js/epilogue.js
+++ b/src/timers/js/epilogue.js
@@ -1,12 +1,5 @@
 /**
-Provides utilities for timed asynchronous callback execution.
-Y.soon is a setImmediate/process.nextTick/setTimeout wrapper.
-
-This module includes [asap.js](https://github.com/kriskowal/asap) for scheduling
-asynchronous tasks.
-
 @module timers
-@author Steven Olmsted
 **/
 
 /**

--- a/src/timers/js/prologue.js
+++ b/src/timers/js/prologue.js
@@ -1,3 +1,15 @@
+/**
+Provides utilities for timed asynchronous callback execution.
+Y.soon is a setImmediate/process.nextTick/setTimeout wrapper.
+
+This module includes [asap.js](https://github.com/kriskowal/asap) for scheduling
+asynchronous tasks.
+
+@module timers
+@main timers
+@author Steven Olmsted
+**/
+
 // Hack. asap.js is written as a Node module and expects require, module and
 // global to be available in the module's scope.
 var module = {},


### PR DESCRIPTION
It needs to shows the correct provided module name.

Fix #1669.
