### PR TITLE
Corrected ButtonGroup docs

### DIFF
--- a/src/button/docs/index.mustache
+++ b/src/button/docs/index.mustache
@@ -144,7 +144,7 @@ YUI().use('button-group', function(Y){
 
 <div id="buttongroup">
     <h3>use('button-group')</h3>
-    <p>`Y.ButtonGroup` is a constructor that is used to generate widgets containing a group of buttons. To avoid widgets inside of widgets, this class is built on top of `Y.ButtonCore`, not `Y.Button`</p>
+    <p>`Y.ButtonGroup` is a constructor that is used to generate widgets containing a group of buttons.</p>
 </div>
 
 
@@ -212,7 +212,7 @@ YUI().use('button-group', function(Y){
 </table>
 
 <h4>Y.ButtonGroup</h4>
-<p>In addition to the inherited `Y.ButtonCore` attributes...</p>
+<p>In addition to the inherited `Y.Widget` attributes...</p>
 <table>
   <thead>
     <tr>
@@ -298,7 +298,7 @@ YUI().use('button-group', function(Y){
 </table>
 
 <h4>Y.ButtonGroup</h4>
-<p>In addition to the inherited `Y.ButtonCore` events...</p>
+<p>In addition to the inherited `Y.Widget` events...</p>
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
Docs wrongly claimed that `Y.ButtonGroup` inherits from `Y.ButtonCore`.
