### PR TITLE
Clean up loader metadata.

### DIFF
--- a/src/loader/meta/loader.json
+++ b/src/loader/meta/loader.json
@@ -18,6 +18,7 @@
                     "loader-base"
                 ]
             },
+            "loader-pathogen-combohandler": {},
             "loader-pathogen-encoder": {
                 "use" : ["loader-base", "loader-rollup", "loader-yui3", "loader-pathogen-combohandler" ]
             }


### PR DESCRIPTION
This fixes an issue in which loader-encoder-combohandler did not appear in loader metadata.

@caridy 
Could you take a look at this when you get a chance? Thanks.
