### PR TITLE
Allow immediate invocation of wrapped function

### DIFF
--- a/src/yui-throttle/js/throttle.js
+++ b/src/yui-throttle/js/throttle.js
@@ -29,6 +29,8 @@ to the `Y` object and is <a href="../classes/YUI.html#method_throttle">documente
  * @since 3.1.0
  */
 Y.throttle = function(fn, ms) {
+    var last;
+    
     ms = (ms) ? ms : (Y.config.throttleTime || 150);
 
     if (ms === -1) {
@@ -37,11 +39,10 @@ Y.throttle = function(fn, ms) {
         };
     }
 
-    var last = Y.Lang.now();
-
     return function() {
         var now = Y.Lang.now();
-        if (now - last > ms) {
+
+        if (!last || (now - last > ms)) {
             last = now;
             fn.apply(this, arguments);
         }


### PR DESCRIPTION
Current version of `throttle` will prevent the immediate invocation of the wrapped function because the `last` var is being set to function creation time instead of being set upon the first invocation of the function.

I found this while running the unit tests that already exist for the class...
