### PR TITLE
NodeList.some() - support of css selector in lieu of a function

### DIFF
--- a/src/node/HISTORY.md
+++ b/src/node/HISTORY.md
@@ -4,7 +4,7 @@ Node Change History
 @VERSION@
 ------
 
-* No changes.
+* NodeList.some(): a css selector can be used in lieu of a function (@customcommander)
 
 3.17.2
 ------

--- a/src/node/js/nodelist.js
+++ b/src/node/js/nodelist.js
@@ -190,11 +190,14 @@ Y.mix(NodeList.prototype, {
 
     /**
      * Executes the function once for each node until a true value is returned.
+     *
      * @method some
-     * @param {Function} fn The function to apply. It receives 3 arguments:
-     * the current node instance, the node's index, and the NodeList instance
-     * @param {Object} context optional An optional context to execute the function from.
-     * Default context is the current Node instance
+     * @param fn {Function}
+     *  The function to apply. It receives 3 arguments:
+     *  the current node instance, the node's index, and the NodeList instance
+     * @param [context] {Object}
+     *  An optional context to execute the function from.
+     *  Default context is the current Node instance
      * @return {Boolean} Whether or not the function returned true for any node.
      */
     some: function(fn, context) {

--- a/src/node/js/nodelist.js
+++ b/src/node/js/nodelist.js
@@ -191,10 +191,27 @@ Y.mix(NodeList.prototype, {
     /**
      * Executes the function once for each node until a true value is returned.
      *
+     * @example
+     *     // <ol>
+     *     //     <li class="bar">xxx</li>
+     *     //     <li class="bar">yyy</li>
+     *     // </ol>
+     *
+     *     Y.all('li').some(function (node) {
+     *         return node.get('text') === 'xxx';
+     *     });
+     *     //=> true
+     *
+     *     Y.all('li').some('.bar');
+     *     //=> true
+     *
      * @method some
-     * @param fn {Function}
+     * @param fn {Function|String}
      *  The function to apply. It receives 3 arguments:
-     *  the current node instance, the node's index, and the NodeList instance
+     *  the current node instance, the node's index, and the NodeList instance.
+     *
+     *  If fn is a string `some` assumes it is a css selector and will return
+     *  true if there is any node in the list matching that selector.
      * @param [context] {Object}
      *  An optional context to execute the function from.
      *  Default context is the current Node instance
@@ -202,6 +219,12 @@ Y.mix(NodeList.prototype, {
      */
     some: function(fn, context) {
         var instance = this;
+        var selector = fn;
+        if (typeof fn === 'string') {
+            fn = function (node) {
+                return node.test(selector);
+            };
+        }
         return Y.Array.some(this._nodes, function(node, index) {
             node = Y.one(node);
             context = context || node;

--- a/src/node/tests/unit/assets/nodelist-test.js
+++ b/src/node/tests/unit/assets/nodelist-test.js
@@ -145,6 +145,14 @@ YUI.add('nodelist-test', function(Y) {
 
         },
 
+        'should return true when some(selector) finds a matching node': function () {
+            Assert.isTrue( Y.all('#test-nodes li').some('.bar') );
+        },
+
+        'should return false when some(selector) cannot find a matching node': function () {
+            Assert.isFalse( Y.all('#test-nodes li').some('.unknown') );
+        },
+
         'should return false when no function returns true': function() {
             var nodes = Y.all('#test-nodes *');
 


### PR DESCRIPTION
Hey guys,

I sometimes forgot that the following doesn't work:

``` javascript
Y.all('li').filter(function () {
  /* code */
});
```

Because `filter()` accepts a css selector but not a function.

Which is fine because we're dealing with nodes and it does make sense to use css selectors in that context. But then I reckon that array-like functions bound to a NodeList instance should behave consistently.

For example `some()` (on a NodeList instance) only accepts a function. Which is confusing imho.

So I made it possible to provide `some()` with a css selector instead of a function.
