### PR TITLE
Fix for broken events when event targets are SVGElementInstances (in Safari)

### DIFF
--- a/src/event/HISTORY.md
+++ b/src/event/HISTORY.md
@@ -4,7 +4,7 @@ Event Infrastructure Change History
 @VERSION@
 ------
 
-* No changes.
+* Fixed broken event delegation when the event target is an SVGElementInstance.
 
 3.18.0
 ------

--- a/src/event/js/delegate.js
+++ b/src/event/js/delegate.js
@@ -246,6 +246,13 @@ delegate._applyFilter = function (filter, args, ce) {
         match     = [],
         isContainer = false;
 
+    // safari's svg element instance needs special handling
+    if (typeof SVGElementInstance !== 'undefined') {
+        if (!target.nodeType && target.correspondingElement) {
+            target = target.correspondingUseElement || target.correspondingElement;
+        }
+    }
+
     // Resolve text nodes to their containing element
     if (target.nodeType === 3) {
         target = target.parentNode;

--- a/src/node/HISTORY.md
+++ b/src/node/HISTORY.md
@@ -4,7 +4,7 @@ Node Change History
 @VERSION@
 ------
 
-* No changes.
+* Fixed broken Y.one/Y.all wrappers when the node is an SVGElementInstance.
 
 3.18.0
 ------

--- a/src/node/js/node-core.js
+++ b/src/node/js/node-core.js
@@ -164,6 +164,8 @@ Y_Node.scrubVal = function(val, node) {
          if (typeof val == 'object' || typeof val == 'function') { // safari nodeList === function
             if (NODE_TYPE in val || Y_DOM.isWindow(val)) {// node || window
                 val = Y.one(val);
+            } else if (typeof SVGElementInstance !== 'undefined' && val.correspondingElement) { // svg node
+                val = Y.one(val.correspondingUseElement || val.correspondingElement);
             } else if ((val.item && !val._nodes) || // dom collection or Node instance
                     (val[0] && val[0][NODE_TYPE])) { // array of DOM Nodes
                 val = Y.all(val);
@@ -284,6 +286,13 @@ Y_Node.one = function(node) {
             }
         } else if (node.getDOMNode) {
             return node; // NOTE: return
+        }
+
+        // safari's svg element instance needs special handling
+        if (typeof SVGElementInstance !== 'undefined') {
+            if (!node.nodeType && node.correspondingElement) {
+                node = node.correspondingUseElement || node.correspondingElement;
+            }
         }
 
         if (node.nodeType || Y.DOM.isWindow(node)) { // avoid bad input (numbers, boolean, etc)

--- a/src/node/js/nodelist.js
+++ b/src/node/js/nodelist.js
@@ -23,6 +23,8 @@ var NodeList = function(nodes) {
             nodes = Y.Selector.query(nodes);
         } else if (nodes.nodeType || Y_DOM.isWindow(nodes)) { // domNode || window
             nodes = [nodes];
+        } else if (typeof SVGElementInstance !== 'undefined' && nodes.correspondingElement) { // svg node
+            nodes = [nodes.correspondingUseElement || nodes.correspondingElement];
         } else if (nodes._node) { // Y.Node
             nodes = [nodes._node];
         } else if (nodes[0] && nodes[0]._node) { // allow array of Y.Nodes


### PR DESCRIPTION
W3 states that SVG element be a bit different from the rest of elements. They are a `SVGElementInstance`, and don't have attributes like `nodeType`, `nodeName`, `parentNode`, etc. A SVGElementInstance instead has a `correspondingElement` or both a `correspondingElement` and a `correspondingUseElement`(for `<use/>`). Both `correspondingElement`and `correspondingUseElement` have all the typical DOM node attributes that you'd expect from other elements.
(ref: http://www.w3.org/TR/SVG/struct.html#InterfaceSVGElementInstance)

Funnily enough, Chrome and Firefox do not follow this "standard", but Safari does. 

Currently YUI doesn't have a support for it, making event targets to be `null` while attempting to wrap a SVGElementInstance into a Y.Node instance; hence this patch.
