### PR TITLE
Update docs for Y.UA.os

### DIFF
--- a/src/yui/js/yui-ua.js
+++ b/src/yui/js/yui-ua.js
@@ -231,7 +231,10 @@ YUI.Env.parseUA = function(subUA) {
         secure: false,
 
         /**
-         * The operating system.  Currently only detecting windows or macintosh
+         * The operating system.
+         *
+         * Possible values are `windows`, `macintosh`, `android`, `symbos`, `linux`, `rhino` and `ios`.
+         *
          * @property os
          * @type string
          * @default null


### PR DESCRIPTION
Current doc says that only `windows` and `macintosh` are supported but from what I could read in the code many more OSes are supported. The doc wasn't simply up to date.
