### PR TITLE
[calendar] very_short_weekdays fallback to datatype-date-format langage data

### DIFF
--- a/src/calendar/js/calendar-base.js
+++ b/src/calendar/js/calendar-base.js
@@ -1084,8 +1084,8 @@ Y.CalendarBase = Y.extend( CalendarBase, Y.Widget, {
             shortWeekDays = dateFormat.a;
         }
 
-            // Initialize the partial template for the weekday row cells.
-            partials.weekday_row = '';
+        // Initialize the partial template for the weekday row cells.
+        partials.weekday_row = '';
 
         // Populate the partial template for the weekday row cells with weekday names
         for (day = firstday; day <= firstday + 6; day++) {


### PR DESCRIPTION
Fix #1796.

Both `shortWeekDays` and `weekDays` will be localized at least `datatype-date-format` is available in specified language by this change.

For example, this issue occurs when language data is not found in `calendar-base` and found in `datatype-date-format` like language `ko`.

Before (v3.17.2):
![2014-06-22 at 22 00](https://cloud.githubusercontent.com/assets/34588/3351522/a9c3e52c-fa0f-11e3-85f8-009b864e180e.png)
After (this PR):
![2014-06-22 at 22 01](https://cloud.githubusercontent.com/assets/34588/3351523/aff04ae4-fa0f-11e3-84d6-a64db298eefe.png)

Note: I'll update `HISTORY.md` after merging this PR.

/cc @brunobasto
