### PR TITLE
Implementation of custom upload method in YUI HTML5 Uploader

### DIFF
--- a/src/file/js/file-html5.js
+++ b/src/file/js/file-html5.js
@@ -217,10 +217,11 @@
         *
         * @method startUpload
         * @param url {String} The URL to upload the file to.
+        * @param method {String} The upload method.
         * @param parameters {Object} (optional) A set of key-value pairs to send as variables along with the file upload HTTP request.
         * @param fileFieldName {String} (optional) The name of the POST variable that should contain the uploaded file ('Filedata' by default)
         */
-        startUpload: function(url, parameters, fileFieldName) {
+        startUpload: function(url, method, parameters, fileFieldName) {
 
             this._set("bytesUploaded", 0);
 
@@ -249,7 +250,7 @@
             xhr.addEventListener ("loadend", boundEventHandler, false);
             xhr.addEventListener ("readystatechange", boundEventHandler, false);
 
-            xhr.open("POST", url, true);
+            xhr.open(method, url, true);
 
             xhr.withCredentials = this.get("xhrWithCredentials");
 

--- a/src/uploader/js/uploader-html5.js
+++ b/src/uploader/js/uploader-html5.js
@@ -588,12 +588,14 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
     * @method upload
     * @param file {File} Reference to the instance of the file to be uploaded.
     * @param url {String} The URL to upload the file to.
+    * @param method {String} The upload method.
     * @param postVars {Object} (optional) A set of key-value pairs to send as variables along with the file upload HTTP request.
     *                          If not specified, the values from the attribute `postVarsPerFile` are used instead.
     */
-    upload : function (file, url, postvars) {
+    upload : function (file, url, method, postvars) {
 
         var uploadURL = url || this.get("uploadURL"),
+            uploadMethod = method || this.get("uploadMethod"),
             postVars = postvars || this.get("postVarsPerFile"),
             fileId = file.get("id");
 
@@ -607,7 +609,7 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
             file.on("uploaderror", this._uploadEventHandler, this);
             file.on("uploadcancel", this._uploadEventHandler, this);
 
-            file.startUpload(uploadURL, postVars, this.get("fileFieldName"));
+            file.startUpload(uploadURL, uploadMethod, postVars, this.get("fileFieldName"));
         }
     },
 
@@ -616,11 +618,12 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
     *
     * @method uploadAll
     * @param url {String} The URL to upload the files to.
+    * @param method {String} The upload method.
     * @param [postVars] {Object} A set of key-value pairs to send as variables along with the file upload HTTP request.
     *                          If not specified, the values from the attribute `postVarsPerFile` are used instead.
     */
-    uploadAll : function (url, postvars) {
-        this.uploadThese(this.get("fileList"), url, postvars);
+    uploadAll : function (url, method, postvars) {
+        this.uploadThese(this.get("fileList"), url, method, postvars);
     },
 
     /**
@@ -629,12 +632,14 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
     * @method uploadThese
     * @param files {Array} The list of files to upload.
     * @param url {String} The URL to upload the files to.
+    * @param method {String} The upload method.
     * @param [postVars] {Object} A set of key-value pairs to send as variables along with the file upload HTTP request.
     *                          If not specified, the values from the attribute `postVarsPerFile` are used instead.
     */
-    uploadThese : function (files, url, postvars) {
+    uploadThese : function (files, url, method, postvars) {
         if (!this.queue) {
             var uploadURL = url || this.get("uploadURL"),
+                uploadMethod = method || this.get("uploadMethod"),
                 postVars = postvars || this.get("postVarsPerFile");
 
             this.queue = new UploaderQueue({
@@ -643,6 +648,7 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
                 fileFieldName: this.get("fileFieldName"),
                 fileList: files,
                 uploadURL: uploadURL,
+                uploadMethod: uploadMethod,
                 perFileParameters: postVars,
                 retryCount: this.get("retryCount"),
                 uploadHeaders: this.get("uploadHeaders"),
@@ -947,7 +953,7 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
         },
 
         /**
-        * The URL to which file upload requested are POSTed. Only used if a different url is not passed to the upload method call.
+        * The URL to which file upload requested are uploaded. Only used if a different url is not passed to the upload method call.
         *
         * @attribute uploadURL
         * @type {String}
@@ -955,6 +961,17 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
         */
         uploadURL: {
             value: ""
+        },
+
+        /**
+        * A String that specifies the upload method.
+        *
+        * @attribute method
+        * @type {String}
+        * @default POST
+        */
+        uploadMethod: {
+            value: "POST"
         },
 
         /**

--- a/src/uploader/js/uploader-queue.js
+++ b/src/uploader/js/uploader-queue.js
@@ -134,7 +134,7 @@ Y.extend(UploaderQueue, Y.Base, {
             currentFile.set("xhrHeaders", this.get("uploadHeaders"));
             currentFile.set("xhrWithCredentials", this.get("withCredentials"));
 
-            currentFile.startUpload(this.get("uploadURL"), fileParameters, this.get("fileFieldName"));
+            currentFile.startUpload(this.get("uploadURL"), this.get("uploadMethod"), fileParameters, this.get("fileFieldName"));
 
             this._registerUpload(currentFile);
         }
@@ -587,6 +587,17 @@ Y.extend(UploaderQueue, Y.Base, {
         */
         uploadURL: {
             value: ""
+        },
+
+        /**
+        * A String that specifies the upload method.
+        *
+        * @attribute method
+        * @type {String}
+        * @default POST
+        */
+        uploadMethod: {
+            value: "POST"
         },
 
         /**


### PR DESCRIPTION
Hi there,

this PR allows for a custom upload method for the YUI HTML5 Uploader. The upload method can be specified on instantiation of Y.Uploader via an additional (optional) Uploader configuration attribute, uploadMethod.
The default value ("POST") means the behaviour stayed the same as the current behaviour, but this new attribute allows for the Uploader to be used with PUT as well (eg. uploadMethod: "PUT").

Do let me know if you have any remarks - thanks in advance for merging this PR!

Kind regards,
David
