### PR TITLE
ButtonGroup renders as single-box widget

### DIFF
--- a/src/button/HISTORY.md
+++ b/src/button/HISTORY.md
@@ -4,7 +4,7 @@ Button Change History
 @VERSION@
 ------
 
-* No changes.
+* ButtonGroup renders as a single-box widget (contentBox === boundingBox)
 
 3.17.2
 ------

--- a/src/button/js/group.js
+++ b/src/button/js/group.js
@@ -24,6 +24,15 @@ function ButtonGroup() {
 /* ButtonGroup extends Widget */
 Y.ButtonGroup = Y.extend(ButtonGroup, Y.Widget, {
 
+	/**
+     * Content box template
+     *
+     * @property CONTENT_TEMPLATE
+     * @type {String}
+     * @default null
+     */
+    CONTENT_TEMPLATE: null,
+
     /**
      * @method renderUI
      * @description Creates a visual representation of the widget based on existing parameters.


### PR DESCRIPTION
I've made this change to simplify buttongroup markup, especially for progressively enhanced markup.

In particular, I had problems with this setup:

``` html
<div id="bgroup" class="yui3-buttongroup">
  <button class="yui3-button">YUI</button>
  <button class="yui3-button">rocks</button>
</div>

<style type="text/css">
  .yui3-buttongroup > .yui3-button { /* not an unreasonable selector, right? */
    border-radius: 0;
  }
</style>

<script>
YUI().use('button-group', function(Y) {
  new Y.ButtonGroup({
    srcNode: '#bgroup',
    type: 'checkbox'
  }).render();
});
</script>
```

The styles are applied before the script enhances the markup, because the `yui3-buttongroup` class is already present on the `srcNode`.

After the script has run though, the markup changes to:

``` html
<div class="yui3-widget yui3-buttongroup">
  <div class="yui3-buttongroup yui3-buttongroup-content">
    <button class="yui3-button">YUI</button>
    <button class="yui3-button">rocks</button>
  </div>
</div>
```

Note that both the `boundingBox` and the `contentBox` have the class `yui3-buttongoup`. The `contentBox` (the original `srcNode`) shouldn't have that class anymore!

As alternatives to single-box `ButtonGroup`s, I could
- change the `srcNode`'s class to `yui3-buttongroup-content`, and change the selector accordingly.
- use an additional class (e.g. `mybuttongroup`) to make my selectors independent of ButtonGroup's rendering. (This is actually the situation I have now, but I want to simplify the code.)

These work, of course, but I much prefer the single-box solution, because it requires less knowledge about the Widget's markup and simplifies CSS selectors.

This change might break some code (js or CSS)! However, Button is still in beta, so that is acceptable, maybe?
