### PR TITLE
Fix model-sync-local corruption

### DIFF
--- a/src/app/js/model-extensions/model-sync-local.js
+++ b/src/app/js/model-extensions/model-sync-local.js
@@ -325,7 +325,7 @@ LocalSync.prototype = {
         }
 
         LocalSync._store[this.root] = Y.Array.filter(LocalSync._store[this.root], function (item) {
-            return item.id != id;
+            return item != id;
         });
 
         this._save();

--- a/src/app/js/model-extensions/model-sync-local.js
+++ b/src/app/js/model-extensions/model-sync-local.js
@@ -290,7 +290,7 @@ LocalSync.prototype = {
         LocalSync._data[id] = hash;
 
         if (this.storage) {
-            this.storage.setItem(id, hash);
+            this.storage.setItem(id, Y.JSON.stringify(hash));
         }
 
         if (Y.Array.indexOf(LocalSync._store[this.root], id) === -1) {


### PR DESCRIPTION
1. Define a model with multiple attributes.
2. Create a model that uses the model-sync-local extension.
3. Set _more than one_ model attribute
4. call `model.save()`.
5. The extension incorrectly saves to local storage (data shows as '[Object Object]').

This change fixes this by stringifying the key/value pairs in the `_update` method.

The second commit fixes `destroy()` where the local storage root key does not remove the model's id from the list.
