### PR TITLE
Examples for the different ways .on() can be used

### DIFF
--- a/src/event-custom/js/event-target.js
+++ b/src/event-custom/js/event-target.js
@@ -189,6 +189,8 @@ ET.prototype = {
      * Subscribe a callback function to a custom event fired by this object or
      * from an object that bubbles its events to this object.
      *
+     *      this.on("change", this._onChange, this);
+     *
      * Callback functions for events published with `emitFacade = true` will
      * receive an `EventFacade` as the first argument (typically named "e").
      * These callbacks can then call `e.preventDefault()` to disable the
@@ -198,9 +200,17 @@ ET.prototype = {
      * after the event name.
      *
      * To subscribe to multiple events at once, pass an object as the first
-     * argument, where the key:value pairs correspond to the eventName:callback,
-     * or pass an array of event names as the first argument to subscribe to
-     * all listed events with the same callback.
+     * argument, where the key:value pairs correspond to the eventName:callback.
+     *
+     *      this.on({
+     *          "attrChange" : this._onAttrChange,
+     *          "change"     : this._onChange
+     *      });
+     *
+     * You can also pass an array of event names as the first argument to
+     * subscribe to all listed events with the same callback.
+     *
+     *      this.on([ "change", "attrChange" ], this._onChange);
      *
      * Returning `false` from a callback is supported as an alternative to
      * calling `e.preventDefault(); e.stopPropagation();`.  However, it is


### PR DESCRIPTION
Had a coworker that was confused about where to find documentation on the different ways `.on()` can be used. Turns out there's a single kinda throwaway sentence in the current docs for it, so I thought adding some examples would help.

![on-examples](https://cloud.githubusercontent.com/assets/49545/3930235/16b82e80-243c-11e4-9ca7-8a6297e8948a.PNG)
