### PR TITLE
Fix dd in ie6, 7

### DIFF
--- a/src/dd/js/drag.js
+++ b/src/dd/js/drag.js
@@ -614,12 +614,12 @@
         */
         _invalids: null,
         /**
-        * A private hash of the default invalid selector strings: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true, '[contenteditable]': true}
+        * A private hash of the default invalid selector strings: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true}
         * @private
         * @property _invalidsDefault
         * @type {Object}
         */
-        _invalidsDefault: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true, '[contenteditable]': true },
+        _invalidsDefault: {'textarea': true, 'input': true, 'a': true, 'button': true, 'select': true },
         /**
         * Private flag to see if the drag threshhold was met
         * @private


### PR DESCRIPTION
Fix for https://github.com/yui/yui3/issues/1971

This pull request rolls back https://github.com/yui/yui3/pull/1831 which breaks dd in ie 6 and 7.

As I understand it, the https://github.com/yui/yui3/pull/1831 fix addresses an edge case in panel while breaking core functionality in dd.

In my testing, the edge case was only fixed in chrome and safari, I could still get past modal in firefox.
Additionally, the steps taken to reproduce the panel issue completely break panel in ie 6 - 10. This is not addressed.

@ispyinternet
@andrewnicols
Please chime in if I'm missing something. Thanks.
