### PR TITLE
Editor - fix issue in which empty node instance throws error.

### DIFF
--- a/src/editor/js/editor-selection.js
+++ b/src/editor/js/editor-selection.js
@@ -955,7 +955,7 @@
         */
         removeCursor: function(keep) {
             var cur = this.getCursor();
-            if (cur) {
+            if (cur && cur.remove) {
                 if (keep) {
                     cur.set('innerHTML', '<br class="yui-cursor">');
                 } else {


### PR DESCRIPTION
Editor has a regression in which an error is thrown during the `removeCursor` method when the `cur` argument is not a `node` instance. This addresses that issue.

@ericf @caridy 
This fix is for the 3.18.0 release. Thanks!
