### PR TITLE
normalize sortBy so it is always an array

### DIFF
--- a/src/datatable/js/sort.js
+++ b/src/datatable/js/sort.js
@@ -580,6 +580,9 @@ Y.mix(Sortable.prototype, {
                 }
 
                 if (i >= len) {
+                    if (!isArray(sortBy)) {
+                        sortBy = [sortBy];
+                    }
                     sortBy.push(column._id);
                 }
             } else {


### PR DESCRIPTION
This fix is required when sortBy is set to a string in the constructor and then the user shift-clicks on a second column.
