### PR TITLE
Mark all Android devices as "mobile"

### DIFF
--- a/src/yui/js/yui-ua.js
+++ b/src/yui/js/yui-ua.js
@@ -351,9 +351,7 @@ YUI.Env.parseUA = function(subUA) {
                     }
                 }
                 if (/ Android/.test(ua)) {
-                    if (/Mobile/.test(ua)) {
-                        o.mobile = 'Android';
-                    }
+                    o.mobile = 'Android';
                     m = ua.match(/Android ([^\s]*);/);
                     if (m && m[1]) {
                         o.android = numberify(m[1]);


### PR DESCRIPTION
The current UA parser does not mark Android tablets, such as the Nexus 7, Nexus 10, etc., as mobile (`Y.UA.mobile`). This creates an inconsistency between Android tablets and iOS tablets, since iPads are marked as such.

Seeing as 99.9% of all Android devices out there are "mobile" (modulo AndroidTV and some other edge cases), it seems like it would make the most sense to mark them all as mobile, as you're already doing for iOS.
